### PR TITLE
refactor(ui): extract contacts rendering

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,5 @@
 pub mod contact_list;
+mod contacts;
 mod layout;
 pub mod message_list;
 mod navigation;
@@ -14,21 +15,17 @@ pub(crate) use layout::{composer_visual_layout, truncate_with_ellipsis};
 
 use crate::app::App;
 use crate::app::actions::{ConversationMode, FocusPane, Section};
-use crate::app::contact_avatars::prioritized_avatar_requests;
 use crate::app::events::{
     ViewerPreviewKey, ViewerPreviewState, ViewerStatus, viewer_preview_request,
 };
-use contact_list::{
-    AVATAR_HEIGHT, AVATAR_WIDTH, CONTACT_ITEM_HEIGHT, ContactList, ContactListItem,
-    contact_visible_range,
-};
+use contacts::render_contacts;
 use message_list::{get_quoted_text, render_messages, render_status_messages};
 use navigation::{
     render_logout_placeholder, render_logs, render_section_rail, render_structural_placeholder,
 };
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Layout, Position, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Style, Stylize},
     symbols,
     text::{Line, Span},
@@ -36,7 +33,6 @@ use ratatui::{
 };
 use ratatui_image::{Resize, StatefulImage};
 use status_list::{StatusList, StatusListItem};
-use std::sync::Arc;
 use whatsrust as wr;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -84,94 +80,6 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     render_url_picker(frame, app);
     render_share_picker(frame, app);
     render_file_picker(frame, app);
-}
-
-fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let chats = if app.contact_search.input.is_empty() {
-        app.sorted_chats.clone()
-    } else {
-        app.filtered_chats.clone()
-    };
-    let items = chats
-        .iter()
-        .map(|chat| ContactListItem::from_chat(app, chat))
-        .collect::<Vec<_>>();
-
-    let mut list_area = area;
-    if !app.contact_search.input.is_empty() || app.contact_search_active {
-        let [search_area, new_list_area] =
-            Layout::vertical([Constraint::Length(1), Constraint::Percentage(100)]).areas(area);
-        list_area = new_list_area;
-
-        let text = format!("/{}", app.contact_search.input);
-        frame.render_widget(Paragraph::new(text), search_area);
-
-        if app.contact_search_active {
-            frame.set_cursor_position(Position::new(
-                // Draw the cursor at the current position in the input field.
-                // This position is can be controlled via the left and right arrow key
-                search_area.x + app.contact_search.character_index as u16 + 1,
-                // Move one line down, from the border to the input line
-                search_area.y,
-            ));
-        }
-    }
-
-    let block = Block::bordered()
-        .title(if let Some(p) = app.history_sync_percent {
-            format!("Contacts ({p}%)")
-        } else {
-            "Contacts".to_string()
-        })
-        .border_style(
-            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
-                ratatui::style::Color::Green
-            } else {
-                ratatui::style::Color::White
-            }),
-        );
-    let contacts_area = block.inner(list_area);
-    block.render(list_area, frame.buffer_mut());
-    frame.render_stateful_widget(
-        ContactList::new(&items),
-        contacts_area,
-        &mut app.chat_list_state,
-    );
-
-    let visible = contact_visible_range(
-        app.chat_list_state.offset(),
-        contacts_area.height,
-        chats.len(),
-    );
-    app.contact_avatars.schedule(
-        prioritized_avatar_requests(
-            &chats,
-            app.chat_list_state.selected(),
-            visible.start,
-            visible.len(),
-        ),
-        app.tx.clone(),
-        Arc::clone(&app.picker),
-    );
-    for index in visible {
-        let row = index.saturating_sub(app.chat_list_state.offset());
-        let y = contacts_area
-            .y
-            .saturating_add((row * CONTACT_ITEM_HEIGHT) as u16);
-        let avatar_area = Rect::new(
-            contacts_area.x,
-            y,
-            AVATAR_WIDTH.min(contacts_area.width),
-            AVATAR_HEIGHT.min(contacts_area.bottom().saturating_sub(y)),
-        );
-        // Partial Kitty placements can leave terminal artifacts after a scroll.
-        if avatar_area.width == AVATAR_WIDTH
-            && avatar_area.height == AVATAR_HEIGHT
-            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
-        {
-            StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
-        }
-    }
 }
 
 fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui/contacts.rs
+++ b/src/ui/contacts.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use super::contact_list::{
+    AVATAR_HEIGHT, AVATAR_WIDTH, CONTACT_ITEM_HEIGHT, ContactList, ContactListItem,
+    contact_visible_range,
+};
+use crate::app::App;
+use crate::app::actions::FocusPane;
+use crate::app::contact_avatars::prioritized_avatar_requests;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Position, Rect},
+    style::{Color, Style},
+    widgets::{Block, Paragraph, StatefulWidget, Widget},
+};
+use ratatui_image::StatefulImage;
+
+pub(super) fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
+    let chats = if app.contact_search.input.is_empty() {
+        app.sorted_chats.clone()
+    } else {
+        app.filtered_chats.clone()
+    };
+    let items = chats
+        .iter()
+        .map(|chat| ContactListItem::from_chat(app, chat))
+        .collect::<Vec<_>>();
+
+    let mut list_area = area;
+    if !app.contact_search.input.is_empty() || app.contact_search_active {
+        let [search_area, new_list_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Percentage(100)]).areas(area);
+        list_area = new_list_area;
+
+        let text = format!("/{}", app.contact_search.input);
+        frame.render_widget(Paragraph::new(text), search_area);
+
+        if app.contact_search_active {
+            frame.set_cursor_position(Position::new(
+                search_area.x + app.contact_search.character_index as u16 + 1,
+                search_area.y,
+            ));
+        }
+    }
+
+    let block = Block::bordered()
+        .title(if let Some(p) = app.history_sync_percent {
+            format!("Contacts ({p}%)")
+        } else {
+            "Contacts".to_string()
+        })
+        .border_style(
+            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
+                Color::Green
+            } else {
+                Color::White
+            }),
+        );
+    let contacts_area = block.inner(list_area);
+    block.render(list_area, frame.buffer_mut());
+    frame.render_stateful_widget(
+        ContactList::new(&items),
+        contacts_area,
+        &mut app.chat_list_state,
+    );
+
+    let visible = contact_visible_range(
+        app.chat_list_state.offset(),
+        contacts_area.height,
+        chats.len(),
+    );
+    app.contact_avatars.schedule(
+        prioritized_avatar_requests(
+            &chats,
+            app.chat_list_state.selected(),
+            visible.start,
+            visible.len(),
+        ),
+        app.tx.clone(),
+        Arc::clone(&app.picker),
+    );
+    for index in visible {
+        let row = index.saturating_sub(app.chat_list_state.offset());
+        let y = contacts_area
+            .y
+            .saturating_add((row * CONTACT_ITEM_HEIGHT) as u16);
+        let avatar_area = Rect::new(
+            contacts_area.x,
+            y,
+            AVATAR_WIDTH.min(contacts_area.width),
+            AVATAR_HEIGHT.min(contacts_area.bottom().saturating_sub(y)),
+        );
+        // Partial Kitty placements can leave terminal artifacts after a scroll.
+        if avatar_area.width == AVATAR_WIDTH
+            && avatar_area.height == AVATAR_HEIGHT
+            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
+        {
+            StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
+        }
+    }
+}

--- a/tests/contact_list_rows.rs
+++ b/tests/contact_list_rows.rs
@@ -7,6 +7,8 @@ use ratatui::{
     widgets::{ListState, StatefulWidget},
 };
 use whatsrust::{JID, Message, MessageContent, MessageInfo};
+use wp_tui::app::actions::{PaneVisibility, Section};
+use wp_tui::app::contact_avatars::prioritized_avatar_requests;
 use wp_tui::ui::{
     self,
     contact_list::{
@@ -15,6 +17,9 @@ use wp_tui::ui::{
 };
 mod common;
 use common::TestApp;
+
+const UI_SOURCE: &str = include_str!("../src/ui.rs");
+const CONTACTS_SOURCE: &str = include_str!("../src/ui/contacts.rs");
 
 #[test]
 fn initials_are_deterministic_for_names_and_unicode() {
@@ -149,6 +154,122 @@ fn search_list_renders_the_same_two_row_item_and_preserves_its_selection() {
     assert!(rows.iter().any(|row| row.contains("Visible Contact")));
     assert!(rows.iter().any(|row| row.contains("preview")));
     assert!(!rows.iter().any(|row| row.contains("Hidden Contact")));
+}
+
+#[test]
+fn visible_chats_preserve_search_geometry_and_selected_contact_rendering() {
+    let mut app = TestApp::new();
+    let selected = JID::from("selected@example.test".to_owned());
+    app.contacts
+        .insert(selected.clone(), "Selected Contact".into());
+    app.sorted_chats = vec![selected.clone()];
+    app.filtered_chats = vec![selected.clone()];
+    app.contact_search.input = "sel".to_owned();
+    app.contact_search.character_index = 2;
+    app.contact_search_active = true;
+    app.chat_list_state.select(Some(0));
+
+    let mut terminal = Terminal::new(TestBackend::new(100, 10)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    let rows = terminal
+        .backend()
+        .buffer()
+        .content()
+        .chunks(100)
+        .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+        .collect::<Vec<_>>();
+
+    assert!(rows.iter().any(|row| row.contains("/sel")));
+    assert!(rows.iter().any(|row| row.contains("Selected Contact")));
+    assert_eq!(app.chat_list_state.selected(), Some(0));
+}
+
+#[test]
+fn avatar_requests_are_selected_first_then_visible_then_overscan() {
+    let chats = (0..8)
+        .map(|index| JID::from(format!("chat-{index}@example.test")))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        prioritized_avatar_requests(&chats, Some(6), 3, 2),
+        vec![
+            chats[6].clone(),
+            chats[3].clone(),
+            chats[4].clone(),
+            chats[0].clone(),
+            chats[1].clone(),
+            chats[2].clone(),
+            chats[5].clone(),
+            chats[7].clone()
+        ]
+    );
+}
+
+#[test]
+fn contacts_module_owns_orchestration_and_preserves_draw_guards() {
+    for symbol in [
+        "render_contacts",
+        "contact_visible_range",
+        "prioritized_avatar_requests",
+        "app.contact_avatars.schedule",
+        "AVATAR_WIDTH",
+        "AVATAR_HEIGHT",
+        "protocol_mut",
+    ] {
+        assert!(CONTACTS_SOURCE.contains(symbol), "contacts owns {symbol}");
+        assert_eq!(UI_SOURCE.matches(&format!("fn {symbol}")).count(), 0);
+    }
+    assert!(CONTACTS_SOURCE.contains("if avatar_area.width == AVATAR_WIDTH"));
+    assert!(CONTACTS_SOURCE.contains("&& avatar_area.height == AVATAR_HEIGHT"));
+    assert!(UI_SOURCE.contains("app.contact_avatars.clear_window();"));
+    assert!(!CONTACTS_SOURCE.contains("pub fn"));
+}
+
+#[test]
+fn hidden_chats_clear_avatar_window_before_rendering_without_invalid_placement() {
+    let mut app = TestApp::new();
+    app.selected_section = Section::Chats;
+    app.pane_visibility = PaneVisibility {
+        section_rail: true,
+        chat_list: false,
+    };
+    app.sorted_chats = vec![JID::from("hidden@example.test".to_owned())];
+
+    let mut terminal = Terminal::new(TestBackend::new(24, 8)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    assert!(
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .any(|cell| cell.symbol() == "C")
+    );
+    assert!(UI_SOURCE.contains("if let Some(area) = areas.chat_list"));
+    assert!(UI_SOURCE.contains("else {\n            app.contact_avatars.clear_window();"));
+}
+
+#[test]
+fn composition_root_keeps_chats_before_overlays() {
+    let draw_source = UI_SOURCE
+        .split_once("pub fn draw")
+        .and_then(|(_, source)| source.split_once("pub fn render_chats"))
+        .map(|(source, _)| source)
+        .expect("draw source should remain in ui.rs");
+    let order = [
+        "render_contacts",
+        "render_chats",
+        "render_attachment_viewer",
+        "render_url_picker",
+        "render_share_picker",
+        "render_file_picker",
+    ];
+    let mut previous = 0;
+    for symbol in order {
+        let current = draw_source.find(symbol).expect("draw call should remain");
+        assert!(current >= previous, "draw order changed at {symbol}");
+        previous = current;
+    }
 }
 
 fn item(name: &str, preview: &str) -> ContactListItem {

--- a/tests/navigation_rendering.rs
+++ b/tests/navigation_rendering.rs
@@ -1,6 +1,11 @@
+use std::fs;
+
 use ratatui::{Terminal, backend::TestBackend};
+use whatsrust as wr;
 use wp_tui::{
     app::actions::{FocusPane, Section},
+    app::events::{AttachmentViewerState, ViewerAttachment, ViewerStatus},
+    file_picker::FilePickerState,
     ui,
 };
 
@@ -42,7 +47,7 @@ fn navigation_symbols_have_bounded_module_ownership() {
 fn draw_keeps_navigation_branch_and_overlay_order() {
     let draw_source = UI_SOURCE
         .split_once("pub fn draw")
-        .and_then(|(_, source)| source.split_once("fn render_contacts"))
+        .and_then(|(_, source)| source.split_once("pub fn render_chats"))
         .map(|(source, _)| source)
         .expect("draw source should be present");
     let order = [
@@ -102,4 +107,68 @@ fn navigation_is_safe_in_a_narrow_frame() {
     let mut terminal = Terminal::new(TestBackend::new(24, 8)).unwrap();
     terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
     assert!(rows(&terminal).join("\n").contains("Sections"));
+}
+
+#[test]
+fn runtime_overlay_layering_keeps_logs_and_branch_below_final_file_picker() {
+    let mut app = TestApp::new();
+    app.focus_pane = FocusPane::SectionRail;
+    app.selected_section = Section::Communities;
+    app.show_logs = true;
+    app.attachment_viewer = Some(AttachmentViewerState::from_attachments(
+        vec![ViewerAttachment {
+            message_id: "overlay-message".into(),
+            kind: wr::FileKind::Document,
+            path: "attachment-marker.bin".into(),
+            status: ViewerStatus::Missing,
+        }],
+        0,
+    ));
+    app.url_picker = Some((vec!["url-marker".to_owned()], 0));
+    let recipient = "share-marker@s.whatsapp.net".to_owned().into();
+    app.share_picker = Some(wp_tui::app::SharePicker::new(
+        vec![recipient],
+        [(
+            "share-marker@s.whatsapp.net".to_owned().into(),
+            "share-marker".to_owned(),
+        )]
+        .into_iter()
+        .collect(),
+        Default::default(),
+    ));
+
+    let directory = tempfile::tempdir().unwrap();
+    fs::write(directory.path().join("file-marker.txt"), "overlay").unwrap();
+    app.file_picker = Some(FilePickerState::open(directory.path()).unwrap());
+
+    let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    let rendered = rows(&terminal).join("\n");
+
+    assert!(
+        rendered.contains("Logs"),
+        "logs must remain rendered: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Communities"),
+        "selected branch must remain rendered: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Attach file:"),
+        "final file picker must win over the picker overlays: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("file-marker.txt"),
+        "final picker contents must render: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("attachment-marker.bin"),
+        "attachment viewer must remain layered below the final picker: {rendered:?}"
+    );
+    for covered in ["url-marker", "share-marker"] {
+        assert!(
+            !rendered.contains(covered),
+            "later overlay must cover {covered}: {rendered:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Extract Contacts rendering and avatar orchestration from the main UI composition module.
- Preserve search geometry, selection, avatar priority, hidden-pane cleanup, and overlay ordering.
- Keep this as PR2 in the modular UI feature-branch chain.

## Changes

- Add `src/ui/contacts.rs` as the bounded Contacts rendering owner.
- Reduce `src/ui.rs` to composition and branch ordering for this slice.
- Add runtime and structural regression coverage for Contacts, avatars, and overlays.

## Chain context

```text
refactor/navigation-rendering  (PR1 dependency)
└── refactor/contacts-rendering  📍 PR2
    └── Status extraction  (PR3 follow-up)
```

**Starts from:** Navigation rendering extracted at commit `5273a4c`.

**Ends with:** Contacts rendering independently owned and behavior-preserving.

**Out of scope:** Status rendering extraction and unrelated tracker integrations.

## Testing

- [x] `cargo test --test contact_list_rows -- --test-threads=1`
- [x] `cargo test --test navigation_rendering -- --test-threads=1`
- [x] `cargo test -- --test-threads=1` — 298 passed
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [ ] `cd whatsrust/lib && go test ./...` — Go bridge unchanged
- [x] Manual runtime rendering exercised through Ratatui `TestBackend`

Closes #35