### PR TITLE
fix: block composer in admin-only groups

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -58,6 +58,7 @@ use crate::ui::text_input::TextInput;
 /// The synthetic chat that carries WhatsApp status broadcasts. Each message's
 /// `info.sender` is the contact who posted the status.
 pub const STATUS_BROADCAST_CHAT: &str = "status@broadcast";
+pub const ADMIN_ONLY_GROUP_MESSAGE: &str = "Only group admins can send messages in this group.";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum InputReaderState {
@@ -212,6 +213,7 @@ pub struct App<'a> {
     message_action_diagnostics: MessageActionDiagnostics,
     pub reactions: HashMap<wr::MessageId, HashMap<wr::JID, Arc<str>>>,
     pub chats: HashMap<wr::JID, Chat>,
+    pub group_permissions: HashMap<wr::JID, wr::GroupInfo>,
 
     // Maps JID to display name
     pub contacts: HashMap<wr::JID, Arc<str>>,
@@ -397,6 +399,7 @@ impl App<'_> {
             message_action_diagnostics: MessageActionDiagnostics::new(false),
             reactions: HashMap::new(),
             chats: HashMap::new(),
+            group_permissions: HashMap::new(),
             contacts: HashMap::new(),
             chat_messages: HashMap::new(),
 
@@ -1307,9 +1310,28 @@ impl App<'_> {
     pub fn open_selected_chat(&mut self) {
         if let Some(chat) = self.get_selected_chat() {
             self.open_chat = Some(chat.clone());
+            self.refresh_group_permission(&chat);
             self.sort_chat_messages(chat);
             self.message_list_state.reset();
         }
+    }
+
+    fn refresh_group_permission(&mut self, chat: &wr::JID) {
+        if Self::is_group_chat(chat) {
+            self.group_permissions.remove(chat);
+            if let Ok(info) = wr::get_group_info(chat) {
+                self.group_permissions.insert(chat.clone(), info);
+            }
+        }
+        self.composer.set_blocked(self.composer_blocked());
+    }
+
+    pub fn composer_blocked(&self) -> bool {
+        self.open_chat().is_some_and(|chat| {
+            self.group_permissions
+                .get(&chat)
+                .is_some_and(|info| info.is_announce && !info.is_admin)
+        })
     }
 
     pub fn is_status_chat(jid: &wr::JID) -> bool {
@@ -1332,6 +1354,7 @@ impl App<'_> {
         });
         self.sort_chats();
         self.open_chat = Some(jid.clone());
+        self.composer.set_blocked(self.composer_blocked());
         self.sort_chat_messages(jid);
         self.message_list_state.reset();
     }

--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -65,6 +65,7 @@ pub struct Composer<'a> {
     pub input: TextArea<'a>,
     pub quote: Option<wr::Message>,
     pub pending: Vec<PendingAttachment>,
+    pub blocked: bool,
 }
 
 impl Default for Composer<'_> {
@@ -76,12 +77,16 @@ impl Default for Composer<'_> {
             input,
             quote: None,
             pending: Vec::new(),
+            blocked: false,
         }
     }
 }
 
 impl Composer<'_> {
     pub fn apply(&mut self, action: ComposerAction) -> ComposerOutcome {
+        if self.blocked {
+            return ComposerOutcome::Idle;
+        }
         match action {
             ComposerAction::Submit => self.submit(),
             ComposerAction::InsertNewline => {
@@ -105,6 +110,9 @@ impl Composer<'_> {
     }
 
     pub fn insert_text(&mut self, text: &str) {
+        if self.blocked {
+            return;
+        }
         self.input.insert_str(text);
     }
 
@@ -123,7 +131,19 @@ impl Composer<'_> {
     }
 
     pub fn queue_attachment(&mut self, path: Arc<str>, kind: wr::FileKind) {
+        if self.blocked {
+            return;
+        }
         self.pending.push(PendingAttachment::new(path, kind));
+    }
+
+    pub fn set_blocked(&mut self, blocked: bool) {
+        self.blocked = blocked;
+        if blocked {
+            self.clear_text();
+            self.quote = None;
+            self.pending.clear();
+        }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -52,6 +52,8 @@ impl App<'_> {
                     }
                 } else if is_attach_file_key(&key) {
                     self.dispatch_action(AppAction::AttachFile);
+                } else if self.composer_blocked() {
+                    return;
                 } else {
                     self.dispatch_composer_action(composer_action_for_editing_key(&key));
                 }
@@ -239,7 +241,7 @@ impl App<'_> {
             AppAction::HalfPageDown => self.half_page_down(),
             AppAction::HalfPageUp => self.half_page_up(),
             AppAction::InsertMode => {
-                if self.focus_pane == FocusPane::Conversation {
+                if self.focus_pane == FocusPane::Conversation && !self.composer_blocked() {
                     self.conversation_mode = ConversationMode::ComposerEditing;
                 }
             }
@@ -336,7 +338,11 @@ impl App<'_> {
                 self.url_picker = None;
                 self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
             }
-            AppAction::AttachFile => self.open_file_picker(),
+            AppAction::AttachFile => {
+                if !self.composer_blocked() {
+                    self.open_file_picker()
+                }
+            }
             AppAction::FilePickerPrevious => self.move_file_picker(-1),
             AppAction::FilePickerNext => self.move_file_picker(1),
             AppAction::FilePickerParent => {
@@ -595,6 +601,10 @@ impl App<'_> {
     }
 
     fn confirm_file_picker(&mut self) {
+        if self.composer_blocked() {
+            self.file_picker = None;
+            return;
+        }
         let Some(paths) = self
             .file_picker
             .as_ref()
@@ -1309,6 +1319,9 @@ impl App<'_> {
     }
 
     fn dispatch_composer_action(&mut self, action: ComposerAction) {
+        if self.composer_blocked() {
+            return;
+        }
         if self.conversation_mode == ConversationMode::EditingMessage
             && matches!(action, ComposerAction::Submit)
         {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -819,15 +819,31 @@ pub fn render_chats(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(outer_block, area);
 
     let composer_width = inner.width.saturating_sub(2);
-    let composer_layout = composer_visual_layout(app.composer.input.lines(), composer_width);
+    let composer_blocked = app.composer_blocked();
+    let composer_layout = composer_visual_layout(
+        if composer_blocked {
+            &[]
+        } else {
+            app.composer.input.lines()
+        },
+        composer_width,
+    );
     let input_cursor = app.composer.input.cursor();
     let composer_cursor = composer_layout.cursor((input_cursor.0, input_cursor.1));
     let composer_rows = composer_layout.rows.len().max(composer_cursor.0 + 1);
     let (chat_area, composer_area) = conversation_areas(
         inner,
-        composer_rows,
-        usize::from(app.composer.quote.is_some()),
-        app.composer.pending.len(),
+        if composer_blocked { 1 } else { composer_rows },
+        if composer_blocked {
+            0
+        } else {
+            usize::from(app.composer.quote.is_some())
+        },
+        if composer_blocked {
+            0
+        } else {
+            app.composer.pending.len()
+        },
     );
 
     if app.open_chat().is_none() {
@@ -846,7 +862,9 @@ pub fn render_chats(frame: &mut Frame, app: &mut App, area: Rect) {
         } else {
             ratatui::style::Color::White
         };
-        let input_title = if app.conversation_mode == ConversationMode::EditingMessage {
+        let input_title = if composer_blocked {
+            " Admin-only group "
+        } else if app.conversation_mode == ConversationMode::EditingMessage {
             " Edit message (Enter save, Esc cancel) "
         } else {
             " Message input "
@@ -859,8 +877,12 @@ pub fn render_chats(frame: &mut Frame, app: &mut App, area: Rect) {
 
         let mut input_area = input_block.inner(composer_area);
 
-        // Show hint in the input area when not editing
-        if app.conversation_mode == ConversationMode::MessageNavigation {
+        if composer_blocked {
+            frame.render_widget(
+                Paragraph::new(crate::app::ADMIN_ONLY_GROUP_MESSAGE).fg(border_color),
+                input_area,
+            );
+        } else if app.conversation_mode == ConversationMode::MessageNavigation {
             let hint = format!(
                 "Press i to write in {} (Ctrl+O attach) | Space 1 sections | Space 2 chats",
                 app.contact_name(&chat_jid)

--- a/tests/composer_behavior.rs
+++ b/tests/composer_behavior.rs
@@ -1,9 +1,11 @@
 use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{Terminal, backend::TestBackend, layout::Rect};
 use wp_tui::app::actions::ComposerAction;
 use wp_tui::app::actions::{AppAction, ConversationMode};
 use wp_tui::app::composer::Composer;
 use wp_tui::app::inputs::composer_action_for_editing_key;
 use wp_tui::key_handler::Key;
+use wp_tui::ui::render_chats;
 mod common;
 use common::TestApp;
 
@@ -160,6 +162,60 @@ fn attachment_only_drafts_are_sendable() {
 
     assert!(outcome.text_messages().is_empty());
     assert_eq!(outcome.file_messages().len(), 1);
+}
+
+#[test]
+fn blocked_composer_rejects_text_attachments_and_submission() {
+    let mut composer = Composer::default();
+    composer.set_blocked(true);
+
+    composer.insert_text("blocked");
+    composer.queue_attachment("image.png".into(), whatsrust::FileKind::Image);
+
+    assert!(composer.text().is_empty());
+    assert!(composer.pending.is_empty());
+    assert!(composer.apply(ComposerAction::Submit).is_idle());
+}
+
+#[test]
+fn admin_only_group_blocks_input_actions_and_renders_message() {
+    let mut app = TestApp::new();
+    let group = whatsrust::JID("123@g.us".into());
+    app.open_chat_by_jid(group.clone());
+    app.group_permissions.insert(
+        group,
+        whatsrust::GroupInfo {
+            jid: whatsrust::JID("123@g.us".into()),
+            name: "Admins only".into(),
+            is_announce: true,
+            is_admin: false,
+        },
+    );
+    let blocked = app.composer_blocked();
+    app.composer.set_blocked(blocked);
+    app.focus_pane = wp_tui::app::actions::FocusPane::Conversation;
+
+    app.dispatch_action(AppAction::InsertMode);
+    app.dispatch_action(AppAction::Composer(ComposerAction::Edit(Key::c('x'))));
+    app.dispatch_action(AppAction::AttachFile);
+
+    assert_eq!(app.conversation_mode, ConversationMode::MessageNavigation);
+    assert!(app.composer.text().is_empty());
+    assert!(app.composer.pending.is_empty());
+
+    let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+    terminal
+        .draw(|frame| render_chats(frame, &mut app, Rect::new(0, 0, 80, 12)))
+        .unwrap();
+    let rendered = terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect::<String>();
+    assert!(rendered.contains("Only group admins can send messages in this group."));
+    assert!(!rendered.contains("Message input"));
 }
 
 fn message(id: &str) -> whatsrust::Message {

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -30,6 +30,12 @@ typedef struct {
 } ChatSettings;
 
 typedef struct {
+	uint8_t status;
+	bool is_announce;
+	bool is_admin;
+} GroupInfoResult;
+
+typedef struct {
 	ContactEntry* entries;
 	uint32_t size;
 } GetContactsResult;
@@ -632,6 +638,58 @@ func GetSelfId(client *whatsmeow.Client) string {
 		return ""
 	}
 	return StrFromJid(*client.Store.ID)
+}
+
+func participantMatchesSelf(client *whatsmeow.Client, participant types.GroupParticipant) bool {
+	if client == nil || client.Store == nil || client.Store.ID == nil {
+		return false
+	}
+	self := client.Store.ID.ToNonAD()
+	for _, candidate := range []types.JID{participant.JID, participant.PhoneNumber, participant.LID} {
+		if candidate.IsZero() {
+			continue
+		}
+		if jidsMatchSelf(self, candidate) {
+			return true
+		}
+		if candidate.Server == types.HiddenUserServer && self.Server == types.DefaultUserServer {
+			if phone, err := client.Store.LIDs.GetPNForLID(context.Background(), candidate); err == nil && phone.ToNonAD() == self {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func jidsMatchSelf(self, candidate types.JID) bool {
+	return !candidate.IsZero() && candidate.ToNonAD() == self.ToNonAD()
+}
+
+//export C_GetGroupInfo
+func C_GetGroupInfo(cjid C.JID) C.GroupInfoResult {
+	if client == nil || cjid == nil {
+		return C.GroupInfoResult{status: 2}
+	}
+	jid := cToJid(cjid).ToNonAD()
+	if jid.Server != types.GroupServer {
+		return C.GroupInfoResult{status: 1}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	info, err := client.GetGroupInfo(ctx, jid)
+	if err != nil {
+		LOG_WARN("failed to get group info for %s: %v", jid, err)
+		return C.GroupInfoResult{status: 3}
+	}
+
+	result := C.GroupInfoResult{is_announce: C.bool(info.IsAnnounce)}
+	for _, participant := range info.Participants {
+		if participantMatchesSelf(client, participant) {
+			result.is_admin = C.bool(participant.IsAdmin || participant.IsSuperAdmin)
+			break
+		}
+	}
+	return result
 }
 
 // GetChatId returns the normalized chat id (conversation key): LID→PN, broadcast→per-sender, status as-is.
@@ -2948,7 +3006,7 @@ func C_GetChatSettings(cjid C.JID) C.ChatSettings {
 		mutedUntil = settings.MutedUntil.Unix()
 	}
 
-return C.ChatSettings{
+	return C.ChatSettings{
 		found:       C.bool(settings.Found),
 		muted_until: C.int64_t(mutedUntil),
 		pinned:      C.bool(settings.Pinned),

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -24,6 +24,17 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func TestJidsMatchSelfNormalizesDeviceIdentity(t *testing.T) {
+	self := types.NewADJID("self", 0, 7)
+	candidate := types.NewJID("self", types.DefaultUserServer)
+	if !jidsMatchSelf(self, candidate) {
+		t.Fatal("device and user JIDs should identify the same participant")
+	}
+	if jidsMatchSelf(self, types.NewJID("other", types.DefaultUserServer)) {
+		t.Fatal("different participants must not match")
+	}
+}
+
 func TestPinnedPresenceContractAndNarrowSubscription(t *testing.T) {
 	lastSeen := time.Unix(42, 0)
 	event := &events.Presence{

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -83,6 +83,13 @@ struct CChatSettings {
 }
 
 #[repr(C)]
+struct CGroupInfoResult {
+    status: u8,
+    is_announce: bool,
+    is_admin: bool,
+}
+
+#[repr(C)]
 struct CMessageInfo {
     id: *const c_char,
     chat: CJID,
@@ -599,10 +606,20 @@ pub struct ChatSettings {
     pub archived: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GroupInfo {
     pub jid: JID,
     pub name: Arc<str>,
+    pub is_announce: bool,
+    pub is_admin: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GroupInfoError {
+    NotGroup,
+    ClientUnavailable,
+    RequestFailed,
+    InvalidBridgeResult,
 }
 
 impl From<&CContact> for Contact {
@@ -678,6 +695,7 @@ unsafe extern "C" {
     fn C_GetProfilePicture(jid: CJID) -> CProfilePictureResult;
     fn C_FreeProfilePicture(result: CProfilePictureResult);
     fn C_GetChatSettings(jid: CJID) -> CChatSettings;
+    fn C_GetGroupInfo(jid: CJID) -> CGroupInfoResult;
     fn C_ResolveDmChatId(jid: CJID) -> *mut c_char;
     fn C_FreeResolveDmChatId(value: *mut c_char);
     fn C_Disconnect();
@@ -1026,9 +1044,7 @@ impl CallbackTranslator<*const CEvent> for Event {
             EventType::MessageAction => unsafe {
                 message_action_event_from_ffi(&*(event.data as *const CMessageActionEvent))
             },
-            EventType::Chat => unsafe {
-                chat_event_from_ffi(&*(event.data as *const CChatEvent))
-            },
+            EventType::Chat => unsafe { chat_event_from_ffi(&*(event.data as *const CChatEvent)) },
             EventType::LogoutResult => unsafe {
                 let result = &(*(event.data as *const CLogoutResultEvent));
                 Event::LogoutResult(
@@ -1547,6 +1563,62 @@ pub fn get_chat_settings(jid: &JID) -> ChatSettings {
     }
 }
 
+fn group_info_from_parts(
+    jid: &JID,
+    status: u8,
+    is_announce: bool,
+    is_admin: bool,
+) -> Result<GroupInfo, GroupInfoError> {
+    match status {
+        0 => Ok(GroupInfo {
+            jid: jid.clone(),
+            name: "".into(),
+            is_announce,
+            is_admin,
+        }),
+        1 => Err(GroupInfoError::NotGroup),
+        2 => Err(GroupInfoError::ClientUnavailable),
+        3 => Err(GroupInfoError::RequestFailed),
+        _ => Err(GroupInfoError::InvalidBridgeResult),
+    }
+}
+
+pub fn get_group_info(jid: &JID) -> Result<GroupInfo, GroupInfoError> {
+    let jid_c = CJID::from(jid);
+    let result = unsafe { C_GetGroupInfo(jid_c) };
+    group_info_from_parts(jid, result.status, result.is_announce, result.is_admin)
+}
+
+#[cfg(test)]
+mod group_info_tests {
+    use super::{GroupInfoError, JID, group_info_from_parts};
+
+    #[test]
+    fn maps_announce_and_admin_flags() {
+        let jid = JID("123@g.us".into());
+        let info = group_info_from_parts(&jid, 0, true, false).unwrap();
+
+        assert_eq!(info.jid, jid);
+        assert!(info.is_announce);
+        assert!(!info.is_admin);
+    }
+
+    #[test]
+    fn maps_bridge_failures_without_claiming_send_permission() {
+        for (status, expected) in [
+            (1, GroupInfoError::NotGroup),
+            (2, GroupInfoError::ClientUnavailable),
+            (3, GroupInfoError::RequestFailed),
+            (255, GroupInfoError::InvalidBridgeResult),
+        ] {
+            assert_eq!(
+                group_info_from_parts(&JID("chat@g.us".into()), status, false, false),
+                Err(expected)
+            );
+        }
+    }
+}
+
 /// Resolves a group participant (or any user JID) to the canonical JID of
 /// its direct conversation: a LID is mapped to its phone number when known,
 /// matching how direct chats are keyed in the conversation list. Used so a
@@ -1555,10 +1627,7 @@ pub fn get_chat_settings(jid: &JID) -> ChatSettings {
 /// JID is unusable.
 pub fn resolve_dm_chat(jid: &JID) -> Option<JID> {
     unsafe {
-        take_owned_c_string(
-            C_ResolveDmChatId(CJID::from(jid)),
-            C_FreeResolveDmChatId,
-        )
-        .map(JID::from)
+        take_owned_c_string(C_ResolveDmChatId(CJID::from(jid)), C_FreeResolveDmChatId)
+            .map(JID::from)
     }
 }


### PR DESCRIPTION
## Summary

- Detect WhatsApp groups where only administrators may send messages.
- Replace the usable composer with a clear admin-only notice for regular members.
- Prevent typing, paste, attachments, and submission paths that WhatsApp would reject.

## Changes

- Bridge group announce/admin permissions through the Go/C/Rust boundary.
- Track the selected group's permission state in the application.
- Block composer actions and render the admin-only explanation.
- Add focused Rust and Go coverage for permission mapping and UI behavior.

## Testing

- [ ] `cargo test -- --test-threads=1`
- [x] `cargo test --test composer_behavior`
- [x] `cargo test -p whatsrust`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cargo check --workspace`
- [x] `cargo fmt --check`
- [ ] Manual testing done

Closes #27