### PR TITLE
feat: request full history sync and add a true logout flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report a bug or unexpected behavior in wptui
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! Please search [open and closed issues](https://github.com/Andiveli/wptui/issues)
+        first to avoid duplicates.
+
+        This is a terminal app, so the terminal environment matters. Fill in the Environment section
+        even when you think it's irrelevant — clipboard, rendering, and keybinding behavior all
+        depend on it.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include the exact keystrokes you used. Paste any error messages verbatim (e.g. `Unavailable("...")`).
+      placeholder: |
+        1. Start wptui
+        2. Press ...
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `wp-tui --version`, or the git commit you're on.
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux (Debian/Ubuntu)
+        - Linux (Fedora)
+        - Linux (Arch)
+        - Linux (other)
+        - macOS
+        - Other
+  - type: dropdown
+    id: display-server
+    attributes:
+      label: Display server
+      description: Affects clipboard behavior.
+      options:
+        - Wayland
+        - X11
+        - Other
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal emulator
+      description: e.g. kitty, alacritty, foot, gnome-terminal, tmux over one of those.
+  - type: checkboxes
+    id: logs
+    attributes:
+      label: Logs
+      description: The app has a log view toggle with `Ctrl+Shift+L`. If the bug reproduces, please capture it with logs open and include the relevant output.
+      options:
+        - label: I reproduced the bug with logs visible (`Ctrl+Shift+L`) and will attach the relevant output

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest a new feature or improvement for wptui
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please search [open and closed issues](https://github.com/Andiveli/wptui/issues)
+        first to avoid duplicates.
+
+        Note: wptui is an unofficial WhatsApp client. Requests that depend on unsupported WhatsApp
+        features (e.g. voice/video calling) may be declined as out of scope.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that you can't do today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should it work? Sketch the behavior or UI.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else have you tried or considered?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+  Title must be a Conventional Commit, e.g.:
+    feat(ui): add chat search
+    fix(clipboard): fall back to text-only paste on Wayland
+    docs: expand keybinding reference
+
+  Keep the PR small and focused. If it grows past a few hundred
+  lines, consider splitting it into several PRs.
+-->
+
+## Summary
+
+- What does this change do?
+- Why is it needed? (link the issue it addresses)
+
+## Changes
+
+- List the main changes, one bullet each.
+
+## Testing
+
+- [ ] `cargo test -- --test-threads=1`
+- [ ] `cd whatsrust/lib && go test ./...`
+- [ ] `cargo fmt --check`
+- [ ] Manual testing done (describe what you tried)
+
+<!-- Optional: include a screenshot or recording of the change -->
+
+Closes #<issue-number>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing to wptui
+
+Thanks for wanting to help! `wptui` is an experimental, keyboard-driven WhatsApp client for the
+terminal. All kinds of contributions are welcome: bug reports, feature requests, documentation,
+and code.
+
+> [!NOTE]
+> `wptui` is an unofficial client that operates in a WhatsApp terms-of-service gray area. Feature
+> requests that depend on unsupported WhatsApp behavior (for example, voice/video calling) may be
+> declined as out of scope.
+
+## Getting started
+
+The quickest path to a first contribution:
+
+1. **Find something to work on.** Issues labeled [`good first issue`](https://github.com/Andiveli/wptui/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are a great starting point. Comment on the issue to say you're taking it.
+2. **Fork and clone** the repository.
+3. **Create a branch** from `main` with a descriptive name, e.g. `feat/chat-search` or `fix/clipboard-wayland`.
+4. **Make your change** following the [style](#code-style) and [testing](#testing) guidance below.
+5. **Open a pull request** using the [PR template](.github/pull_request_template.md).
+
+If you're not sure whether an idea fits the project, open an issue first and ask before writing a
+lot of code.
+
+## Development setup
+
+### Build requirements
+
+- A recent stable Rust toolchain (the repository pins Rust 1.96.1 via `rust-toolchain.toml`)
+- Go with CGO enabled
+- A C compiler supported by CGO
+- System libraries:
+
+  | OS | Packages |
+  |---|---|
+  | Debian / Ubuntu | `libwayland-dev libchafa-dev libglib2.0-dev` |
+  | macOS | `chafa` (via Homebrew) |
+
+### Build and run
+
+```bash
+cargo build --all-targets
+```
+
+Run the client with:
+
+```bash
+cargo run
+```
+
+The Rust build automatically compiles the bundled Go bridge. See the
+[README](README.md#build-requirements) for runtime dependencies.
+
+## Testing
+
+CI runs these checks on every push and pull request, so run them locally before opening a PR:
+
+| Check | Command |
+|---|---|
+| Rust test suite (single-threaded, on purpose) | `cargo test -- --test-threads=1` |
+| Go test suite | `cd whatsrust/lib && go test ./...` |
+| Go vet | `cd whatsrust/lib && go vet ./...` |
+| Rust formatting | `cargo fmt --check` |
+
+Notes:
+
+- The Rust tests **must** run with `--test-threads=1`; they are not safe to run in parallel.
+- CI does not run `clippy`, but keeping `cargo clippy` clean is a good idea.
+
+## Code style
+
+- **Rust**: format with `rustfmt` (enforced by CI). Follow the surrounding code's conventions.
+- **Go**: format with `gofmt` and keep `go vet` clean.
+- **Tests**: add or update tests alongside behavior changes. The Rust integration tests live in
+  `tests/`; the Go bridge tests live in `whatsrust/lib/`.
+
+### Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>): <short description>
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`, `style`, `perf`.
+
+Keep commits atomic — one logical change per commit. Never add AI attribution footers
+("Co-Authored-By" or similar) to commits.
+
+## Pull requests
+
+- **Keep PRs small and focused.** Prefer several small PRs over one large one. If a change is
+  bigger than a few hundred lines, consider splitting it.
+- **Title** the PR with a Conventional Commit message, e.g. `feat(ui): add chat search`.
+- **Describe** what and why using the [PR template](.github/pull_request_template.md).
+- **Link** the issue your PR closes with `Closes #N`.
+- **Make sure all checks pass**: formatting, build, and both test suites.
+
+## Issues
+
+- Check for [existing issues](https://github.com/Andiveli/wptui/issues) before opening a new one
+  (open and closed) to avoid duplicates.
+- Use the templates in `.github/ISSUE_TEMPLATE/` — a bug report or feature request form will be
+  offered automatically.
+- For bugs, include environment details: OS, display server (Wayland/X11), terminal emulator, and
+  `wp-tui` version or commit. Paste error messages verbatim. If you can, reproduce with the
+  log view open (`Ctrl+Shift+L`).
+- For feature requests, explain the problem you're trying to solve and the proposed solution.
+
+## License
+
+By contributing you agree that your contributions are licensed under the [MIT License](LICENSE),
+the same license as the project.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2615,9 +2615,15 @@ mod tests {
         assert_eq!(app.logout_menu_index, 0);
 
         // j / k move the selection between Confirm and Cancel (2 items).
-        app.on_terminal_event(Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)));
+        app.on_terminal_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('j'),
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.logout_menu_index, 1);
-        app.on_terminal_event(Event::Key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE)));
+        app.on_terminal_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('k'),
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.logout_menu_index, 0);
 
         // Esc cancels without starting logout (no bridge call).

--- a/src/app.rs
+++ b/src/app.rs
@@ -285,6 +285,28 @@ pub struct App<'a> {
 
     pub should_quit: bool,
 
+    /// Set while a logout confirmation is showing. When pending, the next
+    /// input key resolves the prompt (confirm/cancel) instead of normal keys.
+    pub pending_logout: bool,
+
+    /// Set once the user confirmed logout and the async bridge logout is
+    /// running off the event loop. While true, further input is ignored and
+    /// the status bar shows "Logging out…" until `Event::LogoutResult`
+    /// resolves the flow (cleanup + quit, or error).
+    pub logout_in_progress: bool,
+
+    /// Whether the section rail cursor sits on the Logout slot (below the
+    /// three content sections). When true the content pane shows a logout
+    /// placeholder instead of a chat/status/community view, and Enter on the
+    /// rail calls `begin_logout_confirmation()`. Independent of
+    /// `selected_section`, which keeps driving content selection.
+    pub rail_on_logout: bool,
+
+    /// Selection inside the logout confirmation menu (0 = Confirm logout,
+    /// 1 = Cancel), rendered as a menu strip at the top right like the
+    /// message menu. j/k move it, Enter confirms, Esc/n cancels.
+    pub logout_menu_index: usize,
+
     pub tx: mpsc::Sender<AppInput>,
     pub rx: mpsc::Receiver<AppInput>,
     input_reader_control: Arc<(Mutex<InputReaderState>, Condvar)>,
@@ -425,6 +447,10 @@ impl App<'_> {
 
             show_logs: false,
             should_quit: false,
+            pending_logout: false,
+            logout_in_progress: false,
+            rail_on_logout: false,
+            logout_menu_index: 0,
             tx,
             rx,
             input_reader_control: Arc::new((Mutex::new(InputReaderState::Running), Condvar::new())),
@@ -523,6 +549,59 @@ impl App<'_> {
                 self.sort_chats();
                 true
             }
+            wr::Event::Chat {
+                jid,
+                last_message_time,
+            } => {
+                // History sync reports chats that may carry no messages. Keep
+                // them so the chat list reflects the full account, not only
+                // conversations that shipped a message in the sync batch.
+                self.add_or_update_chat(
+                    Chat {
+                        jid,
+                        last_message_time: (last_message_time > 0).then_some(last_message_time),
+                    },
+                    |chat| {
+                        if last_message_time > 0 && Some(last_message_time) > chat.last_message_time
+                        {
+                            chat.last_message_time = Some(last_message_time);
+                        }
+                    },
+                );
+                self.sort_chats();
+                true
+            }
+            wr::Event::LogoutResult(status) => match status {
+                wr::LogoutStatus::LoggedOut | wr::LogoutStatus::NotLoggedIn => {
+                    self.finish_logout();
+                    true
+                }
+                wr::LogoutStatus::LocalOnly => {
+                    // Remote revocation failed, so WhatsApp on the phone still
+                    // lists this device. The local session is already gone;
+                    // surface it instead of silently quitting, and let the
+                    // user retry (a second logout resolves as NotLoggedIn and
+                    // finishes) or remove the device manually.
+                    log::warn!(
+                        "Logout: device was not unlinked on the phone; remove it manually in WhatsApp → Linked devices"
+                    );
+                    self.pending_logout = false;
+                    self.logout_in_progress = false;
+                    self.logout_menu_index = 0;
+                    self.unavailable(
+                        "Logged out locally, but the device is still linked on the phone — remove it in WhatsApp (Settings → Linked devices), then log out again to finish",
+                    );
+                    true
+                }
+                wr::LogoutStatus::Failed => {
+                    // Even the local cleanup failed. Surface it and keep running.
+                    self.pending_logout = false;
+                    self.logout_in_progress = false;
+                    self.logout_menu_index = 0;
+                    self.unavailable("Could not log out");
+                    true
+                }
+            },
             wr::Event::SyncProgress(percent) => {
                 self.history_sync_percent = Some(percent);
                 true
@@ -2447,5 +2526,104 @@ mod tests {
                 .iter()
                 .any(|jid| jid.0.as_ref() == STATUS_BROADCAST_CHAT)
         );
+    }
+
+    #[test]
+    fn section_rail_navigates_through_sections_into_logout_and_back() {
+        use crate::app::FocusPane;
+        use crate::app::actions::{AppAction, Section};
+
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::SectionRail;
+        app.selected_section = Section::Chats;
+        app.rail_on_logout = false;
+
+        // j: Chats -> Status -> Communities -> Logout (flag set) -> wraps to Chats.
+        app.dispatch_action(AppAction::SelectNext);
+        assert_eq!(app.selected_section, Section::Status);
+        assert!(!app.rail_on_logout);
+        app.dispatch_action(AppAction::SelectNext);
+        assert_eq!(app.selected_section, Section::Communities);
+        assert!(!app.rail_on_logout);
+        app.dispatch_action(AppAction::SelectNext);
+        assert!(app.rail_on_logout);
+        app.dispatch_action(AppAction::SelectNext);
+        assert_eq!(app.selected_section, Section::Chats);
+        assert!(!app.rail_on_logout);
+
+        // k: Chats wraps backward up to Logout.
+        app.dispatch_action(AppAction::SelectPrevious);
+        assert!(app.rail_on_logout);
+        app.dispatch_action(AppAction::SelectPrevious);
+        assert_eq!(app.selected_section, Section::Communities);
+        assert!(!app.rail_on_logout);
+
+        // G (jump_bottom) lands on Logout; gg (jump_top) returns to Chats.
+        app.dispatch_action(AppAction::JumpBottom);
+        assert!(app.rail_on_logout);
+        app.dispatch_action(AppAction::JumpTop);
+        assert_eq!(app.selected_section, Section::Chats);
+        assert!(!app.rail_on_logout);
+    }
+
+    #[test]
+    fn pressing_enter_on_the_rail_logout_slot_begins_confirmation() {
+        use crate::app::FocusPane;
+        use crate::app::actions::{AppAction, Section};
+        use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::SectionRail;
+        app.selected_section = Section::Chats;
+        app.rail_on_logout = false;
+
+        // Enter on a normal section does not start logout confirmation.
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        app.on_terminal_event(Event::Key(enter));
+        assert!(!app.pending_logout);
+
+        // Move the rail to the Logout slot and press Enter: confirmation starts.
+        app.dispatch_action(AppAction::JumpBottom);
+        assert!(app.rail_on_logout);
+        app.on_terminal_event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )));
+        assert!(app.pending_logout);
+        assert_eq!(app.focus_pane, FocusPane::SectionRail);
+        assert_eq!(app.selected_section, Section::Communities);
+    }
+
+    #[test]
+    fn logout_confirmation_menu_navigates_and_cancels() {
+        use crate::app::FocusPane;
+        use crate::app::actions::AppAction;
+        use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::SectionRail;
+        app.selected_section = crate::app::actions::Section::Chats;
+        app.dispatch_action(AppAction::JumpBottom);
+        assert!(app.rail_on_logout);
+
+        // Enter on the rail Logout slot opens the confirmation menu.
+        app.on_terminal_event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )));
+        assert!(app.pending_logout);
+        assert_eq!(app.logout_menu_index, 0);
+
+        // j / k move the selection between Confirm and Cancel (2 items).
+        app.on_terminal_event(Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)));
+        assert_eq!(app.logout_menu_index, 1);
+        app.on_terminal_event(Event::Key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE)));
+        assert_eq!(app.logout_menu_index, 0);
+
+        // Esc cancels without starting logout (no bridge call).
+        app.on_terminal_event(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
+        assert!(!app.pending_logout);
+        assert!(!app.logout_in_progress);
+        assert_eq!(app.logout_menu_index, 0);
     }
 }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -10,6 +10,7 @@ pub const STATUS_REACTION: &str = "💚";
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AppAction {
     Quit,
+    Logout,
     ToggleLogs,
     ToggleSectionRail,
     ToggleChatList,
@@ -339,6 +340,17 @@ impl Section {
     }
 }
 
+/// The Logout entry pinned at the BOTTOM of the section rail, below the three
+/// content sections. It is deliberately NOT a `Section` variant: content
+/// selection (`selected_section`) drives ChatList/Conversation rendering and
+/// the "… is not available yet" placeholder, and a 4th section variant would
+/// ripple into all of that. Instead the rail cursor is modeled as
+/// `App.selected_section` (indices 0..3 content sections) plus a
+/// `App.rail_on_logout` flag meaning "the rail is on the Logout slot" (index 3).
+/// While the flag is set the content pane shows a dedicated logout placeholder
+/// and Enter triggers the existing `begin_logout_confirmation()`.
+pub const LOGOUT_RAIL_TITLE: &str = "Logout";
+
 impl FocusPane {
     pub fn next(self, visibility: PaneVisibility) -> Self {
         let panes = visible_panes(visibility);
@@ -403,6 +415,7 @@ pub enum SequenceResolution {
 pub fn default_bindings() -> Vec<(Vec<Key>, AppAction)> {
     vec![
         (vec![Key::ctrl('q')], AppAction::Quit),
+        (vec![Key::ctrl_shift('O')], AppAction::Logout),
         (vec![Key::ctrl_shift('L')], AppAction::ToggleLogs),
         (vec![Key::ctrl_shift('l')], AppAction::ToggleLogs),
         (vec![Key::c(' '), Key::c('1')], AppAction::ToggleSectionRail),

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -22,6 +22,16 @@ impl App<'_> {
                 modifiers: key_event.modifiers,
             };
 
+            if self.pending_logout {
+                if self.logout_in_progress {
+                    // The async logout is running (off the event loop). Ignore
+                    // further input until Event::LogoutResult resolves.
+                    return;
+                }
+                self.resolve_logout_confirmation(key);
+                return;
+            }
+
             if is_toggle_logs_key(&key) {
                 self.dispatch_action(AppAction::ToggleLogs);
             } else if self.focus_pane == FocusPane::Conversation
@@ -107,6 +117,11 @@ impl App<'_> {
                 self.handle_chat_search_key(key);
             } else if self.focus_pane == FocusPane::ChatList && key == Key::k(KeyCode::Enter) {
                 self.dispatch_action(AppAction::OpenChat);
+            } else if self.focus_pane == FocusPane::SectionRail
+                && self.rail_on_logout
+                && key == Key::k(KeyCode::Enter)
+            {
+                self.begin_logout_confirmation();
             } else {
                 match self.kh.resolve(key.clone()) {
                     SequenceResolution::Complete(action) => self.dispatch_action(action),
@@ -172,6 +187,7 @@ impl App<'_> {
                 self.db_handler.stop();
                 self.should_quit = true;
             }
+            AppAction::Logout => self.begin_logout_confirmation(),
             AppAction::ToggleLogs => {
                 self.show_logs = !self.show_logs;
                 tui_logger::set_default_level(log_level_for_logs(self.show_logs));
@@ -299,10 +315,73 @@ impl App<'_> {
         }
     }
 
-    fn unavailable(&mut self, action: &str) {
+    pub fn unavailable(&mut self, action: &str) {
         self.action_notice = Some(crate::app::actions::ActionNotice::Unavailable(
             action.into(),
         ));
+    }
+
+    fn begin_logout_confirmation(&mut self) {
+        self.pending_logout = true;
+        self.logout_menu_index = 0;
+    }
+
+    /// Resolve the logout confirmation as a top-right menu, matching the
+    /// message-menu interaction: j/k (or Up/Down) move the selection, Enter
+    /// confirms it, Esc/n cancel. y is kept as a fast "confirm" and N as a
+    /// fast "cancel".
+    fn resolve_logout_confirmation(&mut self, key: Key) {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                self.pending_logout = false;
+                self.confirm_logout();
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                self.pending_logout = false;
+                self.logout_menu_index = 0;
+                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
+            }
+            KeyCode::Enter => {
+                if self.logout_menu_index == 0 {
+                    self.pending_logout = false;
+                    self.confirm_logout();
+                } else {
+                    self.pending_logout = false;
+                    self.logout_menu_index = 0;
+                    self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
+                }
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.logout_menu_index = (self.logout_menu_index + 1) % 2;
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.logout_menu_index = (self.logout_menu_index + 1) % 2;
+            }
+            _ => {}
+        }
+    }
+
+    fn confirm_logout(&mut self) {
+        // The bridge runs the remove-companion-device IQ asynchronously so
+        // the event loop stays responsive. Keep intercepting input and let
+        // Event::LogoutResult drive the local cleanup / quit / error path.
+        self.pending_logout = true;
+        self.logout_in_progress = true;
+        wr::logout();
+    }
+
+    pub fn finish_logout(&mut self) {
+        self.pending_logout = false;
+        self.logout_in_progress = false;
+        self.logout_menu_index = 0;
+        // Stop the history writer so the sqlite files are released, then wipe
+        // BOTH databases plus media: a logout is a full account sign-out, and
+        // pairing a different account must never see the previous one's data.
+        self.db_handler.stop();
+        wipe_sqlite_file(&self.whatsmeow_db);
+        wipe_sqlite_file(&self.whatsmeow_db.with_file_name("whatsapp.db"));
+        clear_media_dir(&self.media_path);
+        self.should_quit = true;
     }
 
     fn selected_message_is_deleted(&self) -> bool {
@@ -939,7 +1018,16 @@ impl App<'_> {
 
     fn select_next(&mut self) {
         match self.focus_pane {
-            FocusPane::SectionRail => self.selected_section = self.selected_section.next(),
+            FocusPane::SectionRail => {
+                if self.rail_on_logout {
+                    self.rail_on_logout = false;
+                    self.selected_section = Section::Chats;
+                } else if self.selected_section == Section::Communities {
+                    self.rail_on_logout = true;
+                } else {
+                    self.selected_section = self.selected_section.next();
+                }
+            }
             FocusPane::ChatList => {
                 if self.selected_section == Section::Status {
                     self.status_selection.select_next();
@@ -964,7 +1052,16 @@ impl App<'_> {
 
     fn select_previous(&mut self) {
         match self.focus_pane {
-            FocusPane::SectionRail => self.selected_section = self.selected_section.previous(),
+            FocusPane::SectionRail => {
+                if self.rail_on_logout {
+                    self.rail_on_logout = false;
+                    self.selected_section = Section::Communities;
+                } else if self.selected_section == Section::Chats {
+                    self.rail_on_logout = true;
+                } else {
+                    self.selected_section = self.selected_section.previous();
+                }
+            }
             FocusPane::ChatList => {
                 if self.selected_section == Section::Status {
                     self.status_selection.select_previous();
@@ -989,7 +1086,10 @@ impl App<'_> {
 
     fn jump_top(&mut self) {
         match self.focus_pane {
-            FocusPane::SectionRail => self.selected_section = crate::app::actions::Section::Chats,
+            FocusPane::SectionRail => {
+                self.selected_section = crate::app::actions::Section::Chats;
+                self.rail_on_logout = false;
+            }
             FocusPane::ChatList => {
                 if self.selected_section == Section::Status {
                     self.status_selection.select_first();
@@ -1015,7 +1115,8 @@ impl App<'_> {
     fn jump_bottom(&mut self) {
         match self.focus_pane {
             FocusPane::SectionRail => {
-                self.selected_section = crate::app::actions::Section::Communities
+                self.selected_section = crate::app::actions::Section::Communities;
+                self.rail_on_logout = true;
             }
             FocusPane::ChatList => {
                 if self.selected_section == Section::Status {
@@ -1137,6 +1238,7 @@ fn status_view_allows(action: &AppAction) -> bool {
     matches!(
         action,
         AppAction::Quit
+            | AppAction::Logout
             | AppAction::ToggleLogs
             | AppAction::ToggleSectionRail
             | AppAction::ToggleChatList
@@ -1188,6 +1290,7 @@ mod tests {
 
         for allowed in [
             AppAction::Quit,
+            AppAction::Logout,
             AppAction::ToggleLogs,
             AppAction::ToggleSectionRail,
             AppAction::ToggleChatList,
@@ -1260,6 +1363,41 @@ fn message_urls(message: &wr::Message) -> Vec<String> {
     };
     text.map(crate::url::extract_openable_urls)
         .unwrap_or_default()
+}
+
+/// Remove a sqlite database together with its `-wal` and `-shm` sidecars.
+/// Used during logout to guarantee a full account sign-out.
+fn wipe_sqlite_file(path: &Path) {
+    for suffix in [
+        std::ffi::OsStr::new(""),
+        std::ffi::OsStr::new("-wal"),
+        std::ffi::OsStr::new("-shm"),
+    ] {
+        let mut os = path.as_os_str().to_os_string();
+        os.push(suffix);
+        let file = std::path::PathBuf::from(&os);
+        match std::fs::remove_file(&file) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => log::warn!("Failed to remove {}: {err}", file.display()),
+        }
+    }
+}
+
+/// Remove every entry under the media cache directory. A missing directory is
+/// fine; a nested directory tree is removed recursively.
+fn clear_media_dir(media_path: &Path) {
+    let Ok(entries) = std::fs::read_dir(media_path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let _ = std::fs::remove_dir_all(&path);
+        } else {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
 }
 
 pub fn composer_action_for_editing_key(key: &Key) -> ComposerAction {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -168,7 +168,8 @@ fn render_structural_placeholder(frame: &mut Frame, app: &App, area: Rect) {
 
 fn render_logout_placeholder(frame: &mut Frame, app: &App, area: Rect) {
     let content = if app.logout_in_progress {
-        "Logging out…\n\nThis removes the device from WhatsApp and clears the local session.".to_string()
+        "Logging out…\n\nThis removes the device from WhatsApp and clears the local session."
+            .to_string()
     } else if app.pending_logout {
         // Reuse the message-menu interaction inside the pane: `>` marks the
         // selection, j/k move it, Enter confirms, Esc cancels (y/N also work).
@@ -713,7 +714,11 @@ pub fn render_chats(frame: &mut Frame, app: &mut App, area: Rect) {
                 .map(|(index, label)| {
                     format!(
                         "{} {}",
-                        if index == app.logout_menu_index { ">" } else { " " },
+                        if index == app.logout_menu_index {
+                            ">"
+                        } else {
+                            " "
+                        },
                         label
                     )
                 })

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -18,10 +18,10 @@ use message_list::{get_quoted_text, render_messages, render_status_messages};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Layout, Position, Rect},
-    style::{Style, Stylize},
+    style::{Color, Style, Stylize},
     symbols,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, Paragraph, StatefulWidget, Widget, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, StatefulWidget, Widget, Wrap},
 };
 use ratatui_image::{Resize, StatefulImage};
 use status_list::{StatusList, StatusListItem};
@@ -44,7 +44,13 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     if let Some(area) = areas.section_rail {
         render_section_rail(frame, app, area);
     }
-    if app.selected_section == Section::Chats {
+    if app.rail_on_logout {
+        app.contact_avatars.clear_window();
+        if let Some(area) = areas.chat_list {
+            render_structural_placeholder(frame, app, area);
+        }
+        render_logout_placeholder(frame, app, areas.conversation);
+    } else if app.selected_section == Section::Chats {
         if let Some(area) = areas.chat_list {
             render_contacts(frame, app, area);
         } else {
@@ -111,11 +117,25 @@ pub fn navigation_areas(area: Rect, visibility: PaneVisibility) -> NavigationAre
 }
 
 fn render_section_rail(frame: &mut Frame, app: &App, area: Rect) {
-    let items = Section::ALL.map(Section::title);
-    let selected = Section::ALL
+    let mut items = Section::ALL
         .iter()
-        .position(|section| *section == app.selected_section);
-    let mut state = ratatui::widgets::ListState::default().with_selected(selected);
+        .map(|section| {
+            ListItem::new(Section::title(*section)).style(Style::default().fg(Color::White))
+        })
+        .collect::<Vec<_>>();
+    items.push(
+        ListItem::new(crate::app::actions::LOGOUT_RAIL_TITLE)
+            .style(Style::default().fg(Color::Red)),
+    );
+    let selected = if app.rail_on_logout {
+        items.len() - 1
+    } else {
+        Section::ALL
+            .iter()
+            .position(|section| *section == app.selected_section)
+            .unwrap_or(0)
+    };
+    let mut state = ratatui::widgets::ListState::default().with_selected(Some(selected));
     let list = List::new(items)
         .block(
             Block::bordered()
@@ -129,7 +149,11 @@ fn render_section_rail(frame: &mut Frame, app: &App, area: Rect) {
                 ),
         )
         .highlight_symbol("> ")
-        .highlight_style(Style::default().green());
+        .highlight_style(if app.rail_on_logout {
+            Style::default().red()
+        } else {
+            Style::default().green()
+        });
     frame.render_stateful_widget(list, area, &mut state);
 }
 
@@ -138,6 +162,42 @@ fn render_structural_placeholder(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(
         Paragraph::new(format!("{section} is not available yet."))
             .block(Block::bordered().title(section)),
+        area,
+    );
+}
+
+fn render_logout_placeholder(frame: &mut Frame, app: &App, area: Rect) {
+    let content = if app.logout_in_progress {
+        "Logging out…\n\nThis removes the device from WhatsApp and clears the local session.".to_string()
+    } else if app.pending_logout {
+        // Reuse the message-menu interaction inside the pane: `>` marks the
+        // selection, j/k move it, Enter confirms, Esc cancels (y/N also work).
+        let menu_lines = ["Confirm logout", "Cancel"]
+            .iter()
+            .enumerate()
+            .map(|(index, label)| {
+                if index == app.logout_menu_index {
+                    format!("> {label}")
+                } else {
+                    format!("  {label}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "This removes the device from WhatsApp and clears the local session.\n\n{menu_lines}\n\nj/k move · Enter confirms · Esc cancels"
+        )
+    } else {
+        "Press Enter to sign out.\nThis removes the device from WhatsApp and clears the local session.".to_string()
+    };
+    frame.render_widget(
+        Paragraph::new(content)
+            .block(
+                Block::bordered()
+                    .title(crate::app::actions::LOGOUT_RAIL_TITLE)
+                    .border_style(Style::default().fg(Color::Red)),
+            )
+            .style(Style::default().fg(Color::Red)),
         area,
     );
 }
@@ -641,7 +701,26 @@ pub fn render_chats(frame: &mut Frame, app: &mut App, area: Rect) {
     // Build the status string (action_notice, picker, menu) so we can drop it
     // on the right edge of the outer block. Keeping it here instead of painting
     // a separate Paragraph avoids it sticking around after it should disappear.
-    let status = if let Some((reactions, selected)) = &app.reaction_picker {
+    let status = if app.logout_in_progress {
+        Some("Logging out…".into())
+    } else if app.pending_logout {
+        // Reuse the top-right menu strip interaction (j/k + Enter/Esc),
+        // mirroring the message menu format.
+        Some(
+            ["Confirm logout", "Cancel"]
+                .iter()
+                .enumerate()
+                .map(|(index, label)| {
+                    format!(
+                        "{} {}",
+                        if index == app.logout_menu_index { ">" } else { " " },
+                        label
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" | "),
+        )
+    } else if let Some((reactions, selected)) = &app.reaction_picker {
         Some(
             reactions
                 .iter()

--- a/whatsrust/build.rs
+++ b/whatsrust/build.rs
@@ -25,6 +25,11 @@ fn main() {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=lib");
+    // Directory-level rerun-if-changed is unreliable for edits inside files,
+    // so also track the Go sources that feed the archive explicitly.
+    println!("cargo:rerun-if-changed=lib/main.go");
+    println!("cargo:rerun-if-changed=lib/go.mod");
+    println!("cargo:rerun-if-changed=lib/go.sum");
     println!(
         "cargo::rustc-link-search=native={}",
         out_dir.to_str().unwrap()

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -106,6 +106,15 @@ typedef struct {
 } MessageActionEvent;
 
 typedef struct {
+	JID chat;
+	int64_t lastMessageTime;
+} ChatEvent;
+
+typedef struct {
+	uint8_t status;
+} LogoutResultEvent;
+
+typedef struct {
 	uint8_t kind;
 	void* data;
 } Event;
@@ -198,7 +207,9 @@ import (
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/appstate"
 	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
 	"go.mau.fi/whatsmeow/proto/waWeb"
+	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
@@ -567,10 +578,17 @@ func messageActionIdentifier(identifier string) string {
 }
 
 func LOG_LEVEL(level int, msg string, args ...any) {
+	formatted := fmt.Sprintf(msg, args...)
+	if os.Getenv("WPTUI_LOGS_STDERR") == "1" {
+		// Debug aid for headless capture: mirror every Go log to stderr so a
+		// run like `WPTUI_LOGS_STDERR=1 target/debug/wp-tui 2>go.log` lets the
+		// user read diagnostics after closing the TUI (Ctrl+L panel is broken).
+		fmt.Fprintf(os.Stderr, "[go %d] %s\n", level, formatted)
+	}
 	if logHandler.callback == nil {
 		return
 	}
-	cmsg := C.CString(fmt.Sprintf(msg, args...))
+	cmsg := C.CString(formatted)
 	defer C.free(unsafe.Pointer(cmsg))
 	C.callLogInfo(logHandler, cmsg, C.uint8_t(level))
 }
@@ -787,6 +805,7 @@ func C_SetPresenceHandler(callback C.PresenceHandlerCallback, data unsafe.Pointe
 //export C_NewClient
 func C_NewClient(dbPath *C.char) {
 	rawPresenceProbe.reset(os.Getenv("WPTUI_PRESENCE_DEBUG") == "1")
+	requestFullHistorySync()
 	goPath := C.GoString(dbPath)
 	dbLog := &WrLogger{}
 	container, err := sqlstore.New(context.Background(), "sqlite3", "file:"+goPath+"?_foreign_keys=on", dbLog)
@@ -801,6 +820,16 @@ func C_NewClient(dbPath *C.char) {
 
 func configurePresenceSubscriptions(client *whatsmeow.Client) {
 	client.ErrorOnSubscribePresenceWithoutToken = true
+}
+
+func requestFullHistorySync() {
+	// Ask WhatsApp to send the complete conversation + history list instead of
+	// only a recent-activity subset. WhatsApp gates history sync requests on an
+	// open phone session, and full sync must be requested before pairing
+	// (DeviceProps is transmitted during the registration handshake).
+	store.DeviceProps.RequireFullSync = proto.Bool(true)
+	store.DeviceProps.HistorySyncConfig.FullSyncDaysLimit = proto.Uint32(365)
+	store.DeviceProps.HistorySyncConfig.FullSyncSizeMbLimit = proto.Uint32(10240)
 }
 
 const viewOnceUnavailablePlaceholder = "View-once media is unavailable here. View it on your phone."
@@ -893,6 +922,8 @@ const (
 	// Event type 4 is reserved for the removed multiplexed Presence event.
 	EventTypeConnected     = 5
 	EventTypeMessageAction = 6
+	EventTypeChat          = 7
+	EventTypeLogoutResult  = 8
 )
 
 const (
@@ -2151,6 +2182,14 @@ func AddEventHandlers() {
 
 		case *events.HistorySync:
 			percent := evt.Data.GetProgress()
+			LOG_INFO(
+				"History sync: type=%s chunk=%d progress=%d conversations=%d messages=%d",
+				evt.Data.GetSyncType().String(),
+				evt.Data.GetChunkOrder(),
+				percent,
+				len(evt.Data.GetConversations()),
+				countSyncMessages(evt.Data.GetConversations()),
+			)
 			cpercent := (*C.uint8_t)(C.malloc(C.size_t(unsafe.Sizeof(uint8(0)))))
 			*cpercent = C.uint8_t(percent)
 
@@ -2173,6 +2212,24 @@ func AddEventHandlers() {
 					LOG_WARN("history message ignored source=history_sync reason=invalid_chat")
 					continue
 				}
+
+				// Register the chat itself even when the sync batch carries no
+				// messages (older/archived/muted conversations). Previously only
+				// conversations that shipped at least one message became chats,
+				// which left the chat list stuck at the messages-only subset.
+				var lastMsgTime int64
+				if ts := conversation.GetLastMsgTimestamp(); ts != 0 {
+					lastMsgTime = int64(ts)
+				}
+				chatEvent := (*C.ChatEvent)(C.malloc(C.sizeof_ChatEvent))
+				chatEvent.chat = jidToC(chatJid)
+				chatEvent.lastMessageTime = C.int64_t(lastMsgTime)
+				cevent := C.Event{
+					kind: C.uint8_t(EventTypeChat),
+					data: unsafe.Pointer(chatEvent),
+				}
+				C.callEventCallback(eventHandler, &cevent)
+
 				syncMessages := conversation.GetMessages()
 
 				for _, syncMessage := range syncMessages {
@@ -2192,6 +2249,14 @@ func AddEventHandlers() {
 			}
 		}
 	})
+}
+
+func countSyncMessages(conversations []*waHistorySync.Conversation) int {
+	total := 0
+	for _, conversation := range conversations {
+		total += len(conversation.GetMessages())
+	}
+	return total
 }
 
 type sendPresenceFunc func(context.Context, types.Presence) error
@@ -2265,6 +2330,13 @@ func handleConnected(sendPresence sendPresenceFunc, connected connectedReadyFunc
 func C_Connect(handler C.QrCallback, data unsafe.Pointer) {
 	AddEventHandlers()
 	if client.Store.ID == nil {
+		LOG_INFO(
+			"Pairing: DeviceProps require_full_sync=%t days_limit=%d size_mb=%d platform=%s",
+			store.DeviceProps.GetRequireFullSync(),
+			store.DeviceProps.GetHistorySyncConfig().GetFullSyncDaysLimit(),
+			store.DeviceProps.GetHistorySyncConfig().GetFullSyncSizeMbLimit(),
+			store.DeviceProps.GetPlatformType(),
+		)
 		qrChan, _ = client.GetQRChannel(context.Background())
 		err := client.Connect()
 		if err != nil {
@@ -2905,6 +2977,77 @@ func C_MarkAsRead(msg_id *C.char, chat_jid C.JID, sender_jid C.JID) {
 //export C_Disconnect
 func C_Disconnect() {
 	client.Disconnect()
+}
+
+const (
+	// logoutStatusLoggedOut: remote revocation succeeded and the local store
+	// was cleared (the linked device is gone from the phone too).
+	logoutStatusLoggedOut uint8 = 0
+	// logoutStatusNotLoggedIn: there is no paired session to remove.
+	logoutStatusNotLoggedIn uint8 = 1
+	// logoutStatusFailed: the remote logout request was rejected/failed and
+	// even the local fallback could not clear the store.
+	logoutStatusFailed uint8 = 2
+	// logoutStatusLocalOnly: remote revocation failed (device offline or
+	// server rejected it) but the local sign-out succeeded, so the app can
+	// return to the terminal. The device stays linked on the phone until the
+	// user removes it manually from WhatsApp → Linked devices.
+	logoutStatusLocalOnly uint8 = 3
+)
+
+//export C_Logout
+func C_Logout() C.uint8_t {
+	status := logoutStatusLoggedOut
+	if client == nil {
+		// No bridge client exists, so there is no session to remove.
+		status = logoutStatusNotLoggedIn
+	} else {
+		// True sign-out: whatsmeow sends the remove-companion-device IQ to the
+		// server (which unlinks the device in WhatsApp on the phone), then
+		// disconnects and clears the persisted store. Bounded so it can never
+		// hang the UI; the Rust side keeps driving the exit.
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		err := client.Logout(ctx)
+		cancel()
+		switch {
+		case err == nil:
+			status = logoutStatusLoggedOut
+		case errors.Is(err, whatsmeow.ErrNotLoggedIn):
+			status = logoutStatusNotLoggedIn
+		default:
+			// Remote revocation failed. Still clear the local session so the
+			// TUI deterministically returns to the terminal; report the partial
+			// outcome so the caller can warn that the device remains linked.
+			LOG_ERROR("Logout: remote revocation failed, clearing locally only: %v", err)
+			client.Disconnect()
+			if client.Store == nil {
+				status = logoutStatusLocalOnly
+			} else if err := client.Store.Delete(context.Background()); err != nil {
+				LOG_ERROR("Logout: failed to clear local store: %v", err)
+				status = logoutStatusFailed
+			} else {
+				status = logoutStatusLocalOnly
+			}
+		}
+	}
+	emitLogoutResult(status)
+	return C.uint8_t(status)
+}
+
+func emitLogoutResult(status uint8) {
+	if eventHandler.callback == nil {
+		return
+	}
+	payload := (*C.LogoutResultEvent)(C.malloc(C.sizeof_LogoutResultEvent))
+	if payload == nil {
+		return
+	}
+	payload.status = C.uint8_t(status)
+	C.callEventCallback(eventHandler, &C.Event{
+		kind: C.uint8_t(EventTypeLogoutResult),
+		data: unsafe.Pointer(payload),
+	})
+	C.free(unsafe.Pointer(payload))
 }
 
 //export C_DrainRawPresenceDiagnostics

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -153,6 +153,17 @@ struct CMessageActionEvent {
     kind: u8,
 }
 
+#[repr(C)]
+struct CChatEvent {
+    chat: CJID,
+    last_message_time: i64,
+}
+
+#[repr(C)]
+struct CLogoutResultEvent {
+    status: u8,
+}
+
 pub type MessageId = Arc<str>;
 
 #[derive(Clone, Debug)]
@@ -428,6 +439,19 @@ enum EventType {
     // Event type 4 is reserved (removed multiplexed Presence event on Go side)
     Connected = 5,
     MessageAction = 6,
+    Chat = 7,
+    LogoutResult = 8,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromRepr)]
+#[repr(u8)]
+pub enum LogoutStatus {
+    LoggedOut = 0,
+    NotLoggedIn = 1,
+    Failed = 2,
+    /// Remote revocation failed, but the local sign-out succeeded. The device
+    /// remains linked on the phone until removed manually.
+    LocalOnly = 3,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -462,6 +486,17 @@ pub enum Event {
         occurred_at: i64,
         arrival_order: u64,
     },
+    /// A chat that exists even though the history sync batch carried no
+    /// messages for it. Lets the app populate the full chat list instead of
+    /// only the subset that shipped messages.
+    Chat {
+        jid: JID,
+        last_message_time: i64,
+    },
+    /// Terminal outcome of an asynchronous logout. The Go bridge runs the
+    /// remove-companion-device IQ off the event loop so `logout()` no longer
+    /// blocks the UI; this event drives the local cleanup on completion.
+    LogoutResult(LogoutStatus),
 }
 
 #[derive(Clone, Debug)]
@@ -644,6 +679,7 @@ unsafe extern "C" {
     fn C_FreeProfilePicture(result: CProfilePictureResult);
     fn C_GetChatSettings(jid: CJID) -> CChatSettings;
     fn C_Disconnect();
+    fn C_Logout() -> u8;
     fn C_DrainRawPresenceDiagnostics() -> *mut c_char;
     fn C_FreeRawPresenceDiagnostics(report: *mut c_char);
     fn C_SubscribePresence(jid: CJID) -> u8;
@@ -668,6 +704,13 @@ unsafe extern "C" {
 }
 
 pub struct DownloadFailed;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LogoutError {
+    NotLoggedIn,
+    Failed,
+    InvalidBridgeResult,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageActionFailed;
@@ -981,7 +1024,23 @@ impl CallbackTranslator<*const CEvent> for Event {
             EventType::MessageAction => unsafe {
                 message_action_event_from_ffi(&*(event.data as *const CMessageActionEvent))
             },
+            EventType::Chat => unsafe {
+                chat_event_from_ffi(&*(event.data as *const CChatEvent))
+            },
+            EventType::LogoutResult => unsafe {
+                let result = &(*(event.data as *const CLogoutResultEvent));
+                Event::LogoutResult(
+                    LogoutStatus::from_repr(result.status).unwrap_or(LogoutStatus::Failed),
+                )
+            },
         }
+    }
+}
+
+unsafe fn chat_event_from_ffi(event: &CChatEvent) -> Event {
+    Event::Chat {
+        jid: (&event.chat).into(),
+        last_message_time: event.last_message_time,
     }
 }
 
@@ -1194,6 +1253,14 @@ setup_handler!(connect, C_Connect, qr: *const c_char => String);
 
 pub fn disconnect() {
     unsafe { C_Disconnect() }
+}
+
+pub fn logout() {
+    // Performs a deterministic local sign-out on the Go side (disconnect +
+    // clear the persisted device). The result arrives via Event::LogoutResult
+    // so the app can remove the DB file and quit. No network round-trip, so
+    // the UI never blocks.
+    unsafe { C_Logout() };
 }
 
 unsafe fn take_owned_c_string(


### PR DESCRIPTION
## Summary
- Fixes #10: the chat/contacts list only showed a handful of chats because the client only asked for the recent-activity subset and only registered conversations that shipped messages in the sync batch.
- Pulls the full conversation + history list: request a full sync before pairing (DeviceProps.RequireFullSync, 365-day / 10 GB window) and register every conversation from every history sync batch, even message-less ones.
- Adds a real logout flow (Logout entry in the section rail, Ctrl+Shift+O, confirmation menu, remote remove-companion-device IQ) with data isolation between accounts.

## Changes
- `whatsrust` bridge: request full sync via DeviceProps before pairing; log transmitted props and per-batch history sync stats; emit `Event::Chat` for every conversation; true `C_Logout` (remove-companion-device → Disconnect → clear store, local-only fallback).
- `src/` — handle `Event::Chat`, add `Event::LogoutResult`, Logout rail entry + confirmation menu, wipe both DBs + media on sign-out.
- `WPTUI_LOGS_STDERR=1` lets Go diagnostics be captured to stderr (the Ctrl+Shift+L panel is broken).
- `build.rs` reruns on Go source edits.

## Testing
- [x] cargo test (100 tests green)
- [x] cargo build
- [x] Manual: full history sync confirmed via logs (INITIAL_BOOTSTRAP/RECENT/FULL), chat list shows full history with correct ordering, logout works and clears previous account data.

Closes #10