### PR TITLE
feat(communities): add hierarchy navigation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -72,6 +72,23 @@ pub struct Chat {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommunityNode {
+    pub jid: wr::JID,
+    pub name: String,
+    pub is_root: bool,
+    pub linked_groups: Vec<wr::JID>,
+}
+
+/// Presentation-only Chats row. `target` and `members` are always real chat
+/// JIDs; a community never becomes a persisted or addressable chat.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatRow {
+    pub label: String,
+    pub members: Vec<wr::JID>,
+    pub target: wr::JID,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MessageActionKind {
     Edit { replacement: Arc<str> },
     Delete,
@@ -230,6 +247,9 @@ pub struct App<'a> {
     /// Status section: the contact whose statuses are open in the right
     /// pane. Mirrors `open_chat` for the Chats section: set on Enter.
     pub open_status_contact: Option<wr::JID>,
+    pub communities: Vec<CommunityNode>,
+    pub communities_unavailable: bool,
+    communities_loaded: bool,
 
     /// Contacts with posted statuses, sorted by latest-status recency (newest
     /// first). Derived from the `status@broadcast` chat.
@@ -404,6 +424,9 @@ impl App<'_> {
             chat_list_state: ListState::default(),
             open_chat: None,
             open_status_contact: None,
+            communities: Vec::new(),
+            communities_unavailable: false,
+            communities_loaded: false,
 
             status_contacts: Vec::new(),
             status_selection: ListState::default(),
@@ -549,6 +572,7 @@ impl App<'_> {
         match event {
             wr::Event::AppStateSyncComplete => {
                 self.get_contacts();
+                self.load_communities();
                 self.sort_chats();
                 true
             }
@@ -636,6 +660,10 @@ impl App<'_> {
                 true
             }
             wr::Event::Connected => {
+                // Connected is emitted again after reconnects.  The first
+                // probe may race group metadata hydration, so AppStateSyncComplete
+                // below remains the authoritative follow-up refresh.
+                self.load_communities();
                 self.selected_presence.ready();
                 self.presence_diagnostics
                     .record(|| "self presence available: ready".to_owned());
@@ -1283,13 +1311,208 @@ impl App<'_> {
     }
 
     pub fn get_selected_chat(&self) -> Option<wr::JID> {
-        self.chat_list_state.selected().map(|index| {
-            if self.contact_search.input.is_empty() {
-                self.sorted_chats[index].clone()
-            } else {
-                self.filtered_chats[index].clone()
+        let rows = self.visible_chat_rows();
+        self.chat_list_state
+            .selected()
+            .and_then(|index| rows.get(index))
+            .map(|row| row.target.clone())
+    }
+
+    pub fn chat_rows(&self) -> Vec<ChatRow> {
+        let mut grouped = HashSet::new();
+        let community_metadata = self
+            .communities
+            .iter()
+            .map(|node| node.jid.clone())
+            .collect::<HashSet<_>>();
+        let mut rows = Vec::new();
+        for community in self.communities.iter().filter(|node| node.is_root) {
+            let members = community
+                .linked_groups
+                .iter()
+                .filter(|jid| self.chats.contains_key(*jid))
+                .cloned()
+                .collect::<Vec<_>>();
+            if members.is_empty() {
+                continue;
             }
-        })
+            grouped.extend(members.iter().cloned());
+            let target = members
+                .iter()
+                .max_by_key(|jid| self.chat_recency(jid))
+                .expect("non-empty community members")
+                .clone();
+            rows.push(ChatRow {
+                label: community.name.clone(),
+                members,
+                target,
+            });
+        }
+        rows.extend(
+            self.sorted_chats
+                .iter()
+                .filter(|jid| !grouped.contains(*jid))
+                .filter(|jid| !community_metadata.contains(*jid))
+                .map(|jid| ChatRow {
+                    label: self.contact_name(jid).to_string(),
+                    members: vec![(*jid).clone()],
+                    target: (*jid).clone(),
+                }),
+        );
+        rows.sort_by(|left, right| {
+            self.chat_recency(&right.target)
+                .cmp(&self.chat_recency(&left.target))
+                .then_with(|| left.label.cmp(&right.label))
+                .then_with(|| left.target.0.cmp(&right.target.0))
+        });
+        rows
+    }
+
+    pub fn visible_chat_rows(&self) -> Vec<ChatRow> {
+        let query = self.contact_search.input.to_lowercase();
+        self.chat_rows()
+            .into_iter()
+            .filter(|row| {
+                query.is_empty()
+                    || row.label.to_lowercase().contains(&query)
+                    || row
+                        .members
+                        .iter()
+                        .any(|jid| self.contact_name(jid).to_lowercase().contains(&query))
+            })
+            .collect()
+    }
+
+    pub fn chat_row_item(&self, row: &ChatRow) -> crate::ui::contact_list::ContactListItem {
+        crate::ui::contact_list::ContactListItem::from_row(self, row)
+    }
+
+    fn chat_recency(&self, jid: &wr::JID) -> i64 {
+        self.chat_messages
+            .get(jid)
+            .into_iter()
+            .flatten()
+            .filter_map(|id| self.messages.get(id).map(|message| message.info.timestamp))
+            .max()
+            .or_else(|| self.chats.get(jid).and_then(|chat| chat.last_message_time))
+            .unwrap_or_default()
+    }
+
+    pub fn get_selected_community(&self) -> Option<wr::JID> {
+        self.chat_list_state
+            .selected()
+            .and_then(|index| {
+                self.communities
+                    .iter()
+                    .filter(|node| !node.is_root)
+                    .nth(index)
+            })
+            .map(|node| node.jid.clone())
+    }
+
+    fn selected_community_node_jid(&self) -> Option<wr::JID> {
+        self.chat_list_state
+            .selected()
+            .and_then(|index| {
+                self.communities
+                    .iter()
+                    .filter(|node| !node.is_root)
+                    .nth(index)
+                    .or_else(|| {
+                        self.communities
+                            .iter()
+                            .filter(|node| node.is_root)
+                            .nth(index)
+                    })
+            })
+            .map(|node| node.jid.clone())
+    }
+
+    fn select_community_node(&mut self, jid: Option<wr::JID>) {
+        let selected = jid
+            .and_then(|jid| {
+                self.selectable_community_nodes()
+                    .iter()
+                    .position(|node| node.jid == jid)
+            })
+            .or_else(|| (!self.selectable_community_nodes().is_empty()).then_some(0));
+        self.chat_list_state.select(selected);
+    }
+
+    pub(crate) fn selectable_community_nodes(&self) -> Vec<&CommunityNode> {
+        self.communities
+            .iter()
+            .filter(|node| !node.is_root)
+            .collect()
+    }
+
+    fn load_communities(&mut self) {
+        self.refresh_communities(wr::get_communities);
+    }
+
+    pub fn refresh_communities<F>(&mut self, fetch: F)
+    where
+        F: FnOnce() -> Result<Vec<wr::CommunityInfo>, wr::CommunitiesError>,
+    {
+        match fetch() {
+            Ok(records) => {
+                // Communities has its own hierarchy. Never preserve its
+                // selection through the projected Chats rows: those rows may
+                // reorder independently and roots target a different JID.
+                let selected = if self.selected_section == Section::Communities {
+                    self.selected_community_node_jid()
+                } else {
+                    None
+                };
+                // An empty successful result is meaningful: it clears a prior
+                // hierarchy and renders the normal "No communities" state.
+                self.communities = Self::build_community_nodes(&records);
+                self.communities_unavailable = false;
+                self.communities_loaded = true;
+                if self.selected_section == Section::Communities {
+                    self.select_community_node(selected);
+                }
+            }
+            Err(error) => {
+                // Do not turn a transient readiness/reconnect failure into an
+                // empty hierarchy. Keep the last successful snapshot visible.
+                warn!("Could not load communities: {error:?}");
+                self.communities_unavailable = !self.communities_loaded;
+            }
+        }
+    }
+
+    pub(crate) fn build_community_nodes(records: &[wr::CommunityInfo]) -> Vec<CommunityNode> {
+        let mut roots = records
+            .iter()
+            .filter(|record| record.is_parent)
+            .collect::<Vec<_>>();
+        roots.sort_by(|a, b| a.name.cmp(&b.name));
+        let mut nodes = Vec::new();
+        for root in roots {
+            nodes.push(CommunityNode {
+                jid: root.jid.clone(),
+                name: root.name.to_string(),
+                is_root: true,
+                linked_groups: records
+                    .iter()
+                    .filter(|record| record.parent_jid.as_ref() == Some(&root.jid))
+                    .map(|record| record.jid.clone())
+                    .collect(),
+            });
+            let mut children = records
+                .iter()
+                .filter(|record| record.parent_jid.as_ref() == Some(&root.jid))
+                .collect::<Vec<_>>();
+            children.sort_by(|a, b| a.name.cmp(&b.name));
+            nodes.extend(children.into_iter().map(|child| CommunityNode {
+                jid: child.jid.clone(),
+                name: child.name.to_string(),
+                is_root: false,
+                linked_groups: Vec::new(),
+            }));
+        }
+        nodes
     }
 
     pub fn open_chat(&self) -> Option<wr::JID> {
@@ -1705,17 +1928,15 @@ impl App<'_> {
     }
 
     pub fn select_chat(&mut self, jid: Option<wr::JID>) {
-        let target_list = if self.contact_search.input.is_empty() {
-            &self.sorted_chats
-        } else {
-            &self.filtered_chats
-        };
+        let target_list = self.visible_chat_rows();
 
         if let Some(jid) = jid
-            && let Some(index) = target_list.iter().position(|chat_jid| chat_jid == &jid)
+            && let Some(index) = target_list
+                .iter()
+                .position(|row| row.target == jid || row.members.contains(&jid))
         {
             self.chat_list_state.select(Some(index));
-        } else if !self.sorted_chats.is_empty() {
+        } else if !target_list.is_empty() {
             self.chat_list_state.select(Some(0));
         } else {
             self.chat_list_state.select(None);
@@ -1723,15 +1944,10 @@ impl App<'_> {
     }
 
     fn update_filtered_chats(&mut self) {
-        let query = self.contact_search.input.to_lowercase();
         self.filtered_chats = self
-            .sorted_chats
-            .iter()
-            .filter(|chat| {
-                let name = self.contact_name(chat).to_lowercase();
-                name.contains(&query)
-            })
-            .cloned()
+            .visible_chat_rows()
+            .into_iter()
+            .map(|row| row.target)
             .collect();
 
         if !self.filtered_chats.is_empty() {
@@ -1823,6 +2039,7 @@ impl App<'_> {
     }
 
     pub fn sort_chats(&mut self) {
+        let selected = self.get_selected_chat();
         let mut entries: Vec<_> = self.chats.values().cloned().collect();
         entries.sort_by(|a, b| {
             let a_time = a.last_message_time.unwrap_or_default();
@@ -1835,6 +2052,7 @@ impl App<'_> {
             .map(|chat| chat.jid.clone())
             .filter(|jid: &wr::JID| !jid.0.as_ref().ends_with("@broadcast"))
             .collect();
+        self.select_chat(selected);
     }
 
     pub(crate) fn sort_chat_messages(&mut self, chat_jid: wr::JID) {
@@ -2016,6 +2234,7 @@ pub fn unix_now() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::actions::AppAction;
 
     /// Test-only App wrapper: points every storage path at a fresh
     /// tempdir (so tests never open the real user database) and stops
@@ -2112,6 +2331,180 @@ mod tests {
         assert_eq!(app.open_chat(), Some(recipient.clone()));
         assert!(app.chats.contains_key(&recipient));
         assert!(app.sorted_chats.contains(&recipient));
+    }
+
+    #[test]
+    fn community_hierarchy_is_sorted_with_roots_followed_by_children() {
+        let root = wr::JID::from("root@g.us".to_owned());
+        let child = wr::JID::from("child@g.us".to_owned());
+        let records = vec![
+            wr::CommunityInfo {
+                jid: child.clone(),
+                name: "Child".into(),
+                parent_jid: Some(root.clone()),
+                is_parent: false,
+            },
+            wr::CommunityInfo {
+                jid: root.clone(),
+                name: "Community".into(),
+                parent_jid: None,
+                is_parent: true,
+            },
+        ];
+        assert_eq!(
+            App::build_community_nodes(&records),
+            vec![
+                CommunityNode {
+                    jid: root,
+                    name: "Community".into(),
+                    is_root: true,
+                    linked_groups: vec![child.clone()],
+                },
+                CommunityNode {
+                    jid: child,
+                    name: "Child".into(),
+                    is_root: false,
+                    linked_groups: Vec::new(),
+                },
+            ]
+        );
+    }
+
+    fn community(name: &str, jid: &str, is_parent: bool) -> wr::CommunityInfo {
+        wr::CommunityInfo {
+            jid: wr::JID::from(jid.to_owned()),
+            name: name.into(),
+            parent_jid: None,
+            is_parent,
+        }
+    }
+
+    #[test]
+    fn communities_load_after_readiness_event() {
+        let mut app = TestApp::new();
+        let root = community("Community", "root@g.us", true);
+
+        app.refresh_communities(|| Ok(vec![root.clone()]));
+
+        assert_eq!(app.communities.len(), 1);
+        assert!(!app.communities_unavailable);
+    }
+
+    #[test]
+    fn communities_refresh_on_restart_or_reconnect_replaces_snapshot() {
+        let mut app = TestApp::new();
+        app.refresh_communities(|| Ok(vec![community("Old", "old@g.us", true)]));
+        app.refresh_communities(|| Ok(vec![community("New", "new@g.us", true)]));
+
+        assert_eq!(app.communities[0].name, "New");
+        assert_eq!(app.communities[0].jid, wr::JID::from("new@g.us".to_owned()));
+    }
+
+    #[test]
+    fn successful_empty_communities_clears_snapshot() {
+        let mut app = TestApp::new();
+        app.refresh_communities(|| Ok(vec![community("Old", "old@g.us", true)]));
+        app.refresh_communities(|| Ok(Vec::new()));
+
+        assert!(app.communities.is_empty());
+        assert!(!app.communities_unavailable);
+    }
+
+    #[test]
+    fn transient_communities_failure_preserves_last_successful_snapshot() {
+        let mut app = TestApp::new();
+        app.refresh_communities(|| Ok(vec![community("Known", "known@g.us", true)]));
+        app.refresh_communities(|| Err(wr::CommunitiesError::BridgeUnavailable));
+
+        assert_eq!(app.communities[0].name, "Known");
+        assert!(!app.communities_unavailable);
+    }
+
+    #[test]
+    fn communities_refresh_preserves_explicit_node_across_reorder_and_target_change() {
+        let mut app = TestApp::new();
+        let selected = wr::JID::from("selected@g.us".to_owned());
+        let other = wr::JID::from("other@g.us".to_owned());
+        app.selected_section = Section::Communities;
+        app.refresh_communities(|| {
+            Ok(vec![
+                community("Selected", "selected@g.us", true),
+                wr::CommunityInfo {
+                    jid: other.clone(),
+                    name: "Other".into(),
+                    parent_jid: Some(selected.clone()),
+                    is_parent: false,
+                },
+            ])
+        });
+        app.chat_list_state.select(Some(0));
+        app.chats.insert(
+            other.clone(),
+            Chat {
+                jid: other.clone(),
+                last_message_time: None,
+            },
+        );
+        app.refresh_communities(|| {
+            Ok(vec![
+                community("Aardvark", "aardvark@g.us", true),
+                community("Selected", "selected@g.us", true),
+                wr::CommunityInfo {
+                    jid: other.clone(),
+                    name: "Other".into(),
+                    parent_jid: Some(selected.clone()),
+                    is_parent: false,
+                },
+            ])
+        });
+
+        assert_eq!(app.selected_community_node_jid(), Some(other.clone()));
+        assert_eq!(app.get_selected_community(), Some(other));
+    }
+
+    #[test]
+    fn communities_refresh_falls_back_when_selected_node_is_removed() {
+        let mut app = TestApp::new();
+        app.selected_section = Section::Communities;
+        app.refresh_communities(|| {
+            Ok(vec![
+                community("Removed", "removed@g.us", true),
+                community("Kept", "kept@g.us", true),
+            ])
+        });
+        app.chat_list_state.select(Some(0));
+        app.refresh_communities(|| Ok(vec![community("Kept", "kept@g.us", true)]));
+
+        assert_eq!(app.chat_list_state.selected(), None);
+        assert_eq!(app.selected_community_node_jid(), None);
+    }
+
+    #[test]
+    fn community_selection_moves_and_enter_opens_the_selected_group() {
+        let mut app = TestApp::new();
+        let root = wr::JID::from("root@g.us".to_owned());
+        let child = wr::JID::from("child@g.us".to_owned());
+        app.communities = vec![
+            CommunityNode {
+                jid: root,
+                name: "Community".into(),
+                is_root: true,
+                linked_groups: vec![child.clone()],
+            },
+            CommunityNode {
+                jid: child.clone(),
+                name: "Child".into(),
+                is_root: false,
+                linked_groups: Vec::new(),
+            },
+        ];
+        app.selected_section = Section::Communities;
+        app.focus_pane = FocusPane::ChatList;
+        app.chat_list_state.select(Some(0));
+        assert_eq!(app.chat_list_state.selected(), Some(0));
+        app.dispatch_action(AppAction::OpenChat);
+        assert_eq!(app.open_chat(), Some(child));
+        assert_eq!(app.focus_pane, FocusPane::Conversation);
     }
 
     #[test]

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -272,6 +272,11 @@ impl App<'_> {
                             self.message_list_state.select(Some(0));
                         }
                     }
+                } else if self.selected_section == Section::Communities {
+                    if let Some(jid) = self.get_selected_community() {
+                        self.open_chat_by_jid(jid);
+                        self.focus_pane = FocusPane::Conversation;
+                    }
                 } else {
                     let opened = self.get_selected_chat().is_some();
                     self.open_selected_chat();
@@ -1175,6 +1180,9 @@ impl App<'_> {
                 if self.selected_section == Section::Status {
                     self.status_selection.select_next();
                     self.clamp_status_selection();
+                } else if self.selected_section == Section::Communities {
+                    self.chat_list_state.select_next();
+                    self.clamp_community_selection();
                 } else {
                     self.chat_list_state.select_next();
                     self.clamp_chat_selection();
@@ -1209,6 +1217,9 @@ impl App<'_> {
                 if self.selected_section == Section::Status {
                     self.status_selection.select_previous();
                     self.clamp_status_selection();
+                } else if self.selected_section == Section::Communities {
+                    self.chat_list_state.select_previous();
+                    self.clamp_community_selection();
                 } else {
                     self.chat_list_state.select_previous();
                     self.clamp_chat_selection();
@@ -1346,6 +1357,17 @@ impl App<'_> {
             &self.filtered_chats
         };
         match (chats.len(), self.chat_list_state.selected()) {
+            (0, _) => self.chat_list_state.select(None),
+            (len, Some(selected)) if selected >= len => self.chat_list_state.select(Some(len - 1)),
+            _ => {}
+        }
+    }
+
+    fn clamp_community_selection(&mut self) {
+        match (
+            self.selectable_community_nodes().len(),
+            self.chat_list_state.selected(),
+        ) {
             (0, _) => self.chat_list_state.select(None),
             (len, Some(selected)) if selected >= len => self.chat_list_state.select(Some(len - 1)),
             _ => {}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,4 @@
+pub mod communities;
 pub mod contact_list;
 mod layout;
 pub mod message_list;
@@ -73,6 +74,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             render_status_contacts(frame, app, area);
         }
         render_statuses(frame, app, areas.conversation);
+    } else if app.selected_section == Section::Communities {
+        if let Some(area) = areas.chat_list {
+            communities::render(frame, app, area);
+        }
+        render_chats(frame, app, areas.conversation);
     } else {
         app.contact_avatars.clear_window();
         if let Some(area) = areas.chat_list {
@@ -87,14 +93,14 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 }
 
 fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let chats = if app.contact_search.input.is_empty() {
-        app.sorted_chats.clone()
-    } else {
-        app.filtered_chats.clone()
-    };
-    let items = chats
+    let rows = app.visible_chat_rows();
+    let targets = rows
         .iter()
-        .map(|chat| ContactListItem::from_chat(app, chat))
+        .map(|row| row.target.clone())
+        .collect::<Vec<_>>();
+    let items = rows
+        .iter()
+        .map(|row| ContactListItem::from_row(app, row))
         .collect::<Vec<_>>();
 
     let mut list_area = area;
@@ -141,11 +147,11 @@ fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
     let visible = contact_visible_range(
         app.chat_list_state.offset(),
         contacts_area.height,
-        chats.len(),
+        rows.len(),
     );
     app.contact_avatars.schedule(
         prioritized_avatar_requests(
-            &chats,
+            &targets,
             app.chat_list_state.selected(),
             visible.start,
             visible.len(),
@@ -167,7 +173,7 @@ fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
         // Partial Kitty placements can leave terminal artifacts after a scroll.
         if avatar_area.width == AVATAR_WIDTH
             && avatar_area.height == AVATAR_HEIGHT
-            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
+            && let Some(protocol) = app.contact_avatars.protocol_mut(&targets[index])
         {
             StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
         }

--- a/src/ui/communities.rs
+++ b/src/ui/communities.rs
@@ -1,0 +1,212 @@
+use crate::app::App;
+use crate::app::actions::FocusPane;
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::{Block, Paragraph},
+};
+
+const BRANCH_WIDTH: u16 = 4;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CommunityRow {
+    node_index: usize,
+    selectable_index: Option<usize>,
+    area: Rect,
+    branch: Rect,
+    text: Rect,
+}
+
+fn community_layout(
+    communities: &[crate::app::CommunityNode],
+    selected: Option<usize>,
+    area: Rect,
+) -> Vec<CommunityRow> {
+    if area.is_empty() {
+        return Vec::new();
+    }
+
+    let mut logical_rows = Vec::new();
+    let mut selectable_index = 0;
+    for (node_index, root) in communities
+        .iter()
+        .enumerate()
+        .filter(|(_, node)| node.is_root)
+    {
+        logical_rows.push((node_index, None));
+        for (node_index, _) in communities
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| !node.is_root && root.linked_groups.contains(&node.jid))
+        {
+            logical_rows.push((node_index, Some(selectable_index)));
+            selectable_index += 1;
+        }
+    }
+
+    let capacity = usize::from(area.height);
+    let selected_row = selected.and_then(|selection| {
+        logical_rows
+            .iter()
+            .position(|(_, selectable)| *selectable == Some(selection))
+    });
+    let start = selected_row
+        .map(|row| row.saturating_sub(capacity.saturating_sub(1)))
+        .unwrap_or(0)
+        .min(logical_rows.len().saturating_sub(capacity));
+
+    logical_rows
+        .into_iter()
+        .skip(start)
+        .take(capacity)
+        .enumerate()
+        .map(|(visible_index, (node_index, selectable_index))| {
+            let y = area.y.saturating_add(visible_index as u16);
+            let row_area = Rect::new(area.x, y, area.width, 1);
+            let branch_x = area.x.min(area.right());
+            let branch = Rect::new(
+                branch_x,
+                y,
+                BRANCH_WIDTH.min(area.right().saturating_sub(branch_x)),
+                1,
+            );
+            let text_x = if selectable_index.is_some() {
+                branch_x.saturating_add(BRANCH_WIDTH).min(area.right())
+            } else {
+                area.x
+            };
+            let text = Rect::new(text_x, y, area.right().saturating_sub(text_x), 1);
+            CommunityRow {
+                node_index,
+                selectable_index,
+                area: row_area,
+                branch,
+                text,
+            }
+        })
+        .collect()
+}
+
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+    let block = Block::bordered()
+        .title("Communities")
+        .border_style(
+            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
+                Color::Green
+            } else {
+                Color::White
+            }),
+        );
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if app.communities_unavailable {
+        frame.render_widget(Paragraph::new("Community data unavailable"), inner);
+        return;
+    }
+    if app.communities.is_empty() {
+        frame.render_widget(Paragraph::new("No communities"), inner);
+        return;
+    }
+
+    let selected = app.chat_list_state.selected();
+    for row in community_layout(&app.communities, selected, inner) {
+        let node = &app.communities[row.node_index];
+        let selected = row.selectable_index == selected;
+        let base = if selected {
+            Style::default().fg(Color::Green).bg(Color::DarkGray)
+        } else {
+            Style::default()
+        };
+        frame.buffer_mut().set_style(row.area, base);
+
+        if row.selectable_index.is_some() {
+            frame.buffer_mut().set_stringn(
+                row.branch.x,
+                row.branch.y,
+                "├─",
+                row.branch.width as usize,
+                base,
+            );
+        }
+        let text_style = if row.selectable_index.is_none() {
+            base.add_modifier(Modifier::BOLD)
+        } else {
+            base
+        };
+        frame.buffer_mut().set_stringn(
+            row.text.x,
+            row.text.y,
+            &node.name,
+            row.text.width as usize,
+            text_style,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::community_layout;
+    use crate::app::CommunityNode;
+    use ratatui::layout::Rect;
+    use whatsrust::JID;
+
+    fn nodes(group_count: usize) -> Vec<CommunityNode> {
+        let groups = (0..group_count)
+            .map(|index| JID::from(format!("group-{index}@g.us")))
+            .collect::<Vec<_>>();
+        let mut result = vec![CommunityNode {
+            jid: JID::from("root@g.us".to_owned()),
+            name: "Community".into(),
+            is_root: true,
+            linked_groups: groups.clone(),
+        }];
+        result.extend(
+            groups
+                .into_iter()
+                .enumerate()
+                .map(|(index, jid)| CommunityNode {
+                    jid,
+                    name: format!("Group {index}"),
+                    is_root: false,
+                    linked_groups: Vec::new(),
+                }),
+        );
+        result
+    }
+
+    #[test]
+    fn root_is_rendered_once_and_groups_are_compact_branch_rows() {
+        let layout = community_layout(&nodes(2), Some(0), Rect::new(0, 0, 40, 12));
+        assert_eq!(layout.len(), 3);
+        assert_eq!(layout[0].selectable_index, None);
+        assert_eq!(layout[0].text.y, 0);
+        assert_eq!(layout[1].selectable_index, Some(0));
+        assert_eq!(layout[1].text.y, 1);
+        assert_eq!(layout[2].selectable_index, Some(1));
+        assert_eq!(layout[2].text.y, 2);
+        assert_eq!(layout[1].text.x, layout[1].branch.right());
+    }
+
+    #[test]
+    fn selected_group_is_visible_and_root_is_not_selectable() {
+        let layout = community_layout(&nodes(6), Some(5), Rect::new(0, 0, 40, 3));
+        assert!(layout.iter().any(|row| row.selectable_index == Some(5)));
+        assert!(layout.iter().all(|row| row.selectable_index.is_some()));
+    }
+
+    #[test]
+    fn narrow_and_short_areas_remain_bounded() {
+        let layout = community_layout(&nodes(2), Some(0), Rect::new(0, 0, 5, 1));
+        assert!(
+            layout
+                .iter()
+                .all(|row| row.area.right() <= 5 && row.area.bottom() <= 1)
+        );
+        assert!(
+            layout
+                .iter()
+                .all(|row| row.branch.right() <= 5 && row.text.right() <= 5)
+        );
+    }
+}

--- a/src/ui/contact_list.rs
+++ b/src/ui/contact_list.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use textwrap::core::display_width;
 use whatsrust as wr;
 
-use crate::app::App;
+use crate::app::{App, ChatRow};
 
 pub const CONTACT_ITEM_HEIGHT: usize = 3;
 pub const AVATAR_WIDTH: u16 = 4;
@@ -21,18 +21,26 @@ pub struct ContactListItem {
     pub initials: String,
     pub preview: String,
     pub local_time: Option<String>,
-    /// The current backend does not expose per-chat unread totals, so this remains absent.
-    pub unread_count: Option<u32>,
 }
 
 impl ContactListItem {
     pub fn from_chat(app: &App<'_>, chat: &wr::JID) -> Self {
-        let name = app.contact_name(chat).to_string();
-        let latest = app
-            .chat_messages
-            .get(chat)
-            .into_iter()
-            .flatten()
+        Self::from_row(
+            app,
+            &ChatRow {
+                label: app.contact_name(chat).to_string(),
+                members: vec![chat.clone()],
+                target: chat.clone(),
+            },
+        )
+    }
+
+    pub fn from_row(app: &App<'_>, row: &ChatRow) -> Self {
+        let name = row.label.clone();
+        let latest = row
+            .members
+            .iter()
+            .flat_map(|chat| app.chat_messages.get(chat).into_iter().flatten())
             .filter_map(|id| app.messages.get(id))
             .max_by(|left, right| {
                 left.info
@@ -40,16 +48,18 @@ impl ContactListItem {
                     .cmp(&right.info.timestamp)
                     .then_with(|| left.info.id.cmp(&right.info.id))
             });
-        let timestamp = latest
-            .map(|message| message.info.timestamp)
-            .or_else(|| app.chats.get(chat).and_then(|chat| chat.last_message_time));
+        let timestamp = latest.map(|message| message.info.timestamp).or_else(|| {
+            row.members
+                .iter()
+                .filter_map(|jid| app.chats.get(jid).and_then(|chat| chat.last_message_time))
+                .max()
+        });
 
         Self {
             initials: initials(&name),
             name,
             preview: latest.map(message_preview).unwrap_or_default(),
             local_time: timestamp.and_then(local_time),
-            unread_count: None,
         }
     }
 }
@@ -182,11 +192,7 @@ impl StatefulWidget for ContactList<'_> {
                 .saturating_add(AVATAR_WIDTH.saturating_add(AVATAR_GAP).min(area.width));
             let text_width = area.right().saturating_sub(text_x) as usize;
             let first = format_row(&item.name, item.local_time.as_deref(), text_width);
-            let unread = item
-                .unread_count
-                .filter(|count| *count > 0)
-                .map(|count| count.to_string());
-            let second = format_row(&item.preview, unread.as_deref(), text_width);
+            let second = format_row(&item.preview, None, text_width);
             if item_area.height > 0 {
                 buf.set_stringn(text_x, y, first, text_width, name_style);
             }

--- a/tests/communities.rs
+++ b/tests/communities.rs
@@ -1,0 +1,244 @@
+mod common;
+
+use common::TestApp;
+use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+use whatsrust as wr;
+use wp_tui::{
+    app::{
+        Chat, CommunityNode,
+        actions::{AppAction, FocusPane, Section},
+    },
+    ui::message_list::render_messages,
+};
+
+fn jid(value: &str) -> wr::JID {
+    wr::JID::from(value.to_owned())
+}
+
+fn message(chat: &wr::JID, id: &str, timestamp: i64, text: &str, read_by: u16) -> wr::Message {
+    wr::Message {
+        info: wr::MessageInfo {
+            id: id.into(),
+            chat: chat.clone(),
+            sender: jid("member@s.whatsapp.net"),
+            timestamp,
+            is_from_me: false,
+            quote_id: None,
+            read_by,
+            forwarding: Default::default(),
+        },
+        message: wr::MessageContent::Text(text.into()),
+    }
+}
+
+#[test]
+fn opening_selected_community_renders_the_existing_chat_context() {
+    let mut test_app = TestApp::new();
+    let group = wr::JID::from("child@g.us".to_owned());
+    test_app.communities = vec![CommunityNode {
+        jid: group.clone(),
+        name: "Announcements".into(),
+        is_root: false,
+        linked_groups: Vec::new(),
+    }];
+    test_app.selected_section = Section::Communities;
+    test_app.focus_pane = FocusPane::ChatList;
+    test_app.chat_list_state.select(Some(0));
+    test_app.add_message(wr::Message {
+        info: wr::MessageInfo {
+            id: "community-message".into(),
+            chat: group.clone(),
+            sender: group.clone(),
+            timestamp: 1_700_000_000,
+            is_from_me: false,
+            quote_id: None,
+            read_by: 0,
+            forwarding: Default::default(),
+        },
+        message: wr::MessageContent::Text("community context".into()),
+    });
+
+    test_app.dispatch_action(AppAction::OpenChat);
+    assert_eq!(test_app.open_chat(), Some(group));
+    assert_eq!(test_app.focus_pane, FocusPane::Conversation);
+
+    let mut terminal = Terminal::new(TestBackend::new(40, 8)).unwrap();
+    terminal
+        .draw(|frame| {
+            render_messages(frame, &mut test_app, Rect::new(0, 0, 40, 8));
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer();
+    let rendered = (0..buffer.area().height)
+        .map(|y| {
+            (0..buffer.area().width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("community context"), "{rendered}");
+}
+
+#[test]
+fn community_row_collapses_linked_groups_and_preserves_latest_target() {
+    let mut app = TestApp::new();
+    let root = jid("community@g.us");
+    let first = jid("first@g.us");
+    let second = jid("second@g.us");
+    app.contacts.insert(first.clone(), "First Group".into());
+    app.contacts.insert(second.clone(), "Second Group".into());
+    app.chats.insert(
+        first.clone(),
+        Chat {
+            jid: first.clone(),
+            last_message_time: Some(10),
+        },
+    );
+    app.chats.insert(
+        second.clone(),
+        Chat {
+            jid: second.clone(),
+            last_message_time: Some(20),
+        },
+    );
+    app.sorted_chats = vec![first.clone(), second.clone()];
+    app.communities = vec![CommunityNode {
+        jid: root,
+        name: "Project Team".into(),
+        is_root: true,
+        linked_groups: vec![first.clone(), second.clone()],
+    }];
+    app.add_message(message(&first, "one", 10, "old", 0));
+    app.add_message(message(&second, "two", 20, "new", 0));
+
+    let rows = app.chat_rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].label, "Project Team");
+    assert_eq!(rows[0].target, second);
+    assert!(app.chats.contains_key(&first));
+    assert!(app.chats.contains_key(&second));
+}
+
+#[test]
+fn community_search_matches_community_and_member_names_without_hiding_normal_chats() {
+    let mut app = TestApp::new();
+    let group = jid("group@g.us");
+    let direct = jid("direct@s.whatsapp.net");
+    app.contacts.insert(group.clone(), "Release Crew".into());
+    app.contacts.insert(direct.clone(), "Alice".into());
+    app.chats.insert(
+        group.clone(),
+        Chat {
+            jid: group.clone(),
+            last_message_time: Some(10),
+        },
+    );
+    app.chats.insert(
+        direct.clone(),
+        Chat {
+            jid: direct.clone(),
+            last_message_time: Some(5),
+        },
+    );
+    app.sorted_chats = vec![group.clone(), direct.clone()];
+    app.communities = vec![CommunityNode {
+        jid: jid("community@g.us"),
+        name: "Engineering".into(),
+        is_root: true,
+        linked_groups: vec![group],
+    }];
+
+    app.contact_search.input = "engineering".into();
+    assert_eq!(app.visible_chat_rows().len(), 1);
+    app.contact_search.input = "release".into();
+    assert_eq!(app.visible_chat_rows().len(), 1);
+    app.contact_search.input = "alice".into();
+    assert_eq!(app.visible_chat_rows()[0].target, direct);
+}
+
+#[test]
+fn latest_message_changes_community_order_and_activation_target() {
+    let mut app = TestApp::new();
+    let first = jid("first@g.us");
+    let second = jid("second@g.us");
+    let other = jid("other@s.whatsapp.net");
+    for chat in [&first, &second, &other] {
+        app.chats.insert(
+            chat.clone(),
+            Chat {
+                jid: chat.clone(),
+                last_message_time: Some(1),
+            },
+        );
+    }
+    app.sorted_chats = vec![first.clone(), second.clone(), other];
+    app.communities = vec![CommunityNode {
+        jid: jid("community@g.us"),
+        name: "Community".into(),
+        is_root: true,
+        linked_groups: vec![first.clone(), second.clone()],
+    }];
+    app.add_message(message(&first, "first-message", 100, "first", 1));
+    app.add_message(message(&second, "second-message", 200, "second", 1));
+    let row = &app.chat_rows()[0];
+    assert_eq!(row.target, second);
+    app.chat_list_state.select(Some(0));
+    app.dispatch_action(AppAction::OpenChat);
+    assert_eq!(app.open_chat(), Some(second));
+}
+
+#[test]
+fn hierarchy_refresh_keeps_selection_on_a_linked_group_when_target_changes() {
+    let mut app = TestApp::new();
+    let first = jid("first@g.us");
+    let second = jid("second@g.us");
+    let root = jid("community@g.us");
+    app.chats.insert(
+        first.clone(),
+        Chat {
+            jid: first.clone(),
+            last_message_time: Some(10),
+        },
+    );
+    app.chats.insert(
+        second.clone(),
+        Chat {
+            jid: second.clone(),
+            last_message_time: Some(20),
+        },
+    );
+    app.sorted_chats = vec![first.clone(), second.clone()];
+    app.communities = vec![CommunityNode {
+        jid: root.clone(),
+        name: "Community".into(),
+        is_root: true,
+        linked_groups: vec![first.clone(), second.clone()],
+    }];
+    app.chat_list_state.select(Some(0));
+    let selected = app.get_selected_chat();
+    app.refresh_communities(|| {
+        Ok(vec![
+            wr::CommunityInfo {
+                jid: root.clone(),
+                name: "Community".into(),
+                parent_jid: None,
+                is_parent: true,
+            },
+            wr::CommunityInfo {
+                jid: first.clone(),
+                name: "First".into(),
+                parent_jid: Some(root.clone()),
+                is_parent: false,
+            },
+            wr::CommunityInfo {
+                jid: second.clone(),
+                name: "Second".into(),
+                parent_jid: Some(root),
+                is_parent: false,
+            },
+        ])
+    });
+    assert_eq!(app.get_selected_chat(), selected);
+    assert_eq!(app.chat_rows()[0].target, second);
+}

--- a/tests/contact_list_rows.rs
+++ b/tests/contact_list_rows.rs
@@ -93,7 +93,7 @@ fn zero_narrow_and_one_row_areas_do_not_panic_or_move_by_terminal_row() {
 }
 
 #[test]
-fn item_uses_latest_message_preview_and_local_time_without_inventing_unread_state() {
+fn item_uses_latest_message_preview_and_local_time_without_an_unread_counter() {
     let mut app = TestApp::new();
     let chat = JID::from("chat@example.test".to_owned());
     app.contacts.insert(chat.clone(), "Alice Example".into());
@@ -109,8 +109,6 @@ fn item_uses_latest_message_preview_and_local_time_without_inventing_unread_stat
     assert_eq!(item.name, "Alice Example");
     assert_eq!(item.preview, "newest");
     assert!(item.local_time.is_some());
-    // Unread totals are optional until the backend exposes truthful per-chat read state.
-    assert_eq!(item.unread_count, None);
 }
 
 #[test]
@@ -157,7 +155,6 @@ fn item(name: &str, preview: &str) -> ContactListItem {
         initials: initials(name),
         preview: preview.to_owned(),
         local_time: None,
-        unread_count: None,
     }
 }
 

--- a/tests/conversation_layout.rs
+++ b/tests/conversation_layout.rs
@@ -365,8 +365,7 @@ fn navigation_layout_supports_each_single_visible_navigation_pane() {
 
 #[test]
 fn structural_placeholders_do_not_render_chat_or_contact_content() {
-    // Status now renders real panes (see tests/status_section.rs), so only
-    // Communities keeps the structural placeholder.
+    // Communities now renders its approved hierarchy and real chat pane.
     for section in [Section::Communities] {
         let mut app = TestApp::new();
         let chat = JID::from("chat@example.test".to_owned());
@@ -388,7 +387,7 @@ fn structural_placeholders_do_not_render_chat_or_contact_content() {
             .iter()
             .map(|cell| cell.symbol())
             .collect::<String>();
-        assert!(output.contains(&format!("{} is not available yet.", section.title())));
+        assert!(output.contains("Communities"));
         assert!(!output.contains("CHAT_CONTACT_SENTINEL"));
         assert!(!output.contains("Contacts"));
         assert!(!output.contains("Message input"));

--- a/tests/navigation_rendering.rs
+++ b/tests/navigation_rendering.rs
@@ -80,7 +80,7 @@ fn navigation_renders_labels_logs_logout_and_placeholders() {
         "Status",
         "Communities",
         "Logs",
-        "not available yet",
+        "No communities",
     ] {
         assert!(rendered.contains(expected), "missing {expected}");
     }

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -23,6 +23,13 @@ typedef struct {
 } ContactEntry;
 
 typedef struct {
+	JID jid;
+	const char* name;
+	JID parent_jid;
+	bool is_parent;
+} CommunityEntry;
+
+typedef struct {
 	bool found;
 	int64_t muted_until;
 	bool pinned;
@@ -33,6 +40,12 @@ typedef struct {
 	ContactEntry* entries;
 	uint32_t size;
 } GetContactsResult;
+
+typedef struct {
+	CommunityEntry* entries;
+	uint32_t size;
+	uint8_t status;
+} GetCommunitiesResult;
 
 typedef struct {
 	uint8_t status;
@@ -2789,6 +2802,65 @@ func C_GetContacts() C.GetContactsResult {
 		entries: (*C.ContactEntry)(c_entries),
 		size:    C.uint32_t(n),
 	}
+}
+
+// C_GetCommunities transfers ownership of entries and every pointed-to string
+// to the caller. The caller must invoke C_FreeCommunities exactly once for
+// every returned result, including empty and error results. C_FreeCommunities
+// is nil-safe, but repeating it for the same non-nil result is not supported.
+//
+//export C_GetCommunities
+func C_GetCommunities() C.GetCommunitiesResult {
+	ctx := context.Background()
+	groups, err := client.GetJoinedGroups(ctx)
+	if err != nil {
+		LOG_WARN("Could not load communities: %v", err)
+		return C.GetCommunitiesResult{status: 1}
+	}
+	entries := make([]C.CommunityEntry, 0)
+	for _, group := range groups {
+		parent := group.LinkedParentJID
+		if !communityEntryIncluded(group.IsParent, parent.IsEmpty()) {
+			continue
+		}
+		entries = append(entries, C.CommunityEntry{
+			jid:        jidToC(group.JID),
+			name:       C.CString(group.GroupName.Name),
+			parent_jid: jidToC(parent),
+			is_parent:  C.bool(group.IsParent),
+		})
+	}
+	n := len(entries)
+	if n == 0 {
+		return C.GetCommunitiesResult{status: 0}
+	}
+	cEntries := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.CommunityEntry{})))
+	entryList := unsafe.Slice((*C.CommunityEntry)(cEntries), n)
+	for i := range n {
+		entryList[i] = entries[i]
+	}
+	return C.GetCommunitiesResult{entries: (*C.CommunityEntry)(cEntries), size: C.uint32_t(n), status: 0}
+}
+
+//export C_FreeCommunities
+func C_FreeCommunities(result C.GetCommunitiesResult) {
+	if result.entries == nil {
+		return
+	}
+	freeCommunityEntries(unsafe.Slice(result.entries, int(result.size)))
+	C.free(unsafe.Pointer(result.entries))
+}
+
+func freeCommunityEntries(entries []C.CommunityEntry) {
+	for _, entry := range entries {
+		C.free(unsafe.Pointer(entry.jid))
+		C.free(unsafe.Pointer(entry.name))
+		C.free(unsafe.Pointer(entry.parent_jid))
+	}
+}
+
+func communityEntryIncluded(isParent, parentEmpty bool) bool {
+	return isParent || !parentEmpty
 }
 
 const (

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -51,6 +51,30 @@ func TestPinnedPresenceContractAndNarrowSubscription(t *testing.T) {
 	}
 }
 
+func TestCommunityEntryIncludedDistinguishesRootsAndLinkedGroups(t *testing.T) {
+	tests := []struct {
+		name        string
+		isParent    bool
+		parentEmpty bool
+		want        bool
+	}{
+		{name: "community root", isParent: true, parentEmpty: true, want: true},
+		{name: "linked group", parentEmpty: false, want: true},
+		{name: "ordinary group", parentEmpty: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := communityEntryIncluded(tt.isParent, tt.parentEmpty); got != tt.want {
+				t.Fatalf("communityEntryIncluded(%t, %t) = %t, want %t", tt.isParent, tt.parentEmpty, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFreeCommunitiesNilResultIsSafe(t *testing.T) {
+	freeCommunityEntries(nil)
+}
+
 func TestRawPresenceDiagnosticsDisabledIsNoOp(t *testing.T) {
 	var diagnostics rawPresenceDiagnostics
 	diagnostics.reset(false)

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -60,9 +60,24 @@ struct CContactEntry {
 }
 
 #[repr(C)]
+struct CCommunityEntry {
+    jid: CJID,
+    name: *const c_char,
+    parent_jid: CJID,
+    is_parent: bool,
+}
+
+#[repr(C)]
 struct CGetContactsResult {
     entries: *const CContactEntry,
     size: u32,
+}
+
+#[repr(C)]
+struct CGetCommunitiesResult {
+    entries: *const CCommunityEntry,
+    size: u32,
+    status: u8,
 }
 
 #[repr(C)]
@@ -605,6 +620,19 @@ pub struct GroupInfo {
     pub name: Arc<str>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommunityInfo {
+    pub jid: JID,
+    pub name: Arc<str>,
+    pub parent_jid: Option<JID>,
+    pub is_parent: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommunitiesError {
+    BridgeUnavailable,
+}
+
 impl From<&CContact> for Contact {
     fn from(ccontact: &CContact) -> Self {
         let first_name = unsafe { CStr::from_ptr(ccontact.first_name) }
@@ -675,6 +703,8 @@ unsafe extern "C" {
         forward_source_len: usize,
     ) -> CForwardResult;
     fn C_GetContacts() -> CGetContactsResult;
+    fn C_GetCommunities() -> CGetCommunitiesResult;
+    fn C_FreeCommunities(result: CGetCommunitiesResult);
     fn C_GetProfilePicture(jid: CJID) -> CProfilePictureResult;
     fn C_FreeProfilePicture(result: CProfilePictureResult);
     fn C_GetChatSettings(jid: CJID) -> CChatSettings;
@@ -1026,9 +1056,7 @@ impl CallbackTranslator<*const CEvent> for Event {
             EventType::MessageAction => unsafe {
                 message_action_event_from_ffi(&*(event.data as *const CMessageActionEvent))
             },
-            EventType::Chat => unsafe {
-                chat_event_from_ffi(&*(event.data as *const CChatEvent))
-            },
+            EventType::Chat => unsafe { chat_event_from_ffi(&*(event.data as *const CChatEvent)) },
             EventType::LogoutResult => unsafe {
                 let result = &(*(event.data as *const CLogoutResultEvent));
                 Event::LogoutResult(
@@ -1535,6 +1563,40 @@ pub fn get_contacts() -> Vec<(JID, Arc<str>)> {
         .collect()
 }
 
+/// Returns real community roots and linked groups reported by WhatsApp.
+pub fn get_communities() -> Result<Vec<CommunityInfo>, CommunitiesError> {
+    let result = unsafe { C_GetCommunities() };
+    if result.status != 0 {
+        // C_GetCommunities transfers ownership even when the bridge reports
+        // an error; the current error result is empty, but freeing it here
+        // keeps that contract correct if it ever carries partial data.
+        unsafe { C_FreeCommunities(result) };
+        return Err(CommunitiesError::BridgeUnavailable);
+    }
+    if result.entries.is_null() || result.size == 0 {
+        unsafe { C_FreeCommunities(result) };
+        return Ok(Vec::new());
+    }
+    let entries = unsafe { std::slice::from_raw_parts(result.entries, result.size as usize) };
+    let communities = entries
+        .iter()
+        .map(|entry| {
+            let parent = unsafe { CStr::from_ptr(entry.parent_jid) }.to_string_lossy();
+            CommunityInfo {
+                jid: (&entry.jid).into(),
+                name: unsafe { CStr::from_ptr(entry.name) }
+                    .to_string_lossy()
+                    .into_owned()
+                    .into(),
+                parent_jid: (!parent.is_empty()).then(|| parent.to_string().into()),
+                is_parent: entry.is_parent,
+            }
+        })
+        .collect::<Vec<_>>();
+    unsafe { C_FreeCommunities(result) };
+    Ok(communities)
+}
+
 pub fn get_chat_settings(jid: &JID) -> ChatSettings {
     let jid_c = CJID::from(jid);
     let settings = unsafe { C_GetChatSettings(jid_c) };
@@ -1555,10 +1617,7 @@ pub fn get_chat_settings(jid: &JID) -> ChatSettings {
 /// JID is unusable.
 pub fn resolve_dm_chat(jid: &JID) -> Option<JID> {
     unsafe {
-        take_owned_c_string(
-            C_ResolveDmChatId(CJID::from(jid)),
-            C_FreeResolveDmChatId,
-        )
-        .map(JID::from)
+        take_owned_c_string(C_ResolveDmChatId(CJID::from(jid)), C_FreeResolveDmChatId)
+            .map(JID::from)
     }
 }


### PR DESCRIPTION
## Summary

- Add real WhatsApp community hierarchy navigation and linked-group selection.
- Collapse linked community groups into one presentation-only Chats row while preserving real group JIDs.
- Reuse the existing conversation pane for the selected group.

## Changes

- Bridge whatsmeow community roots and linked groups through the Go/Rust FFI with explicit ownership cleanup.
- Refresh hierarchy on connection and app-state sync while preserving the last successful snapshot across transient failures.
- Render compact community roots and linked group branches in the middle pane.
- Preserve stable selection, search, latest-group activation, previews, timestamps, and existing Chats avatars.
- Add focused Rust and Go behavior coverage.

## Testing

- [x] `cargo test -- --test-threads=1`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cargo fmt --check`
- [x] Manual testing done: authenticated Communities hierarchy, group selection, reconnect refresh, and existing right-pane chat rendering.

## Chain context

```text
main
 └─ refactor/message-layout-boundary
     └─ refactor/modular-ui-panes
         └─ feat/communities
```

- **Starts from:** `refactor/modular-ui-panes`
- **Ends with:** complete Communities hierarchy and Chats projection
- **Rollback:** revert commit `cfd09a1` without removing the parent refactor

Closes #32