### PR TITLE
fix(messages): stabilize media preview height

### DIFF
--- a/src/ui/message_layout.rs
+++ b/src/ui/message_layout.rs
@@ -96,13 +96,13 @@ impl<'a> From<&LayoutInput<'a>> for OwnedLayoutInput {
                 HeightContent::File {
                     kind,
                     caption,
-                    preview_loaded,
+                    preview_loaded: _,
                     forwarding,
                     status,
                 } => OwnedHeightContent::File {
                     kind,
                     caption: caption.map(Into::into),
-                    preview_loaded,
+                    preview_loaded: false,
                     forwarding,
                     status,
                 },
@@ -138,21 +138,20 @@ impl OwnedLayoutInput {
                     OwnedHeightContent::File {
                         kind,
                         caption,
-                        preview_loaded,
+                        preview_loaded: _,
                         forwarding,
                         status,
                     },
                     HeightContent::File {
                         kind: other_kind,
                         caption: other_caption,
-                        preview_loaded: other_preview,
+                        preview_loaded: _,
                         forwarding: other_forwarding,
                         status: other_status,
                     },
                 ) => {
                     *kind == other_kind
                         && caption.as_deref() == other_caption
-                        && *preview_loaded == other_preview
                         && *forwarding == other_forwarding
                         && *status == other_status
                 }
@@ -252,7 +251,7 @@ pub(crate) fn height(
         HeightContent::File {
             kind,
             caption,
-            preview_loaded,
+            preview_loaded: _,
             forwarding,
             status,
         } => {
@@ -261,13 +260,12 @@ pub(crate) fn height(
                 |caption| inline_content_lines(caption, *status, content_width).len(),
             );
             let file_height = match kind {
-                HeightFileKind::Video if *preview_loaded => VIDEO_HEIGHT,
-                HeightFileKind::Image | HeightFileKind::Sticker if *preview_loaded => IMAGE_HEIGHT,
+                // Reserve media geometry independently of the asynchronous
+                // preview lifecycle so the message list cannot reflow.
+                HeightFileKind::Video => VIDEO_HEIGHT,
+                HeightFileKind::Image | HeightFileKind::Sticker => IMAGE_HEIGHT,
                 HeightFileKind::Audio => 2,
-                HeightFileKind::Image
-                | HeightFileKind::Video
-                | HeightFileKind::Document
-                | HeightFileKind::Sticker => 1,
+                HeightFileKind::Document => 1,
             };
             file_height + caption_height + forwarding_indicator_lines(*forwarding, content_width)
         }
@@ -335,7 +333,7 @@ mod tests {
         );
     }
     #[test]
-    fn every_file_kind_and_preview_state_has_a_deterministic_height() {
+    fn every_file_kind_and_preview_state_has_a_stable_height() {
         let kinds = [
             HeightFileKind::Image,
             HeightFileKind::Video,
@@ -358,24 +356,30 @@ mod tests {
             };
             assert_eq!(
                 height(&mut cache, &id, &input),
-                if kind == HeightFileKind::Audio { 4 } else { 3 }
+                match kind {
+                    HeightFileKind::Audio => 4,
+                    HeightFileKind::Image | HeightFileKind::Video | HeightFileKind::Sticker => 14,
+                    HeightFileKind::Document => 3,
+                }
             );
-            if matches!(
-                kind,
-                HeightFileKind::Image | HeightFileKind::Video | HeightFileKind::Sticker
-            ) {
-                let loaded = LayoutInput {
-                    content: HeightContent::File {
-                        kind,
-                        caption: Some("caption"),
-                        preview_loaded: true,
-                        forwarding: None,
-                        status: None,
-                    },
-                    ..text("")
-                };
-                assert!(height(&mut cache, &id, &loaded) > 3);
-            }
+            let loaded = LayoutInput {
+                content: HeightContent::File {
+                    kind,
+                    caption: Some("caption"),
+                    preview_loaded: true,
+                    forwarding: None,
+                    status: None,
+                },
+                ..text("")
+            };
+            assert_eq!(
+                height(&mut cache, &id, &loaded),
+                match kind {
+                    HeightFileKind::Audio => 4,
+                    HeightFileKind::Image | HeightFileKind::Video | HeightFileKind::Sticker => 14,
+                    HeightFileKind::Document => 3,
+                }
+            );
         }
     }
 }

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -124,19 +124,12 @@ fn message_content_area(area: Rect, is_selected: bool) -> Rect {
     }
 }
 
-fn file_content_height(id: &wr::MessageId, file: &wr::FileContent, app: &mut App) -> usize {
+fn file_content_height(_id: &wr::MessageId, file: &wr::FileContent, _app: &mut App) -> usize {
     match file.kind {
-        FileKind::Image | FileKind::Sticker | FileKind::Video => match app.metadata.get(id) {
-            None => 1,
-            Some(Metadata::File(meta)) => match meta {
-                FileMeta::Downloading
-                | FileMeta::DownloadFailed
-                | FileMeta::Downloaded
-                | FileMeta::LoadFailed
-                | FileMeta::Loading => 1,
-                FileMeta::Loaded => preview_height(&file.kind),
-            },
-        },
+        // Media previews occupy their final block from the first render. The
+        // preview lifecycle changes only the contents of this block, never its
+        // geometry.
+        FileKind::Image | FileKind::Sticker | FileKind::Video => preview_height(&file.kind),
         // Audio renders a static play bar under the file line, so it takes
         // two rows. Must stay in sync with `message_height`.
         FileKind::Audio => 2,

--- a/tests/message_height_cache.rs
+++ b/tests/message_height_cache.rs
@@ -51,17 +51,72 @@ fn reply_context_presence_cannot_reuse_stale_height() {
 }
 
 #[test]
-fn media_state_changes_cannot_reuse_stale_height() {
+fn delayed_media_preview_keeps_height_and_cache_stable() {
     let mut app = TestApp::new();
-    let message = file_message("image", FileKind::Image, Some("caption"));
+    let messages = [
+        file_message("image", FileKind::Image, Some("caption")),
+        file_message("video", FileKind::Video, Some("caption")),
+        file_message("sticker", FileKind::Sticker, None),
+    ];
+
+    for message in &messages {
+        app.metadata
+            .insert(message.info.id.clone(), Metadata::File(FileMeta::Loading));
+        let loading_height = height(message, 20, false, &mut app);
+        assert_eq!(loading_height, height(message, 20, false, &mut app));
+
+        app.metadata
+            .insert(message.info.id.clone(), Metadata::File(FileMeta::Loaded));
+        assert_eq!(height(message, 20, false, &mut app), loading_height);
+    }
+}
+
+#[test]
+fn delayed_media_preview_preserves_offsets_visible_range_anchor_and_selection() {
+    let mut app = TestApp::new();
+    let messages = [
+        file_message("older", FileKind::Document, None),
+        file_message("media", FileKind::Image, Some("caption")),
+        text_message("newer", "hello"),
+    ];
+
+    let offsets = |app: &mut App<'_>| {
+        messages
+            .iter()
+            .map(|message| height(message, 20, false, app))
+            .scan(0, |offset, height| {
+                *offset += height;
+                Some(*offset)
+            })
+            .collect::<Vec<_>>()
+    };
 
     app.metadata
-        .insert(message.info.id.clone(), Metadata::File(FileMeta::Loading));
-    assert_eq!(height(&message, 20, false, &mut app), 3);
+        .insert("media".into(), Metadata::File(FileMeta::Loading));
+    let before = offsets(&mut app);
+    let before_anchor = before[1];
+    let before_visible = before
+        .iter()
+        .enumerate()
+        .filter(|(_, bottom)| **bottom > before_anchor.saturating_sub(2))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
 
     app.metadata
-        .insert(message.info.id.clone(), Metadata::File(FileMeta::Loaded));
-    assert_eq!(height(&message, 20, false, &mut app), 14);
+        .insert("media".into(), Metadata::File(FileMeta::Loaded));
+    let after = offsets(&mut app);
+    let after_anchor = after[1];
+    let after_visible = after
+        .iter()
+        .enumerate()
+        .filter(|(_, bottom)| **bottom > after_anchor.saturating_sub(2))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+
+    assert_eq!(before, after);
+    assert_eq!(before_anchor, after_anchor);
+    assert_eq!(before_visible, after_visible);
+    assert_eq!(messages[1].info.id.as_ref(), "media");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Reserve final image, video, and sticker message height before asynchronous previews finish loading.
- Prevent viewport and focus reflow when preview state changes.

## Changes

- Make media preview lifecycle content-only rather than geometry-significant.
- Reserve the existing 12-row image/video/sticker block in loading, missing, failed, and ready states.
- Keep captions, quotes, reactions, forwarding/status, grouping, and selection rows unchanged.
- Remove preview readiness from message-height cache identity.
- Add regressions for stable heights, cumulative offsets, visible range, anchor, and selection.

## Testing

- [x] `cargo test -- --test-threads=1`
- [ ] `cd whatsrust/lib && go test ./...` — N/A; no Go changes
- [x] `cargo fmt --check`
- [x] Manual testing done: delayed image/video/sticker previews retain stable message geometry.

## Chain context

```text
main
 └─ refactor/message-layout-boundary
     └─ refactor/modular-ui-panes
         └─ fix/stable-media-message-height
```

- **Starts from:** `refactor/modular-ui-panes`
- **Ends with:** preview-state-independent media geometry
- **Rollback:** revert commit `4695810` without removing the parent refactor

Closes #31