### PR TITLE
fix(messages): show unavailable view-once media

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -2059,6 +2059,14 @@ func dispatchIncomingMessageWithDecrypt(
 		dispatchAction(action)
 		return
 	}
+	rawMessage := evt.RawMessage
+	if rawMessage == nil && evt.SourceWebMsg != nil {
+		rawMessage = evt.SourceWebMsg.GetMessage()
+	}
+	if message, ok := unavailableViewOnceMessage(rawMessage); ok {
+		dispatchMessage(evt.Info, message, false)
+		return
+	}
 	dispatchMessage(evt.Info, evt.Message, false)
 }
 
@@ -2948,7 +2956,7 @@ func C_GetChatSettings(cjid C.JID) C.ChatSettings {
 		mutedUntil = settings.MutedUntil.Unix()
 	}
 
-return C.ChatSettings{
+	return C.ChatSettings{
 		found:       C.bool(settings.Found),
 		muted_until: C.int64_t(mutedUntil),
 		pinned:      C.bool(settings.Pinned),

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -869,6 +869,96 @@ func TestIncomingMessageDispatchesNormalizedEditBeforeOrdinaryMessage(t *testing
 	}
 }
 
+func TestIncomingMessageDispatchesViewOncePlaceholderFromAuthoritativeEnvelope(t *testing.T) {
+	chat := types.NewJID("1234567890", types.DefaultUserServer)
+	sender := types.NewJID("0987654321", types.DefaultUserServer)
+	info := types.MessageInfo{
+		MessageSource: types.MessageSource{Chat: chat, Sender: sender},
+		ID:            "view-once-message",
+		Timestamp:     time.Unix(42, 0),
+	}
+	viewOnce := func(message *waE2E.Message) *waE2E.Message {
+		return &waE2E.Message{ViewOnceMessage: &waE2E.FutureProofMessage{Message: message}}
+	}
+
+	cases := []struct {
+		name  string
+		event *events.Message
+	}{
+		{
+			name: "live raw envelope",
+			event: &events.Message{
+				Info:       info,
+				Message:    &waE2E.Message{ImageMessage: &waE2E.ImageMessage{}},
+				RawMessage: viewOnce(&waE2E.Message{ImageMessage: &waE2E.ImageMessage{}}),
+			},
+		},
+		{
+			name: "history source envelope",
+			event: &events.Message{
+				Info:    info,
+				Message: &waE2E.Message{VideoMessage: &waE2E.VideoMessage{}},
+				SourceWebMsg: &waWeb.WebMessageInfo{
+					Message: viewOnce(&waE2E.Message{VideoMessage: &waE2E.VideoMessage{}}),
+				},
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var actions []messageActionEvent
+			var dispatched []struct {
+				info    types.MessageInfo
+				message *waE2E.Message
+				isRetry bool
+			}
+			dispatchIncomingMessageWithDecrypt(testCase.event, func(action messageActionEvent) {
+				actions = append(actions, action)
+			}, func(info types.MessageInfo, message *waE2E.Message, isRetry bool) {
+				dispatched = append(dispatched, struct {
+					info    types.MessageInfo
+					message *waE2E.Message
+					isRetry bool
+				}{info, message, isRetry})
+			}, nil)
+
+			if len(actions) != 0 || len(dispatched) != 1 {
+				t.Fatalf("actions=%d dispatched=%d, want actions=0 dispatched=1", len(actions), len(dispatched))
+			}
+			if dispatched[0].info.ID != info.ID || dispatched[0].info.Chat != info.Chat || dispatched[0].info.Sender != info.Sender {
+				t.Fatalf("message info was not preserved: %#v", dispatched[0].info)
+			}
+			if dispatched[0].isRetry || dispatched[0].message.GetConversation() != viewOnceUnavailablePlaceholder {
+				t.Fatalf("unexpected placeholder dispatch: %#v", dispatched[0])
+			}
+		})
+	}
+}
+
+func TestIncomingMessageDispatchKeepsOrdinaryMessageWithoutRawViewOnce(t *testing.T) {
+	info := types.MessageInfo{ID: "ordinary-message"}
+	ordinary := &waE2E.Message{Conversation: stringPointer("ordinary")}
+	event := &events.Message{Info: info, Message: ordinary}
+
+	actions := 0
+	dispatched := 0
+	var got *waE2E.Message
+	dispatchIncomingMessageWithDecrypt(event, func(messageActionEvent) {
+		actions++
+	}, func(_ types.MessageInfo, message *waE2E.Message, isRetry bool) {
+		dispatched++
+		got = message
+		if isRetry {
+			t.Fatal("ordinary message was marked as a retry")
+		}
+	}, nil)
+
+	if actions != 0 || dispatched != 1 || got != ordinary {
+		t.Fatalf("actions=%d dispatched=%d got=%p, want actions=0 dispatched=1 original=%p", actions, dispatched, got, ordinary)
+	}
+}
+
 func TestIncomingSecretEncryptedMessageEditDispatch(t *testing.T) {
 	chat := types.NewJID("1234567890", types.DefaultUserServer)
 	editor := types.NewJID("0987654321", types.DefaultUserServer)


### PR DESCRIPTION
## Summary

- Keep incoming View Once messages visible as a safe unavailable-media placeholder.
- Detect the authoritative wrapper before whatsmeow normalization can discard it.
- Preserve the public boundary: media is not exposed, downloaded, cached, or forwarded.

## Changes

- Inspect live `RawMessage` and history `SourceWebMsg` envelopes before ordinary dispatch.
- Preserve message identity and existing secret/message-action precedence.
- Add ingress regressions for live/history View Once and ordinary messages.

## Testing

- [x] `cargo test -- --test-threads=1` — 268 passed
- [x] `cd whatsrust/lib && go test ./...` — passed
- [x] `cd whatsrust/lib && go vet ./...` — passed
- [x] Candidate Go formatting verified with `gofmt -d main.go main_test.go`
- [ ] Manual testing done

## Chain context

```text
main
 └─ refactor/message-layout-boundary
     └─ refactor/modular-ui-panes
         └─ 📍 fix/view-once-ingress
```

- **Starts from:** `refactor/modular-ui-panes`
- **Ends with:** View Once placeholders dispatched from authoritative ingress envelopes
- **Depends on:** the current modular UI refactor tip
- **Follow-up:** none for View Once ingress
- **Out of scope:** exposing View Once media, bypassing WhatsApp restrictions, UI refactoring, group-permission work
- **Review budget:** 100 changed lines

Closes #29