### PR TITLE
refactor: integrate completed architecture chain

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -895,7 +895,7 @@ impl App<'_> {
         }
 
         loop {
-            let now = unix_now();
+            let now = self.now();
             let msg = match self.selected_presence.redraw_after(now) {
                 Some(timeout) => match self.rx.recv_timeout(timeout) {
                     Ok(input) => Ok(input),
@@ -1150,7 +1150,7 @@ impl App<'_> {
                     last_seen,
                 })) => self
                     .selected_presence
-                    .update(&from, unavailable, last_seen, unix_now()),
+                    .update(&from, unavailable, last_seen, self.now()),
                 Ok(AppInput::Terminal(event)) => {
                     self.on_terminal_event(event);
                     true
@@ -1194,7 +1194,7 @@ impl App<'_> {
 
     fn sync_selected_presence(&mut self) {
         let selected = self.open_chat.clone();
-        let now = unix_now();
+        let now = self.now();
         if self.selected_presence.select(selected, now) {
             let selected = self
                 .selected_presence
@@ -1722,10 +1722,7 @@ impl App<'_> {
         replacement: Arc<str>,
     ) {
         self.local_action_sequence = self.local_action_sequence.saturating_add(1);
-        let occurred_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_secs() as i64)
-            .unwrap_or(message.info.timestamp);
+        let occurred_at = now_or(message.info.timestamp, &*self.clock);
         self.apply_message_action(MessageAction {
             action_id: format!(
                 "local-edit:{}:{}",
@@ -1743,10 +1740,7 @@ impl App<'_> {
 
     pub(crate) fn record_local_message_delete(&mut self, message: &wr::Message) {
         self.local_action_sequence = self.local_action_sequence.saturating_add(1);
-        let occurred_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_secs() as i64)
-            .unwrap_or(message.info.timestamp);
+        let occurred_at = now_or(message.info.timestamp, &*self.clock);
         self.apply_message_action(MessageAction {
             action_id: format!(
                 "local-delete:{}:{}",
@@ -2126,6 +2120,7 @@ pub fn unix_now() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::presence::PresenceMarker;
 
     #[derive(Debug)]
     struct FixedClock(Option<i64>);
@@ -2139,6 +2134,25 @@ mod tests {
     impl Clock for FixedClock {
         fn unix_seconds(&self) -> Option<i64> {
             self.0
+        }
+    }
+
+    #[derive(Clone)]
+    struct MutableClock(Arc<Mutex<Option<i64>>>);
+
+    impl MutableClock {
+        fn new(value: Option<i64>) -> Self {
+            Self(Arc::new(Mutex::new(value)))
+        }
+
+        fn set(&self, value: Option<i64>) {
+            *self.0.lock().unwrap() = value;
+        }
+    }
+
+    impl Clock for MutableClock {
+        fn unix_seconds(&self) -> Option<i64> {
+            *self.0.lock().unwrap()
         }
     }
 
@@ -2974,6 +2988,101 @@ mod tests {
         );
         assert!(app.messages.contains_key("default"));
         app.db_handler.stop();
+    }
+
+    #[test]
+    fn local_message_actions_use_injected_clock_and_message_timestamp_fallback() {
+        let chat = wr::JID::from("chat@g.us".to_owned());
+        let message = message(&chat, "local-action", 77);
+        let mut app = app_with_ports(FixedClock::new(1_700_000_000), RecordingNotifier::default());
+        app.record_local_message_edit(&message, "edited".into());
+        assert_eq!(
+            app.message_actions[&message.info.id][0].occurred_at,
+            1_700_000_000
+        );
+
+        let mut app = app_with_ports(FixedClock::new(1_700_000_000), RecordingNotifier::default());
+        app.record_local_message_delete(&message);
+        assert_eq!(
+            app.message_actions[&message.info.id][0].occurred_at,
+            1_700_000_000
+        );
+
+        let mut app = app_with_ports(FixedClock(None), RecordingNotifier::default());
+        app.record_local_message_delete(&message);
+        assert_eq!(app.message_actions[&message.info.id][0].occurred_at, 77);
+    }
+
+    #[test]
+    fn injected_clock_preserves_mute_boundary_and_presence_timing() {
+        let chat = wr::JID::from("alice@s.whatsapp.net".to_owned());
+        let clock = MutableClock::new(Some(1_000));
+        let mut app = app_with_ports(clock.clone(), RecordingNotifier::default());
+        app.open_chat = Some(chat.clone());
+        let now = app.now();
+        app.selected_presence.select(Some(chat.clone()), now);
+        app.selected_presence.update(&chat, true, 0, now);
+
+        assert!(!notification_is_muted(true, 1_000, app.now()));
+        let now = app.now();
+        assert_eq!(
+            app.selected_presence.marker(Some(&chat), now),
+            Some(PresenceMarker::RecentlyOffline)
+        );
+        assert_eq!(
+            app.selected_presence.redraw_after(app.now()),
+            Some(Duration::from_secs(300))
+        );
+
+        clock.set(Some(1_299));
+        let now = app.now();
+        assert_eq!(
+            app.selected_presence.marker(Some(&chat), now),
+            Some(PresenceMarker::RecentlyOffline)
+        );
+        assert_eq!(
+            app.selected_presence.redraw_after(app.now()),
+            Some(Duration::from_secs(1))
+        );
+        clock.set(Some(1_300));
+        assert!(notification_is_muted(true, 1_301, app.now()));
+        assert!(!notification_is_muted(true, 1_300, app.now()));
+        let now = app.now();
+        assert_eq!(
+            app.selected_presence.marker(Some(&chat), now),
+            Some(PresenceMarker::Offline)
+        );
+        assert_eq!(app.selected_presence.redraw_after(app.now()), None);
+
+        clock.set(None);
+        assert_eq!(app.now(), 0);
+    }
+
+    #[test]
+    fn injected_clock_reaches_presence_and_ui_marker_path() {
+        use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+
+        let chat = wr::JID::from("alice@s.whatsapp.net".to_owned());
+        let mut app = app_with_ports(FixedClock::new(1_700_000_000), RecordingNotifier::default());
+        app.contacts.insert(chat.clone(), "Alice".into());
+        app.open_chat = Some(chat.clone());
+        let now = app.now();
+        app.selected_presence.select(Some(chat.clone()), now);
+        app.selected_presence.update(&chat, true, 0, now);
+
+        let mut terminal = Terminal::new(TestBackend::new(40, 8)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render_chats(frame, &mut app, Rect::new(0, 0, 40, 8)))
+            .unwrap();
+        let row = terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(40)
+            .next()
+            .unwrap();
+        let title = row.iter().map(|cell| cell.symbol()).collect::<String>();
+        assert!(title.contains("● Alice"), "rendered title: {title:?}");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,6 +59,45 @@ use crate::ui::text_input::TextInput;
 /// `info.sender` is the contact who posted the status.
 pub const STATUS_BROADCAST_CHAT: &str = "status@broadcast";
 
+pub trait Clock {
+    fn unix_seconds(&self) -> Option<i64>;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn unix_seconds(&self) -> Option<i64> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|duration| duration.as_secs() as i64)
+    }
+}
+
+pub struct NotificationProjection {
+    pub summary: Arc<str>,
+    pub body: String,
+}
+
+pub trait Notifier {
+    fn show(&self, notification: &NotificationProjection) -> Result<(), String>;
+}
+
+#[derive(Debug, Default)]
+pub struct NotifyRustNotifier;
+
+impl Notifier for NotifyRustNotifier {
+    fn show(&self, notification: &NotificationProjection) -> Result<(), String> {
+        Notification::new()
+            .summary(&notification.summary)
+            .body(&notification.body)
+            .show()
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum InputReaderState {
     Running,
@@ -205,6 +244,8 @@ pub struct App<'a> {
     pub db_handler: DatabaseHandler,
     pub media_path: PathBuf,
     pub whatsmeow_db: PathBuf,
+    pub clock: Box<dyn Clock>,
+    pub notifier: Box<dyn Notifier>,
 
     pub messages: HashMap<wr::MessageId, wr::Message>,
     pub message_actions: HashMap<wr::MessageId, Vec<MessageAction>>,
@@ -328,7 +369,14 @@ impl Default for App<'_> {
         let project_dirs = ProjectDirs::from("com", "nullptr", "wptui").unwrap();
         let data_dir = project_dirs.data_dir();
         let cache_dir = project_dirs.cache_dir();
-        Self::with_data_dir_and_picker(data_dir, cache_dir, picker, default_protocol_type)
+        Self::with_data_dir_and_picker_and_ports(
+            data_dir,
+            cache_dir,
+            picker,
+            default_protocol_type,
+            Box::new(SystemClock),
+            Box::new(NotifyRustNotifier),
+        )
     }
 }
 
@@ -368,14 +416,46 @@ impl App<'_> {
             Picker::halfblocks()
         });
         let default_protocol_type = picker.protocol_type();
-        Self::with_data_dir_and_picker(data_dir, cache_dir, picker, default_protocol_type)
+        Self::with_data_dir_and_picker_and_ports(
+            data_dir,
+            cache_dir,
+            picker,
+            default_protocol_type,
+            Box::new(SystemClock),
+            Box::new(NotifyRustNotifier),
+        )
     }
 
-    fn with_data_dir_and_picker(
+    pub fn with_data_dir_and_ports(
+        data_dir: &Path,
+        cache_dir: &Path,
+        clock: Box<dyn Clock>,
+        notifier: Box<dyn Notifier>,
+    ) -> Self {
+        let picker = Picker::from_query_stdio().unwrap_or_else(|err| {
+            log::warn!(
+                "Failed to query terminal image capabilities; falling back to halfblocks: {err}"
+            );
+            Picker::halfblocks()
+        });
+        let default_protocol_type = picker.protocol_type();
+        Self::with_data_dir_and_picker_and_ports(
+            data_dir,
+            cache_dir,
+            picker,
+            default_protocol_type,
+            clock,
+            notifier,
+        )
+    }
+
+    fn with_data_dir_and_picker_and_ports(
         data_dir: &Path,
         cache_dir: &Path,
         picker: Picker,
         default_protocol_type: ProtocolType,
+        clock: Box<dyn Clock>,
+        notifier: Box<dyn Notifier>,
     ) -> Self {
         fs::create_dir_all(data_dir).unwrap();
 
@@ -387,6 +467,8 @@ impl App<'_> {
             db_handler: DatabaseHandler::new(&data_dir.join("whatsapp.db")),
             media_path: data_dir.join("media"),
             whatsmeow_db: data_dir.join("whatsmeow.db"),
+            clock,
+            notifier,
 
             clipboard_reader,
             clipboard_writer,
@@ -1061,21 +1143,7 @@ impl App<'_> {
                 Ok(AppInput::Message {
                     message: msg,
                     is_sync,
-                }) => {
-                    if !is_sync {
-                        self.handle_notification(&msg);
-                    }
-
-                    self.db_handler.add_message(&msg);
-                    self.add_message(msg);
-
-                    let chat_jid = self.get_selected_chat();
-
-                    self.sort_chats();
-
-                    self.select_chat(chat_jid);
-                    !is_sync
-                }
+                }) => self.process_message(msg, is_sync),
                 Ok(AppInput::Presence(wr::PresenceUpdate {
                     from,
                     unavailable,
@@ -1226,45 +1294,51 @@ impl App<'_> {
             .unwrap_or_else(|| jid.0.clone())
     }
 
-    fn handle_notification(&self, message: &wr::Message) {
+    fn process_message(&mut self, message: wr::Message, is_sync: bool) -> bool {
+        self.process_message_with_lookup(message, is_sync, wr::get_chat_settings)
+    }
+
+    fn process_message_with_lookup(
+        &mut self,
+        message: wr::Message,
+        is_sync: bool,
+        lookup: impl FnMut(&wr::JID) -> wr::ChatSettings,
+    ) -> bool {
+        if !is_sync {
+            self.handle_notification_with_lookup(&message, lookup);
+        }
+
+        self.db_handler.add_message(&message);
+        self.add_message(message);
+
+        let chat_jid = self.get_selected_chat();
+        self.sort_chats();
+        self.select_chat(chat_jid);
+        !is_sync
+    }
+
+    fn handle_notification_with_lookup(
+        &self,
+        message: &wr::Message,
+        mut lookup: impl FnMut(&wr::JID) -> wr::ChatSettings,
+    ) {
         if !self.should_notify(message) {
             return;
         }
 
-        let chat_settings = wr::get_chat_settings(&message.info.chat);
+        let chat_settings = lookup(&message.info.chat);
         info!(
             "Chat settings for {:?}: {:?}",
             message.info.chat, chat_settings
         );
-        if chat_settings.found {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|duration| duration.as_secs() as i64)
-                .unwrap_or_default();
-            if chat_settings.muted_until > now {
-                return;
-            }
+        if chat_settings.found && notification_is_muted(true, chat_settings.muted_until, self.now())
+        {
+            return;
         }
 
-        let summary = self.contact_name(&message.info.sender);
-        let body = match &message.message {
-            wr::MessageContent::Text(text) => text.to_string(),
-            wr::MessageContent::File(file) => {
-                if let Some(caption) = &file.caption {
-                    caption.to_string()
-                } else {
-                    match file.kind {
-                        wr::FileKind::Image => "Sent an image".to_string(),
-                        wr::FileKind::Video => "Sent a video".to_string(),
-                        wr::FileKind::Audio => "Sent an audio message".to_string(),
-                        wr::FileKind::Document => "Sent a document".to_string(),
-                        wr::FileKind::Sticker => "Sent a sticker".to_string(),
-                    }
-                }
-            }
-        };
-
-        if let Err(err) = Notification::new().summary(&summary).body(&body).show() {
+        let notification =
+            notification_projection(message, self.contact_name(&message.info.sender));
+        if let Err(err) = self.notifier.show(&notification) {
             error!("Failed to show desktop notification: {err}");
         }
     }
@@ -1272,7 +1346,11 @@ impl App<'_> {
     /// Desktop notifications are suppressed for the user's own messages and
     /// for status broadcasts (statuses surface in the Status section instead).
     fn should_notify(&self, message: &wr::Message) -> bool {
-        !message.info.is_from_me && !Self::is_status_chat(&message.info.chat)
+        notification_eligibility(message)
+    }
+
+    pub(crate) fn now(&self) -> i64 {
+        now_or(0, &*self.clock)
     }
 
     fn stop_input_reader(&self) {
@@ -2006,6 +2084,38 @@ pub fn remove_status_media_files(media_path: &Path, relative_paths: &[PathBuf]) 
     remove_owned_media_files(media_path, relative_paths);
 }
 
+fn notification_eligibility(message: &wr::Message) -> bool {
+    !message.info.is_from_me && !App::is_status_chat(&message.info.chat)
+}
+
+fn notification_is_muted(found: bool, muted_until: i64, now: i64) -> bool {
+    found && muted_until > now
+}
+
+fn notification_projection(message: &wr::Message, summary: Arc<str>) -> NotificationProjection {
+    let body = match &message.message {
+        wr::MessageContent::Text(text) => text.to_string(),
+        wr::MessageContent::File(file) => {
+            if let Some(caption) = &file.caption {
+                caption.to_string()
+            } else {
+                match file.kind {
+                    wr::FileKind::Image => "Sent an image".to_string(),
+                    wr::FileKind::Video => "Sent a video".to_string(),
+                    wr::FileKind::Audio => "Sent an audio message".to_string(),
+                    wr::FileKind::Document => "Sent a document".to_string(),
+                    wr::FileKind::Sticker => "Sent a sticker".to_string(),
+                }
+            }
+        }
+    };
+    NotificationProjection { summary, body }
+}
+
+fn now_or(fallback: i64, clock: &dyn Clock) -> i64 {
+    clock.unix_seconds().unwrap_or(fallback)
+}
+
 pub fn unix_now() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2016,6 +2126,54 @@ pub fn unix_now() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Debug)]
+    struct FixedClock(Option<i64>);
+
+    impl FixedClock {
+        fn new(value: i64) -> Self {
+            Self(Some(value))
+        }
+    }
+
+    impl Clock for FixedClock {
+        fn unix_seconds(&self) -> Option<i64> {
+            self.0
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingNotifier {
+        notifications: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl RecordingNotifier {
+        fn notifications(&self) -> Vec<(String, String)> {
+            self.notifications.lock().unwrap().clone()
+        }
+    }
+
+    impl Notifier for RecordingNotifier {
+        fn show(&self, notification: &NotificationProjection) -> Result<(), String> {
+            self.notifications
+                .lock()
+                .unwrap()
+                .push((notification.summary.to_string(), notification.body.clone()));
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct FailingNotifier {
+        attempts: Arc<Mutex<usize>>,
+    }
+
+    impl Notifier for FailingNotifier {
+        fn show(&self, _notification: &NotificationProjection) -> Result<(), String> {
+            *self.attempts.lock().unwrap() += 1;
+            Err("notification failed".to_owned())
+        }
+    }
 
     /// Test-only App wrapper: points every storage path at a fresh
     /// tempdir (so tests never open the real user database) and stops
@@ -2055,6 +2213,22 @@ mod tests {
         fn drop(&mut self) {
             self.app.db_handler.stop();
         }
+    }
+
+    fn app_with_ports<C, N>(clock: C, notifier: N) -> TestApp
+    where
+        C: Clock + 'static,
+        N: Notifier + 'static,
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let app = App::with_data_dir_and_ports(
+            dir.path(),
+            dir.path(),
+            Box::new(clock),
+            Box::new(notifier),
+        );
+        app.db_handler.init();
+        TestApp { app, _dir: dir }
     }
 
     impl std::ops::Deref for TestApp {
@@ -2688,6 +2862,118 @@ mod tests {
 
         let status = status_message(&broadcast, "status", 3);
         assert!(!app.should_notify(&status));
+    }
+
+    #[test]
+    fn notification_projection_preserves_untrusted_message_text() {
+        let sender = wr::JID::from("alice@s.whatsapp.net".to_owned());
+        let message = message(&sender, "ignored", 1);
+        let projection = notification_projection(&message, Arc::from("Alice"));
+
+        assert_eq!(projection.summary.as_ref(), "Alice");
+        assert_eq!(projection.body, "ignored");
+
+        let message = wr::Message {
+            message: wr::MessageContent::Text("こんにちは\n\"quoted\"\u{0007}".into()),
+            ..message
+        };
+        let projection = notification_projection(&message, Arc::from("名前\n\"sender\""));
+        assert_eq!(projection.summary.as_ref(), "名前\n\"sender\"");
+        assert_eq!(projection.body, "こんにちは\n\"quoted\"\u{0007}");
+    }
+
+    #[test]
+    fn production_message_handler_covers_notification_policy_and_continuation() {
+        let chat = wr::JID::from("chat@g.us".to_owned());
+        let notifier = RecordingNotifier::default();
+        let mut app = app_with_ports(FixedClock::new(2_000), notifier.clone());
+
+        assert!(
+            app.process_message_with_lookup(message(&chat, "ordinary", 1), false, |_| {
+                wr::ChatSettings {
+                    found: false,
+                    ..Default::default()
+                }
+            },)
+        );
+        assert_eq!(
+            notifier.notifications(),
+            vec![("chat@g.us".to_owned(), "ordinary".to_owned())]
+        );
+        assert!(app.messages.contains_key("ordinary"));
+
+        let muted = RecordingNotifier::default();
+        let mut app = app_with_ports(FixedClock::new(2_000), muted.clone());
+        assert!(
+            app.process_message_with_lookup(message(&chat, "muted", 2), false, |_| {
+                wr::ChatSettings {
+                    found: true,
+                    muted_until: 2_001,
+                    ..Default::default()
+                }
+            },)
+        );
+        assert!(muted.notifications().is_empty());
+        assert!(app.messages.contains_key("muted"));
+
+        for (id, message) in [
+            ("own", {
+                let mut message = message(&chat, "own", 3);
+                message.info.is_from_me = true;
+                message
+            }),
+            ("status", status_message(&chat, "status", 4)),
+        ] {
+            let notifier = RecordingNotifier::default();
+            let lookup_calls = Arc::new(Mutex::new(0));
+            let calls = lookup_calls.clone();
+            let mut app = app_with_ports(FixedClock::new(2_000), notifier.clone());
+            assert!(app.process_message_with_lookup(message, false, |_| {
+                *calls.lock().unwrap() += 1;
+                Default::default()
+            }));
+            assert_eq!(*lookup_calls.lock().unwrap(), 0, "{id} lookup");
+            assert!(notifier.notifications().is_empty(), "{id} notification");
+            assert!(app.messages.contains_key(id));
+        }
+
+        let attempts = Arc::new(Mutex::new(0));
+        let failing = FailingNotifier {
+            attempts: attempts.clone(),
+        };
+        let mut app = app_with_ports(FixedClock::new(2_000), failing);
+        assert!(
+            app.process_message_with_lookup(message(&chat, "failure", 5), false, |_| {
+                Default::default()
+            },)
+        );
+        assert_eq!(*attempts.lock().unwrap(), 1);
+        assert!(app.messages.contains_key("failure"));
+
+        let sync = RecordingNotifier::default();
+        let mut app = app_with_ports(FixedClock::new(2_000), sync.clone());
+        assert!(
+            !app.process_message_with_lookup(message(&chat, "sync", 6), true, |_| panic!(
+                "sync messages must not look up chat settings"
+            ),)
+        );
+        assert!(sync.notifications().is_empty());
+        assert!(app.messages.contains_key("sync"));
+    }
+
+    #[test]
+    fn production_default_handler_keeps_message_processing_usable() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = App::with_data_dir(dir.path(), dir.path());
+        app.db_handler.init();
+        let chat = wr::JID::from("chat@g.us".to_owned());
+        assert!(
+            app.process_message_with_lookup(message(&chat, "default", 7), false, |_| {
+                Default::default()
+            },)
+        );
+        assert!(app.messages.contains_key("default"));
+        app.db_handler.stop();
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,6 +3,7 @@ mod contacts;
 mod layout;
 pub mod message_list;
 mod navigation;
+mod status;
 pub mod status_list;
 pub mod text_input;
 
@@ -19,7 +20,7 @@ use crate::app::events::{
     ViewerPreviewKey, ViewerPreviewState, ViewerStatus, viewer_preview_request,
 };
 use contacts::render_contacts;
-use message_list::{get_quoted_text, render_messages, render_status_messages};
+use message_list::{get_quoted_text, render_messages};
 use navigation::{
     render_logout_placeholder, render_logs, render_section_rail, render_structural_placeholder,
 };
@@ -29,10 +30,10 @@ use ratatui::{
     style::{Style, Stylize},
     symbols,
     text::{Line, Span},
-    widgets::{Block, Clear, Paragraph, StatefulWidget, Widget, Wrap},
+    widgets::{Block, Clear, Paragraph, StatefulWidget, Wrap},
 };
 use ratatui_image::{Resize, StatefulImage};
-use status_list::{StatusList, StatusListItem};
+use status::{render_status_contacts, render_statuses};
 use whatsrust as wr;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -80,62 +81,6 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     render_url_picker(frame, app);
     render_share_picker(frame, app);
     render_file_picker(frame, app);
-}
-
-fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let items = app
-        .status_contacts
-        .iter()
-        .map(|contact| StatusListItem::from_contact(app, contact))
-        .collect::<Vec<_>>();
-
-    let block = Block::bordered()
-        .title("Status")
-        .border_style(
-            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
-                ratatui::style::Color::Green
-            } else {
-                ratatui::style::Color::White
-            }),
-        );
-    let list_area = block.inner(area);
-    block.render(area, frame.buffer_mut());
-
-    if items.is_empty() {
-        frame.render_widget(Paragraph::new("No statuses yet"), list_area);
-        return;
-    }
-    frame.render_stateful_widget(
-        StatusList::new(&items),
-        list_area,
-        &mut app.status_selection,
-    );
-}
-
-fn render_statuses(frame: &mut Frame, app: &mut App, area: Rect) {
-    let title = app
-        .open_status_contact()
-        .map(|contact| app.contact_name(&contact).to_string())
-        .unwrap_or_else(|| "Status".to_string());
-    let border_color = if app.focus_pane == FocusPane::Conversation {
-        ratatui::style::Color::Green
-    } else {
-        ratatui::style::Color::White
-    };
-    let block = Block::bordered()
-        .title(title)
-        .border_style(Style::default().fg(border_color));
-    let content_area = block.inner(area);
-    block.render(area, frame.buffer_mut());
-
-    if app.open_status_contact().is_none() {
-        frame.render_widget(
-            Paragraph::new("Select a contact to view their statuses"),
-            content_area,
-        );
-        return;
-    }
-    render_status_messages(frame, app, content_area);
 }
 
 const ANDIVELI_LOGO: [&str; 19] = [

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -232,9 +232,8 @@ pub fn render_chats(frame: &mut Frame, app: &mut App, area: Rect) {
         })
     };
     let selected_chat = app.open_chat();
-    let marker = app
-        .selected_presence
-        .marker(selected_chat.as_ref(), crate::app::unix_now());
+    let now = app.now();
+    let marker = app.selected_presence.marker(selected_chat.as_ref(), now);
     let marker_span = marker.map(|marker| match marker {
         crate::app::presence::PresenceMarker::Online => Span::styled("●", Style::default().green()),
         crate::app::presence::PresenceMarker::RecentlyOffline => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,5 @@
 pub mod contact_list;
+mod contacts;
 mod layout;
 pub mod message_list;
 mod navigation;
@@ -14,21 +15,17 @@ pub(crate) use layout::{composer_visual_layout, truncate_with_ellipsis};
 
 use crate::app::App;
 use crate::app::actions::{ConversationMode, FocusPane, Section};
-use crate::app::contact_avatars::prioritized_avatar_requests;
 use crate::app::events::{
     ViewerPreviewKey, ViewerPreviewState, ViewerStatus, viewer_preview_request,
 };
-use contact_list::{
-    AVATAR_HEIGHT, AVATAR_WIDTH, CONTACT_ITEM_HEIGHT, ContactList, ContactListItem,
-    contact_visible_range,
-};
+use contacts::render_contacts;
 use message_list::{get_quoted_text, render_messages, render_status_messages};
 use navigation::{
     render_logout_placeholder, render_logs, render_section_rail, render_structural_placeholder,
 };
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Layout, Position, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Style, Stylize},
     symbols,
     text::{Line, Span},
@@ -36,7 +33,6 @@ use ratatui::{
 };
 use ratatui_image::{Resize, StatefulImage};
 use status_list::{StatusList, StatusListItem};
-use std::sync::Arc;
 use whatsrust as wr;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -84,94 +80,6 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     render_url_picker(frame, app);
     render_share_picker(frame, app);
     render_file_picker(frame, app);
-}
-
-fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let chats = if app.contact_search.input.is_empty() {
-        app.sorted_chats.clone()
-    } else {
-        app.filtered_chats.clone()
-    };
-    let items = chats
-        .iter()
-        .map(|chat| ContactListItem::from_chat(app, chat))
-        .collect::<Vec<_>>();
-
-    let mut list_area = area;
-    if !app.contact_search.input.is_empty() || app.contact_search_active {
-        let [search_area, new_list_area] =
-            Layout::vertical([Constraint::Length(1), Constraint::Percentage(100)]).areas(area);
-        list_area = new_list_area;
-
-        let text = format!("/{}", app.contact_search.input);
-        frame.render_widget(Paragraph::new(text), search_area);
-
-        if app.contact_search_active {
-            frame.set_cursor_position(Position::new(
-                // Draw the cursor at the current position in the input field.
-                // This position is can be controlled via the left and right arrow key
-                search_area.x + app.contact_search.character_index as u16 + 1,
-                // Move one line down, from the border to the input line
-                search_area.y,
-            ));
-        }
-    }
-
-    let block = Block::bordered()
-        .title(if let Some(p) = app.history_sync_percent {
-            format!("Contacts ({p}%)")
-        } else {
-            "Contacts".to_string()
-        })
-        .border_style(
-            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
-                ratatui::style::Color::Green
-            } else {
-                ratatui::style::Color::White
-            }),
-        );
-    let contacts_area = block.inner(list_area);
-    block.render(list_area, frame.buffer_mut());
-    frame.render_stateful_widget(
-        ContactList::new(&items),
-        contacts_area,
-        &mut app.chat_list_state,
-    );
-
-    let visible = contact_visible_range(
-        app.chat_list_state.offset(),
-        contacts_area.height,
-        chats.len(),
-    );
-    app.contact_avatars.schedule(
-        prioritized_avatar_requests(
-            &chats,
-            app.chat_list_state.selected(),
-            visible.start,
-            visible.len(),
-        ),
-        app.tx.clone(),
-        Arc::clone(&app.picker),
-    );
-    for index in visible {
-        let row = index.saturating_sub(app.chat_list_state.offset());
-        let y = contacts_area
-            .y
-            .saturating_add((row * CONTACT_ITEM_HEIGHT) as u16);
-        let avatar_area = Rect::new(
-            contacts_area.x,
-            y,
-            AVATAR_WIDTH.min(contacts_area.width),
-            AVATAR_HEIGHT.min(contacts_area.bottom().saturating_sub(y)),
-        );
-        // Partial Kitty placements can leave terminal artifacts after a scroll.
-        if avatar_area.width == AVATAR_WIDTH
-            && avatar_area.height == AVATAR_HEIGHT
-            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
-        {
-            StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
-        }
-    }
 }
 
 fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui/contacts.rs
+++ b/src/ui/contacts.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use super::contact_list::{
+    AVATAR_HEIGHT, AVATAR_WIDTH, CONTACT_ITEM_HEIGHT, ContactList, ContactListItem,
+    contact_visible_range,
+};
+use crate::app::App;
+use crate::app::actions::FocusPane;
+use crate::app::contact_avatars::prioritized_avatar_requests;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Position, Rect},
+    style::{Color, Style},
+    widgets::{Block, Paragraph, StatefulWidget, Widget},
+};
+use ratatui_image::StatefulImage;
+
+pub(super) fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
+    let chats = if app.contact_search.input.is_empty() {
+        app.sorted_chats.clone()
+    } else {
+        app.filtered_chats.clone()
+    };
+    let items = chats
+        .iter()
+        .map(|chat| ContactListItem::from_chat(app, chat))
+        .collect::<Vec<_>>();
+
+    let mut list_area = area;
+    if !app.contact_search.input.is_empty() || app.contact_search_active {
+        let [search_area, new_list_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Percentage(100)]).areas(area);
+        list_area = new_list_area;
+
+        let text = format!("/{}", app.contact_search.input);
+        frame.render_widget(Paragraph::new(text), search_area);
+
+        if app.contact_search_active {
+            frame.set_cursor_position(Position::new(
+                search_area.x + app.contact_search.character_index as u16 + 1,
+                search_area.y,
+            ));
+        }
+    }
+
+    let block = Block::bordered()
+        .title(if let Some(p) = app.history_sync_percent {
+            format!("Contacts ({p}%)")
+        } else {
+            "Contacts".to_string()
+        })
+        .border_style(
+            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
+                Color::Green
+            } else {
+                Color::White
+            }),
+        );
+    let contacts_area = block.inner(list_area);
+    block.render(list_area, frame.buffer_mut());
+    frame.render_stateful_widget(
+        ContactList::new(&items),
+        contacts_area,
+        &mut app.chat_list_state,
+    );
+
+    let visible = contact_visible_range(
+        app.chat_list_state.offset(),
+        contacts_area.height,
+        chats.len(),
+    );
+    app.contact_avatars.schedule(
+        prioritized_avatar_requests(
+            &chats,
+            app.chat_list_state.selected(),
+            visible.start,
+            visible.len(),
+        ),
+        app.tx.clone(),
+        Arc::clone(&app.picker),
+    );
+    for index in visible {
+        let row = index.saturating_sub(app.chat_list_state.offset());
+        let y = contacts_area
+            .y
+            .saturating_add((row * CONTACT_ITEM_HEIGHT) as u16);
+        let avatar_area = Rect::new(
+            contacts_area.x,
+            y,
+            AVATAR_WIDTH.min(contacts_area.width),
+            AVATAR_HEIGHT.min(contacts_area.bottom().saturating_sub(y)),
+        );
+        // Partial Kitty placements can leave terminal artifacts after a scroll.
+        if avatar_area.width == AVATAR_WIDTH
+            && avatar_area.height == AVATAR_HEIGHT
+            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
+        {
+            StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
+        }
+    }
+}

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -1,0 +1,66 @@
+use super::status_list::{StatusList, StatusListItem};
+use crate::app::App;
+use crate::app::actions::FocusPane;
+use crate::ui::message_list::render_status_messages;
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Paragraph, Widget},
+};
+
+pub(super) fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
+    let items = app
+        .status_contacts
+        .iter()
+        .map(|contact| StatusListItem::from_contact(app, contact))
+        .collect::<Vec<_>>();
+
+    let block = Block::bordered()
+        .title("Status")
+        .border_style(
+            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
+                Color::Green
+            } else {
+                Color::White
+            }),
+        );
+    let list_area = block.inner(area);
+    block.render(area, frame.buffer_mut());
+
+    if items.is_empty() {
+        frame.render_widget(Paragraph::new("No statuses yet"), list_area);
+        return;
+    }
+    frame.render_stateful_widget(
+        StatusList::new(&items),
+        list_area,
+        &mut app.status_selection,
+    );
+}
+
+pub(super) fn render_statuses(frame: &mut Frame, app: &mut App, area: Rect) {
+    let title = app
+        .open_status_contact()
+        .map(|contact| app.contact_name(&contact).to_string())
+        .unwrap_or_else(|| "Status".to_string());
+    let border_color = if app.focus_pane == FocusPane::Conversation {
+        Color::Green
+    } else {
+        Color::White
+    };
+    let block = Block::bordered()
+        .title(title)
+        .border_style(Style::default().fg(border_color));
+    let content_area = block.inner(area);
+    block.render(area, frame.buffer_mut());
+
+    if app.open_status_contact().is_none() {
+        frame.render_widget(
+            Paragraph::new("Select a contact to view their statuses"),
+            content_area,
+        );
+        return;
+    }
+    render_status_messages(frame, app, content_area);
+}

--- a/tests/contact_list_rows.rs
+++ b/tests/contact_list_rows.rs
@@ -7,6 +7,8 @@ use ratatui::{
     widgets::{ListState, StatefulWidget},
 };
 use whatsrust::{JID, Message, MessageContent, MessageInfo};
+use wp_tui::app::actions::{PaneVisibility, Section};
+use wp_tui::app::contact_avatars::prioritized_avatar_requests;
 use wp_tui::ui::{
     self,
     contact_list::{
@@ -15,6 +17,9 @@ use wp_tui::ui::{
 };
 mod common;
 use common::TestApp;
+
+const UI_SOURCE: &str = include_str!("../src/ui.rs");
+const CONTACTS_SOURCE: &str = include_str!("../src/ui/contacts.rs");
 
 #[test]
 fn initials_are_deterministic_for_names_and_unicode() {
@@ -149,6 +154,122 @@ fn search_list_renders_the_same_two_row_item_and_preserves_its_selection() {
     assert!(rows.iter().any(|row| row.contains("Visible Contact")));
     assert!(rows.iter().any(|row| row.contains("preview")));
     assert!(!rows.iter().any(|row| row.contains("Hidden Contact")));
+}
+
+#[test]
+fn visible_chats_preserve_search_geometry_and_selected_contact_rendering() {
+    let mut app = TestApp::new();
+    let selected = JID::from("selected@example.test".to_owned());
+    app.contacts
+        .insert(selected.clone(), "Selected Contact".into());
+    app.sorted_chats = vec![selected.clone()];
+    app.filtered_chats = vec![selected.clone()];
+    app.contact_search.input = "sel".to_owned();
+    app.contact_search.character_index = 2;
+    app.contact_search_active = true;
+    app.chat_list_state.select(Some(0));
+
+    let mut terminal = Terminal::new(TestBackend::new(100, 10)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    let rows = terminal
+        .backend()
+        .buffer()
+        .content()
+        .chunks(100)
+        .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+        .collect::<Vec<_>>();
+
+    assert!(rows.iter().any(|row| row.contains("/sel")));
+    assert!(rows.iter().any(|row| row.contains("Selected Contact")));
+    assert_eq!(app.chat_list_state.selected(), Some(0));
+}
+
+#[test]
+fn avatar_requests_are_selected_first_then_visible_then_overscan() {
+    let chats = (0..8)
+        .map(|index| JID::from(format!("chat-{index}@example.test")))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        prioritized_avatar_requests(&chats, Some(6), 3, 2),
+        vec![
+            chats[6].clone(),
+            chats[3].clone(),
+            chats[4].clone(),
+            chats[0].clone(),
+            chats[1].clone(),
+            chats[2].clone(),
+            chats[5].clone(),
+            chats[7].clone()
+        ]
+    );
+}
+
+#[test]
+fn contacts_module_owns_orchestration_and_preserves_draw_guards() {
+    for symbol in [
+        "render_contacts",
+        "contact_visible_range",
+        "prioritized_avatar_requests",
+        "app.contact_avatars.schedule",
+        "AVATAR_WIDTH",
+        "AVATAR_HEIGHT",
+        "protocol_mut",
+    ] {
+        assert!(CONTACTS_SOURCE.contains(symbol), "contacts owns {symbol}");
+        assert_eq!(UI_SOURCE.matches(&format!("fn {symbol}")).count(), 0);
+    }
+    assert!(CONTACTS_SOURCE.contains("if avatar_area.width == AVATAR_WIDTH"));
+    assert!(CONTACTS_SOURCE.contains("&& avatar_area.height == AVATAR_HEIGHT"));
+    assert!(UI_SOURCE.contains("app.contact_avatars.clear_window();"));
+    assert!(!CONTACTS_SOURCE.contains("pub fn"));
+}
+
+#[test]
+fn hidden_chats_clear_avatar_window_before_rendering_without_invalid_placement() {
+    let mut app = TestApp::new();
+    app.selected_section = Section::Chats;
+    app.pane_visibility = PaneVisibility {
+        section_rail: true,
+        chat_list: false,
+    };
+    app.sorted_chats = vec![JID::from("hidden@example.test".to_owned())];
+
+    let mut terminal = Terminal::new(TestBackend::new(24, 8)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    assert!(
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .any(|cell| cell.symbol() == "C")
+    );
+    assert!(UI_SOURCE.contains("if let Some(area) = areas.chat_list"));
+    assert!(UI_SOURCE.contains("else {\n            app.contact_avatars.clear_window();"));
+}
+
+#[test]
+fn composition_root_keeps_chats_before_overlays() {
+    let draw_source = UI_SOURCE
+        .split_once("pub fn draw")
+        .and_then(|(_, source)| source.split_once("pub fn render_chats"))
+        .map(|(source, _)| source)
+        .expect("draw source should remain in ui.rs");
+    let order = [
+        "render_contacts",
+        "render_chats",
+        "render_attachment_viewer",
+        "render_url_picker",
+        "render_share_picker",
+        "render_file_picker",
+    ];
+    let mut previous = 0;
+    for symbol in order {
+        let current = draw_source.find(symbol).expect("draw call should remain");
+        assert!(current >= previous, "draw order changed at {symbol}");
+        previous = current;
+    }
 }
 
 fn item(name: &str, preview: &str) -> ContactListItem {

--- a/tests/navigation_rendering.rs
+++ b/tests/navigation_rendering.rs
@@ -1,6 +1,11 @@
+use std::fs;
+
 use ratatui::{Terminal, backend::TestBackend};
+use whatsrust as wr;
 use wp_tui::{
     app::actions::{FocusPane, Section},
+    app::events::{AttachmentViewerState, ViewerAttachment, ViewerStatus},
+    file_picker::FilePickerState,
     ui,
 };
 
@@ -42,7 +47,7 @@ fn navigation_symbols_have_bounded_module_ownership() {
 fn draw_keeps_navigation_branch_and_overlay_order() {
     let draw_source = UI_SOURCE
         .split_once("pub fn draw")
-        .and_then(|(_, source)| source.split_once("fn render_contacts"))
+        .and_then(|(_, source)| source.split_once("pub fn render_chats"))
         .map(|(source, _)| source)
         .expect("draw source should be present");
     let order = [
@@ -102,4 +107,68 @@ fn navigation_is_safe_in_a_narrow_frame() {
     let mut terminal = Terminal::new(TestBackend::new(24, 8)).unwrap();
     terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
     assert!(rows(&terminal).join("\n").contains("Sections"));
+}
+
+#[test]
+fn runtime_overlay_layering_keeps_logs_and_branch_below_final_file_picker() {
+    let mut app = TestApp::new();
+    app.focus_pane = FocusPane::SectionRail;
+    app.selected_section = Section::Communities;
+    app.show_logs = true;
+    app.attachment_viewer = Some(AttachmentViewerState::from_attachments(
+        vec![ViewerAttachment {
+            message_id: "overlay-message".into(),
+            kind: wr::FileKind::Document,
+            path: "attachment-marker.bin".into(),
+            status: ViewerStatus::Missing,
+        }],
+        0,
+    ));
+    app.url_picker = Some((vec!["url-marker".to_owned()], 0));
+    let recipient = "share-marker@s.whatsapp.net".to_owned().into();
+    app.share_picker = Some(wp_tui::app::SharePicker::new(
+        vec![recipient],
+        [(
+            "share-marker@s.whatsapp.net".to_owned().into(),
+            "share-marker".to_owned(),
+        )]
+        .into_iter()
+        .collect(),
+        Default::default(),
+    ));
+
+    let directory = tempfile::tempdir().unwrap();
+    fs::write(directory.path().join("file-marker.txt"), "overlay").unwrap();
+    app.file_picker = Some(FilePickerState::open(directory.path()).unwrap());
+
+    let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    let rendered = rows(&terminal).join("\n");
+
+    assert!(
+        rendered.contains("Logs"),
+        "logs must remain rendered: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Communities"),
+        "selected branch must remain rendered: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Attach file:"),
+        "final file picker must win over the picker overlays: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("file-marker.txt"),
+        "final picker contents must render: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("attachment-marker.bin"),
+        "attachment viewer must remain layered below the final picker: {rendered:?}"
+    );
+    for covered in ["url-marker", "share-marker"] {
+        assert!(
+            !rendered.contains(covered),
+            "later overlay must cover {covered}: {rendered:?}"
+        );
+    }
 }

--- a/tests/status_section.rs
+++ b/tests/status_section.rs
@@ -363,3 +363,50 @@ fn chats_section_still_lists_only_real_conversations() {
             .any(|jid| jid.0.as_ref() == "status@broadcast")
     );
 }
+
+#[test]
+fn status_renderers_have_a_dedicated_owner_and_ui_keeps_composition() {
+    let source = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ui.rs"))
+        .expect("ui source should be readable");
+    let status_source =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ui/status.rs"))
+            .expect("status renderer module should exist");
+
+    assert!(status_source.contains("pub(super) fn render_status_contacts"));
+    assert!(status_source.contains("pub(super) fn render_statuses"));
+    assert!(!source.contains("fn render_status_contacts"));
+    assert!(!source.contains("fn render_statuses"));
+    assert!(source.contains("render_status_contacts(frame, app, area)"));
+    assert!(source.contains("render_statuses(frame, app, areas.conversation)"));
+}
+
+#[test]
+fn status_empty_and_opened_states_are_safe_in_tiny_supported_frames() {
+    let mut app = TestApp::new();
+    app.selected_section = Section::Status;
+    let empty_output = render(&mut app, 20, 6);
+    assert!(
+        empty_output.contains("No s"),
+        "empty state missing: {empty_output:?}"
+    );
+
+    let mut opened_app = TestApp::new();
+    opened_app.selected_section = Section::Status;
+    opened_app.focus_pane = FocusPane::ChatList;
+    let alice = JID::from("alice@s.whatsapp.net".to_owned());
+    opened_app.contacts.insert(alice.clone(), "Alice".into());
+    opened_app.add_message(status_message(
+        &alice,
+        "tiny-status",
+        unix_now(),
+        "tiny message",
+    ));
+    opened_app.status_contacts = vec![alice.clone()];
+    opened_app.status_selection.select(Some(0));
+    opened_app.open_selected_status();
+    let opened_output = render(&mut opened_app, 60, 8);
+    assert!(
+        opened_output.contains("tiny") || opened_output.contains("Alice"),
+        "opened state missing: {opened_output:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Integrate the completed Contacts, Status, notification-port, and clock/presence refactor chain into the modular UI tracker.
- Preserve the tracker branch's Communities, view-once, and stable media-height behavior while resolving the two overlapping UI conflicts.

## Changes

- Compose extracted Contacts and Status renderers from `src/ui.rs`.
- Preserve Communities navigation and presentation behavior in `src/app.rs` and `src/ui.rs`.
- Integrate injected notification and clock ports.
- Extend focused runtime coverage for contact rows, navigation overlay order, and status rendering.

## Testing

- [x] `cargo test -- --test-threads=1` (323 passed)
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cargo fmt --check`
- [x] `cargo check --all-targets`
- [x] Focused integration tests (44 passed)
- [ ] Manual testing done

Closes #35
Closes #37
Closes #39
Closes #40