### PR TITLE
refactor(ui): extract status rendering

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,6 +3,7 @@ mod contacts;
 mod layout;
 pub mod message_list;
 mod navigation;
+mod status;
 pub mod status_list;
 pub mod text_input;
 
@@ -19,7 +20,7 @@ use crate::app::events::{
     ViewerPreviewKey, ViewerPreviewState, ViewerStatus, viewer_preview_request,
 };
 use contacts::render_contacts;
-use message_list::{get_quoted_text, render_messages, render_status_messages};
+use message_list::{get_quoted_text, render_messages};
 use navigation::{
     render_logout_placeholder, render_logs, render_section_rail, render_structural_placeholder,
 };
@@ -29,10 +30,10 @@ use ratatui::{
     style::{Style, Stylize},
     symbols,
     text::{Line, Span},
-    widgets::{Block, Clear, Paragraph, StatefulWidget, Widget, Wrap},
+    widgets::{Block, Clear, Paragraph, StatefulWidget, Wrap},
 };
 use ratatui_image::{Resize, StatefulImage};
-use status_list::{StatusList, StatusListItem};
+use status::{render_status_contacts, render_statuses};
 use whatsrust as wr;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -80,62 +81,6 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     render_url_picker(frame, app);
     render_share_picker(frame, app);
     render_file_picker(frame, app);
-}
-
-fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let items = app
-        .status_contacts
-        .iter()
-        .map(|contact| StatusListItem::from_contact(app, contact))
-        .collect::<Vec<_>>();
-
-    let block = Block::bordered()
-        .title("Status")
-        .border_style(
-            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
-                ratatui::style::Color::Green
-            } else {
-                ratatui::style::Color::White
-            }),
-        );
-    let list_area = block.inner(area);
-    block.render(area, frame.buffer_mut());
-
-    if items.is_empty() {
-        frame.render_widget(Paragraph::new("No statuses yet"), list_area);
-        return;
-    }
-    frame.render_stateful_widget(
-        StatusList::new(&items),
-        list_area,
-        &mut app.status_selection,
-    );
-}
-
-fn render_statuses(frame: &mut Frame, app: &mut App, area: Rect) {
-    let title = app
-        .open_status_contact()
-        .map(|contact| app.contact_name(&contact).to_string())
-        .unwrap_or_else(|| "Status".to_string());
-    let border_color = if app.focus_pane == FocusPane::Conversation {
-        ratatui::style::Color::Green
-    } else {
-        ratatui::style::Color::White
-    };
-    let block = Block::bordered()
-        .title(title)
-        .border_style(Style::default().fg(border_color));
-    let content_area = block.inner(area);
-    block.render(area, frame.buffer_mut());
-
-    if app.open_status_contact().is_none() {
-        frame.render_widget(
-            Paragraph::new("Select a contact to view their statuses"),
-            content_area,
-        );
-        return;
-    }
-    render_status_messages(frame, app, content_area);
 }
 
 const ANDIVELI_LOGO: [&str; 19] = [

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -1,0 +1,66 @@
+use super::status_list::{StatusList, StatusListItem};
+use crate::app::App;
+use crate::app::actions::FocusPane;
+use crate::ui::message_list::render_status_messages;
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Paragraph, Widget},
+};
+
+pub(super) fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
+    let items = app
+        .status_contacts
+        .iter()
+        .map(|contact| StatusListItem::from_contact(app, contact))
+        .collect::<Vec<_>>();
+
+    let block = Block::bordered()
+        .title("Status")
+        .border_style(
+            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
+                Color::Green
+            } else {
+                Color::White
+            }),
+        );
+    let list_area = block.inner(area);
+    block.render(area, frame.buffer_mut());
+
+    if items.is_empty() {
+        frame.render_widget(Paragraph::new("No statuses yet"), list_area);
+        return;
+    }
+    frame.render_stateful_widget(
+        StatusList::new(&items),
+        list_area,
+        &mut app.status_selection,
+    );
+}
+
+pub(super) fn render_statuses(frame: &mut Frame, app: &mut App, area: Rect) {
+    let title = app
+        .open_status_contact()
+        .map(|contact| app.contact_name(&contact).to_string())
+        .unwrap_or_else(|| "Status".to_string());
+    let border_color = if app.focus_pane == FocusPane::Conversation {
+        Color::Green
+    } else {
+        Color::White
+    };
+    let block = Block::bordered()
+        .title(title)
+        .border_style(Style::default().fg(border_color));
+    let content_area = block.inner(area);
+    block.render(area, frame.buffer_mut());
+
+    if app.open_status_contact().is_none() {
+        frame.render_widget(
+            Paragraph::new("Select a contact to view their statuses"),
+            content_area,
+        );
+        return;
+    }
+    render_status_messages(frame, app, content_area);
+}

--- a/tests/status_section.rs
+++ b/tests/status_section.rs
@@ -363,3 +363,50 @@ fn chats_section_still_lists_only_real_conversations() {
             .any(|jid| jid.0.as_ref() == "status@broadcast")
     );
 }
+
+#[test]
+fn status_renderers_have_a_dedicated_owner_and_ui_keeps_composition() {
+    let source = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ui.rs"))
+        .expect("ui source should be readable");
+    let status_source =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ui/status.rs"))
+            .expect("status renderer module should exist");
+
+    assert!(status_source.contains("pub(super) fn render_status_contacts"));
+    assert!(status_source.contains("pub(super) fn render_statuses"));
+    assert!(!source.contains("fn render_status_contacts"));
+    assert!(!source.contains("fn render_statuses"));
+    assert!(source.contains("render_status_contacts(frame, app, area)"));
+    assert!(source.contains("render_statuses(frame, app, areas.conversation)"));
+}
+
+#[test]
+fn status_empty_and_opened_states_are_safe_in_tiny_supported_frames() {
+    let mut app = TestApp::new();
+    app.selected_section = Section::Status;
+    let empty_output = render(&mut app, 20, 6);
+    assert!(
+        empty_output.contains("No s"),
+        "empty state missing: {empty_output:?}"
+    );
+
+    let mut opened_app = TestApp::new();
+    opened_app.selected_section = Section::Status;
+    opened_app.focus_pane = FocusPane::ChatList;
+    let alice = JID::from("alice@s.whatsapp.net".to_owned());
+    opened_app.contacts.insert(alice.clone(), "Alice".into());
+    opened_app.add_message(status_message(
+        &alice,
+        "tiny-status",
+        unix_now(),
+        "tiny message",
+    ));
+    opened_app.status_contacts = vec![alice.clone()];
+    opened_app.status_selection.select(Some(0));
+    opened_app.open_selected_status();
+    let opened_output = render(&mut opened_app, 60, 8);
+    assert!(
+        opened_output.contains("tiny") || opened_output.contains("Alice"),
+        "opened state missing: {opened_output:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Extract Status contact-list and opened-status rendering from the UI composition root.
- Preserve clear timing, focus styling, titles, markers, media/message rendering, and narrow-frame safety.
- Complete PR3 of the modular UI feature-branch chain.

## Changes

- Add `src/ui/status.rs` as the bounded Status rendering owner.
- Reduce `src/ui.rs` to branch and overlay composition for Status.
- Add ownership and tiny/narrow runtime regression coverage.

## Chain context

```text
refactor/navigation-rendering  (PR1 dependency)
└── refactor/contacts-rendering  (PR2: #36)
    └── refactor/status-rendering  📍 PR3
```

**Starts from:** PR2 Contacts extraction at `2297df9`.

**Ends with:** Status rendering independently owned; all planned modular UI slices complete.

**Out of scope:** Unrelated tracker integrations and later UI features.

## Testing

- [x] `cargo test --test status_section -- --test-threads=1` — 12 passed
- [x] `cargo test --test contact_list_rows -- --test-threads=1` — 13 passed
- [x] `cargo test --test navigation_rendering -- --test-threads=1` — 5 passed
- [x] `cargo test -- --test-threads=1` — 300 passed
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [ ] `cd whatsrust/lib && go test ./...` — Go bridge unchanged
- [x] Ratatui `TestBackend` exercised empty, selected, opened, tiny, and narrow Status scenarios

Closes #37