### PR TITLE
refactor: merge modular UI and architecture improvements

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -895,7 +895,7 @@ impl App<'_> {
         }
 
         loop {
-            let now = unix_now();
+            let now = self.now();
             let msg = match self.selected_presence.redraw_after(now) {
                 Some(timeout) => match self.rx.recv_timeout(timeout) {
                     Ok(input) => Ok(input),
@@ -1150,7 +1150,7 @@ impl App<'_> {
                     last_seen,
                 })) => self
                     .selected_presence
-                    .update(&from, unavailable, last_seen, unix_now()),
+                    .update(&from, unavailable, last_seen, self.now()),
                 Ok(AppInput::Terminal(event)) => {
                     self.on_terminal_event(event);
                     true
@@ -1194,7 +1194,7 @@ impl App<'_> {
 
     fn sync_selected_presence(&mut self) {
         let selected = self.open_chat.clone();
-        let now = unix_now();
+        let now = self.now();
         if self.selected_presence.select(selected, now) {
             let selected = self
                 .selected_presence
@@ -1722,10 +1722,7 @@ impl App<'_> {
         replacement: Arc<str>,
     ) {
         self.local_action_sequence = self.local_action_sequence.saturating_add(1);
-        let occurred_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_secs() as i64)
-            .unwrap_or(message.info.timestamp);
+        let occurred_at = now_or(message.info.timestamp, &*self.clock);
         self.apply_message_action(MessageAction {
             action_id: format!(
                 "local-edit:{}:{}",
@@ -1743,10 +1740,7 @@ impl App<'_> {
 
     pub(crate) fn record_local_message_delete(&mut self, message: &wr::Message) {
         self.local_action_sequence = self.local_action_sequence.saturating_add(1);
-        let occurred_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_secs() as i64)
-            .unwrap_or(message.info.timestamp);
+        let occurred_at = now_or(message.info.timestamp, &*self.clock);
         self.apply_message_action(MessageAction {
             action_id: format!(
                 "local-delete:{}:{}",
@@ -2126,6 +2120,7 @@ pub fn unix_now() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::presence::PresenceMarker;
 
     #[derive(Debug)]
     struct FixedClock(Option<i64>);
@@ -2139,6 +2134,25 @@ mod tests {
     impl Clock for FixedClock {
         fn unix_seconds(&self) -> Option<i64> {
             self.0
+        }
+    }
+
+    #[derive(Clone)]
+    struct MutableClock(Arc<Mutex<Option<i64>>>);
+
+    impl MutableClock {
+        fn new(value: Option<i64>) -> Self {
+            Self(Arc::new(Mutex::new(value)))
+        }
+
+        fn set(&self, value: Option<i64>) {
+            *self.0.lock().unwrap() = value;
+        }
+    }
+
+    impl Clock for MutableClock {
+        fn unix_seconds(&self) -> Option<i64> {
+            *self.0.lock().unwrap()
         }
     }
 
@@ -2974,6 +2988,101 @@ mod tests {
         );
         assert!(app.messages.contains_key("default"));
         app.db_handler.stop();
+    }
+
+    #[test]
+    fn local_message_actions_use_injected_clock_and_message_timestamp_fallback() {
+        let chat = wr::JID::from("chat@g.us".to_owned());
+        let message = message(&chat, "local-action", 77);
+        let mut app = app_with_ports(FixedClock::new(1_700_000_000), RecordingNotifier::default());
+        app.record_local_message_edit(&message, "edited".into());
+        assert_eq!(
+            app.message_actions[&message.info.id][0].occurred_at,
+            1_700_000_000
+        );
+
+        let mut app = app_with_ports(FixedClock::new(1_700_000_000), RecordingNotifier::default());
+        app.record_local_message_delete(&message);
+        assert_eq!(
+            app.message_actions[&message.info.id][0].occurred_at,
+            1_700_000_000
+        );
+
+        let mut app = app_with_ports(FixedClock(None), RecordingNotifier::default());
+        app.record_local_message_delete(&message);
+        assert_eq!(app.message_actions[&message.info.id][0].occurred_at, 77);
+    }
+
+    #[test]
+    fn injected_clock_preserves_mute_boundary_and_presence_timing() {
+        let chat = wr::JID::from("alice@s.whatsapp.net".to_owned());
+        let clock = MutableClock::new(Some(1_000));
+        let mut app = app_with_ports(clock.clone(), RecordingNotifier::default());
+        app.open_chat = Some(chat.clone());
+        let now = app.now();
+        app.selected_presence.select(Some(chat.clone()), now);
+        app.selected_presence.update(&chat, true, 0, now);
+
+        assert!(!notification_is_muted(true, 1_000, app.now()));
+        let now = app.now();
+        assert_eq!(
+            app.selected_presence.marker(Some(&chat), now),
+            Some(PresenceMarker::RecentlyOffline)
+        );
+        assert_eq!(
+            app.selected_presence.redraw_after(app.now()),
+            Some(Duration::from_secs(300))
+        );
+
+        clock.set(Some(1_299));
+        let now = app.now();
+        assert_eq!(
+            app.selected_presence.marker(Some(&chat), now),
+            Some(PresenceMarker::RecentlyOffline)
+        );
+        assert_eq!(
+            app.selected_presence.redraw_after(app.now()),
+            Some(Duration::from_secs(1))
+        );
+        clock.set(Some(1_300));
+        assert!(notification_is_muted(true, 1_301, app.now()));
+        assert!(!notification_is_muted(true, 1_300, app.now()));
+        let now = app.now();
+        assert_eq!(
+            app.selected_presence.marker(Some(&chat), now),
+            Some(PresenceMarker::Offline)
+        );
+        assert_eq!(app.selected_presence.redraw_after(app.now()), None);
+
+        clock.set(None);
+        assert_eq!(app.now(), 0);
+    }
+
+    #[test]
+    fn injected_clock_reaches_presence_and_ui_marker_path() {
+        use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+
+        let chat = wr::JID::from("alice@s.whatsapp.net".to_owned());
+        let mut app = app_with_ports(FixedClock::new(1_700_000_000), RecordingNotifier::default());
+        app.contacts.insert(chat.clone(), "Alice".into());
+        app.open_chat = Some(chat.clone());
+        let now = app.now();
+        app.selected_presence.select(Some(chat.clone()), now);
+        app.selected_presence.update(&chat, true, 0, now);
+
+        let mut terminal = Terminal::new(TestBackend::new(40, 8)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render_chats(frame, &mut app, Rect::new(0, 0, 40, 8)))
+            .unwrap();
+        let row = terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(40)
+            .next()
+            .unwrap();
+        let title = row.iter().map(|cell| cell.symbol()).collect::<String>();
+        assert!(title.contains("● Alice"), "rendered title: {title:?}");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,6 +59,45 @@ use crate::ui::text_input::TextInput;
 /// `info.sender` is the contact who posted the status.
 pub const STATUS_BROADCAST_CHAT: &str = "status@broadcast";
 
+pub trait Clock {
+    fn unix_seconds(&self) -> Option<i64>;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn unix_seconds(&self) -> Option<i64> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|duration| duration.as_secs() as i64)
+    }
+}
+
+pub struct NotificationProjection {
+    pub summary: Arc<str>,
+    pub body: String,
+}
+
+pub trait Notifier {
+    fn show(&self, notification: &NotificationProjection) -> Result<(), String>;
+}
+
+#[derive(Debug, Default)]
+pub struct NotifyRustNotifier;
+
+impl Notifier for NotifyRustNotifier {
+    fn show(&self, notification: &NotificationProjection) -> Result<(), String> {
+        Notification::new()
+            .summary(&notification.summary)
+            .body(&notification.body)
+            .show()
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum InputReaderState {
     Running,
@@ -205,6 +244,8 @@ pub struct App<'a> {
     pub db_handler: DatabaseHandler,
     pub media_path: PathBuf,
     pub whatsmeow_db: PathBuf,
+    pub clock: Box<dyn Clock>,
+    pub notifier: Box<dyn Notifier>,
 
     pub messages: HashMap<wr::MessageId, wr::Message>,
     pub message_actions: HashMap<wr::MessageId, Vec<MessageAction>>,
@@ -328,7 +369,14 @@ impl Default for App<'_> {
         let project_dirs = ProjectDirs::from("com", "nullptr", "wptui").unwrap();
         let data_dir = project_dirs.data_dir();
         let cache_dir = project_dirs.cache_dir();
-        Self::with_data_dir_and_picker(data_dir, cache_dir, picker, default_protocol_type)
+        Self::with_data_dir_and_picker_and_ports(
+            data_dir,
+            cache_dir,
+            picker,
+            default_protocol_type,
+            Box::new(SystemClock),
+            Box::new(NotifyRustNotifier),
+        )
     }
 }
 
@@ -368,14 +416,46 @@ impl App<'_> {
             Picker::halfblocks()
         });
         let default_protocol_type = picker.protocol_type();
-        Self::with_data_dir_and_picker(data_dir, cache_dir, picker, default_protocol_type)
+        Self::with_data_dir_and_picker_and_ports(
+            data_dir,
+            cache_dir,
+            picker,
+            default_protocol_type,
+            Box::new(SystemClock),
+            Box::new(NotifyRustNotifier),
+        )
     }
 
-    fn with_data_dir_and_picker(
+    pub fn with_data_dir_and_ports(
+        data_dir: &Path,
+        cache_dir: &Path,
+        clock: Box<dyn Clock>,
+        notifier: Box<dyn Notifier>,
+    ) -> Self {
+        let picker = Picker::from_query_stdio().unwrap_or_else(|err| {
+            log::warn!(
+                "Failed to query terminal image capabilities; falling back to halfblocks: {err}"
+            );
+            Picker::halfblocks()
+        });
+        let default_protocol_type = picker.protocol_type();
+        Self::with_data_dir_and_picker_and_ports(
+            data_dir,
+            cache_dir,
+            picker,
+            default_protocol_type,
+            clock,
+            notifier,
+        )
+    }
+
+    fn with_data_dir_and_picker_and_ports(
         data_dir: &Path,
         cache_dir: &Path,
         picker: Picker,
         default_protocol_type: ProtocolType,
+        clock: Box<dyn Clock>,
+        notifier: Box<dyn Notifier>,
     ) -> Self {
         fs::create_dir_all(data_dir).unwrap();
 
@@ -387,6 +467,8 @@ impl App<'_> {
             db_handler: DatabaseHandler::new(&data_dir.join("whatsapp.db")),
             media_path: data_dir.join("media"),
             whatsmeow_db: data_dir.join("whatsmeow.db"),
+            clock,
+            notifier,
 
             clipboard_reader,
             clipboard_writer,
@@ -1061,21 +1143,7 @@ impl App<'_> {
                 Ok(AppInput::Message {
                     message: msg,
                     is_sync,
-                }) => {
-                    if !is_sync {
-                        self.handle_notification(&msg);
-                    }
-
-                    self.db_handler.add_message(&msg);
-                    self.add_message(msg);
-
-                    let chat_jid = self.get_selected_chat();
-
-                    self.sort_chats();
-
-                    self.select_chat(chat_jid);
-                    !is_sync
-                }
+                }) => self.process_message(msg, is_sync),
                 Ok(AppInput::Presence(wr::PresenceUpdate {
                     from,
                     unavailable,
@@ -1226,45 +1294,51 @@ impl App<'_> {
             .unwrap_or_else(|| jid.0.clone())
     }
 
-    fn handle_notification(&self, message: &wr::Message) {
+    fn process_message(&mut self, message: wr::Message, is_sync: bool) -> bool {
+        self.process_message_with_lookup(message, is_sync, wr::get_chat_settings)
+    }
+
+    fn process_message_with_lookup(
+        &mut self,
+        message: wr::Message,
+        is_sync: bool,
+        lookup: impl FnMut(&wr::JID) -> wr::ChatSettings,
+    ) -> bool {
+        if !is_sync {
+            self.handle_notification_with_lookup(&message, lookup);
+        }
+
+        self.db_handler.add_message(&message);
+        self.add_message(message);
+
+        let chat_jid = self.get_selected_chat();
+        self.sort_chats();
+        self.select_chat(chat_jid);
+        !is_sync
+    }
+
+    fn handle_notification_with_lookup(
+        &self,
+        message: &wr::Message,
+        mut lookup: impl FnMut(&wr::JID) -> wr::ChatSettings,
+    ) {
         if !self.should_notify(message) {
             return;
         }
 
-        let chat_settings = wr::get_chat_settings(&message.info.chat);
+        let chat_settings = lookup(&message.info.chat);
         info!(
             "Chat settings for {:?}: {:?}",
             message.info.chat, chat_settings
         );
-        if chat_settings.found {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|duration| duration.as_secs() as i64)
-                .unwrap_or_default();
-            if chat_settings.muted_until > now {
-                return;
-            }
+        if chat_settings.found && notification_is_muted(true, chat_settings.muted_until, self.now())
+        {
+            return;
         }
 
-        let summary = self.contact_name(&message.info.sender);
-        let body = match &message.message {
-            wr::MessageContent::Text(text) => text.to_string(),
-            wr::MessageContent::File(file) => {
-                if let Some(caption) = &file.caption {
-                    caption.to_string()
-                } else {
-                    match file.kind {
-                        wr::FileKind::Image => "Sent an image".to_string(),
-                        wr::FileKind::Video => "Sent a video".to_string(),
-                        wr::FileKind::Audio => "Sent an audio message".to_string(),
-                        wr::FileKind::Document => "Sent a document".to_string(),
-                        wr::FileKind::Sticker => "Sent a sticker".to_string(),
-                    }
-                }
-            }
-        };
-
-        if let Err(err) = Notification::new().summary(&summary).body(&body).show() {
+        let notification =
+            notification_projection(message, self.contact_name(&message.info.sender));
+        if let Err(err) = self.notifier.show(&notification) {
             error!("Failed to show desktop notification: {err}");
         }
     }
@@ -1272,7 +1346,11 @@ impl App<'_> {
     /// Desktop notifications are suppressed for the user's own messages and
     /// for status broadcasts (statuses surface in the Status section instead).
     fn should_notify(&self, message: &wr::Message) -> bool {
-        !message.info.is_from_me && !Self::is_status_chat(&message.info.chat)
+        notification_eligibility(message)
+    }
+
+    pub(crate) fn now(&self) -> i64 {
+        now_or(0, &*self.clock)
     }
 
     fn stop_input_reader(&self) {
@@ -2006,6 +2084,38 @@ pub fn remove_status_media_files(media_path: &Path, relative_paths: &[PathBuf]) 
     remove_owned_media_files(media_path, relative_paths);
 }
 
+fn notification_eligibility(message: &wr::Message) -> bool {
+    !message.info.is_from_me && !App::is_status_chat(&message.info.chat)
+}
+
+fn notification_is_muted(found: bool, muted_until: i64, now: i64) -> bool {
+    found && muted_until > now
+}
+
+fn notification_projection(message: &wr::Message, summary: Arc<str>) -> NotificationProjection {
+    let body = match &message.message {
+        wr::MessageContent::Text(text) => text.to_string(),
+        wr::MessageContent::File(file) => {
+            if let Some(caption) = &file.caption {
+                caption.to_string()
+            } else {
+                match file.kind {
+                    wr::FileKind::Image => "Sent an image".to_string(),
+                    wr::FileKind::Video => "Sent a video".to_string(),
+                    wr::FileKind::Audio => "Sent an audio message".to_string(),
+                    wr::FileKind::Document => "Sent a document".to_string(),
+                    wr::FileKind::Sticker => "Sent a sticker".to_string(),
+                }
+            }
+        }
+    };
+    NotificationProjection { summary, body }
+}
+
+fn now_or(fallback: i64, clock: &dyn Clock) -> i64 {
+    clock.unix_seconds().unwrap_or(fallback)
+}
+
 pub fn unix_now() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2016,6 +2126,54 @@ pub fn unix_now() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Debug)]
+    struct FixedClock(Option<i64>);
+
+    impl FixedClock {
+        fn new(value: i64) -> Self {
+            Self(Some(value))
+        }
+    }
+
+    impl Clock for FixedClock {
+        fn unix_seconds(&self) -> Option<i64> {
+            self.0
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingNotifier {
+        notifications: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl RecordingNotifier {
+        fn notifications(&self) -> Vec<(String, String)> {
+            self.notifications.lock().unwrap().clone()
+        }
+    }
+
+    impl Notifier for RecordingNotifier {
+        fn show(&self, notification: &NotificationProjection) -> Result<(), String> {
+            self.notifications
+                .lock()
+                .unwrap()
+                .push((notification.summary.to_string(), notification.body.clone()));
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct FailingNotifier {
+        attempts: Arc<Mutex<usize>>,
+    }
+
+    impl Notifier for FailingNotifier {
+        fn show(&self, _notification: &NotificationProjection) -> Result<(), String> {
+            *self.attempts.lock().unwrap() += 1;
+            Err("notification failed".to_owned())
+        }
+    }
 
     /// Test-only App wrapper: points every storage path at a fresh
     /// tempdir (so tests never open the real user database) and stops
@@ -2055,6 +2213,22 @@ mod tests {
         fn drop(&mut self) {
             self.app.db_handler.stop();
         }
+    }
+
+    fn app_with_ports<C, N>(clock: C, notifier: N) -> TestApp
+    where
+        C: Clock + 'static,
+        N: Notifier + 'static,
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let app = App::with_data_dir_and_ports(
+            dir.path(),
+            dir.path(),
+            Box::new(clock),
+            Box::new(notifier),
+        );
+        app.db_handler.init();
+        TestApp { app, _dir: dir }
     }
 
     impl std::ops::Deref for TestApp {
@@ -2688,6 +2862,118 @@ mod tests {
 
         let status = status_message(&broadcast, "status", 3);
         assert!(!app.should_notify(&status));
+    }
+
+    #[test]
+    fn notification_projection_preserves_untrusted_message_text() {
+        let sender = wr::JID::from("alice@s.whatsapp.net".to_owned());
+        let message = message(&sender, "ignored", 1);
+        let projection = notification_projection(&message, Arc::from("Alice"));
+
+        assert_eq!(projection.summary.as_ref(), "Alice");
+        assert_eq!(projection.body, "ignored");
+
+        let message = wr::Message {
+            message: wr::MessageContent::Text("こんにちは\n\"quoted\"\u{0007}".into()),
+            ..message
+        };
+        let projection = notification_projection(&message, Arc::from("名前\n\"sender\""));
+        assert_eq!(projection.summary.as_ref(), "名前\n\"sender\"");
+        assert_eq!(projection.body, "こんにちは\n\"quoted\"\u{0007}");
+    }
+
+    #[test]
+    fn production_message_handler_covers_notification_policy_and_continuation() {
+        let chat = wr::JID::from("chat@g.us".to_owned());
+        let notifier = RecordingNotifier::default();
+        let mut app = app_with_ports(FixedClock::new(2_000), notifier.clone());
+
+        assert!(
+            app.process_message_with_lookup(message(&chat, "ordinary", 1), false, |_| {
+                wr::ChatSettings {
+                    found: false,
+                    ..Default::default()
+                }
+            },)
+        );
+        assert_eq!(
+            notifier.notifications(),
+            vec![("chat@g.us".to_owned(), "ordinary".to_owned())]
+        );
+        assert!(app.messages.contains_key("ordinary"));
+
+        let muted = RecordingNotifier::default();
+        let mut app = app_with_ports(FixedClock::new(2_000), muted.clone());
+        assert!(
+            app.process_message_with_lookup(message(&chat, "muted", 2), false, |_| {
+                wr::ChatSettings {
+                    found: true,
+                    muted_until: 2_001,
+                    ..Default::default()
+                }
+            },)
+        );
+        assert!(muted.notifications().is_empty());
+        assert!(app.messages.contains_key("muted"));
+
+        for (id, message) in [
+            ("own", {
+                let mut message = message(&chat, "own", 3);
+                message.info.is_from_me = true;
+                message
+            }),
+            ("status", status_message(&chat, "status", 4)),
+        ] {
+            let notifier = RecordingNotifier::default();
+            let lookup_calls = Arc::new(Mutex::new(0));
+            let calls = lookup_calls.clone();
+            let mut app = app_with_ports(FixedClock::new(2_000), notifier.clone());
+            assert!(app.process_message_with_lookup(message, false, |_| {
+                *calls.lock().unwrap() += 1;
+                Default::default()
+            }));
+            assert_eq!(*lookup_calls.lock().unwrap(), 0, "{id} lookup");
+            assert!(notifier.notifications().is_empty(), "{id} notification");
+            assert!(app.messages.contains_key(id));
+        }
+
+        let attempts = Arc::new(Mutex::new(0));
+        let failing = FailingNotifier {
+            attempts: attempts.clone(),
+        };
+        let mut app = app_with_ports(FixedClock::new(2_000), failing);
+        assert!(
+            app.process_message_with_lookup(message(&chat, "failure", 5), false, |_| {
+                Default::default()
+            },)
+        );
+        assert_eq!(*attempts.lock().unwrap(), 1);
+        assert!(app.messages.contains_key("failure"));
+
+        let sync = RecordingNotifier::default();
+        let mut app = app_with_ports(FixedClock::new(2_000), sync.clone());
+        assert!(
+            !app.process_message_with_lookup(message(&chat, "sync", 6), true, |_| panic!(
+                "sync messages must not look up chat settings"
+            ),)
+        );
+        assert!(sync.notifications().is_empty());
+        assert!(app.messages.contains_key("sync"));
+    }
+
+    #[test]
+    fn production_default_handler_keeps_message_processing_usable() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = App::with_data_dir(dir.path(), dir.path());
+        app.db_handler.init();
+        let chat = wr::JID::from("chat@g.us".to_owned());
+        assert!(
+            app.process_message_with_lookup(message(&chat, "default", 7), false, |_| {
+                Default::default()
+            },)
+        );
+        assert!(app.messages.contains_key("default"));
+        app.db_handler.stop();
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -72,6 +72,23 @@ pub struct Chat {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommunityNode {
+    pub jid: wr::JID,
+    pub name: String,
+    pub is_root: bool,
+    pub linked_groups: Vec<wr::JID>,
+}
+
+/// Presentation-only Chats row. `target` and `members` are always real chat
+/// JIDs; a community never becomes a persisted or addressable chat.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatRow {
+    pub label: String,
+    pub members: Vec<wr::JID>,
+    pub target: wr::JID,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MessageActionKind {
     Edit { replacement: Arc<str> },
     Delete,
@@ -230,6 +247,9 @@ pub struct App<'a> {
     /// Status section: the contact whose statuses are open in the right
     /// pane. Mirrors `open_chat` for the Chats section: set on Enter.
     pub open_status_contact: Option<wr::JID>,
+    pub communities: Vec<CommunityNode>,
+    pub communities_unavailable: bool,
+    communities_loaded: bool,
 
     /// Contacts with posted statuses, sorted by latest-status recency (newest
     /// first). Derived from the `status@broadcast` chat.
@@ -404,6 +424,9 @@ impl App<'_> {
             chat_list_state: ListState::default(),
             open_chat: None,
             open_status_contact: None,
+            communities: Vec::new(),
+            communities_unavailable: false,
+            communities_loaded: false,
 
             status_contacts: Vec::new(),
             status_selection: ListState::default(),
@@ -549,6 +572,7 @@ impl App<'_> {
         match event {
             wr::Event::AppStateSyncComplete => {
                 self.get_contacts();
+                self.load_communities();
                 self.sort_chats();
                 true
             }
@@ -636,6 +660,10 @@ impl App<'_> {
                 true
             }
             wr::Event::Connected => {
+                // Connected is emitted again after reconnects.  The first
+                // probe may race group metadata hydration, so AppStateSyncComplete
+                // below remains the authoritative follow-up refresh.
+                self.load_communities();
                 self.selected_presence.ready();
                 self.presence_diagnostics
                     .record(|| "self presence available: ready".to_owned());
@@ -1283,13 +1311,208 @@ impl App<'_> {
     }
 
     pub fn get_selected_chat(&self) -> Option<wr::JID> {
-        self.chat_list_state.selected().map(|index| {
-            if self.contact_search.input.is_empty() {
-                self.sorted_chats[index].clone()
-            } else {
-                self.filtered_chats[index].clone()
+        let rows = self.visible_chat_rows();
+        self.chat_list_state
+            .selected()
+            .and_then(|index| rows.get(index))
+            .map(|row| row.target.clone())
+    }
+
+    pub fn chat_rows(&self) -> Vec<ChatRow> {
+        let mut grouped = HashSet::new();
+        let community_metadata = self
+            .communities
+            .iter()
+            .map(|node| node.jid.clone())
+            .collect::<HashSet<_>>();
+        let mut rows = Vec::new();
+        for community in self.communities.iter().filter(|node| node.is_root) {
+            let members = community
+                .linked_groups
+                .iter()
+                .filter(|jid| self.chats.contains_key(*jid))
+                .cloned()
+                .collect::<Vec<_>>();
+            if members.is_empty() {
+                continue;
             }
-        })
+            grouped.extend(members.iter().cloned());
+            let target = members
+                .iter()
+                .max_by_key(|jid| self.chat_recency(jid))
+                .expect("non-empty community members")
+                .clone();
+            rows.push(ChatRow {
+                label: community.name.clone(),
+                members,
+                target,
+            });
+        }
+        rows.extend(
+            self.sorted_chats
+                .iter()
+                .filter(|jid| !grouped.contains(*jid))
+                .filter(|jid| !community_metadata.contains(*jid))
+                .map(|jid| ChatRow {
+                    label: self.contact_name(jid).to_string(),
+                    members: vec![(*jid).clone()],
+                    target: (*jid).clone(),
+                }),
+        );
+        rows.sort_by(|left, right| {
+            self.chat_recency(&right.target)
+                .cmp(&self.chat_recency(&left.target))
+                .then_with(|| left.label.cmp(&right.label))
+                .then_with(|| left.target.0.cmp(&right.target.0))
+        });
+        rows
+    }
+
+    pub fn visible_chat_rows(&self) -> Vec<ChatRow> {
+        let query = self.contact_search.input.to_lowercase();
+        self.chat_rows()
+            .into_iter()
+            .filter(|row| {
+                query.is_empty()
+                    || row.label.to_lowercase().contains(&query)
+                    || row
+                        .members
+                        .iter()
+                        .any(|jid| self.contact_name(jid).to_lowercase().contains(&query))
+            })
+            .collect()
+    }
+
+    pub fn chat_row_item(&self, row: &ChatRow) -> crate::ui::contact_list::ContactListItem {
+        crate::ui::contact_list::ContactListItem::from_row(self, row)
+    }
+
+    fn chat_recency(&self, jid: &wr::JID) -> i64 {
+        self.chat_messages
+            .get(jid)
+            .into_iter()
+            .flatten()
+            .filter_map(|id| self.messages.get(id).map(|message| message.info.timestamp))
+            .max()
+            .or_else(|| self.chats.get(jid).and_then(|chat| chat.last_message_time))
+            .unwrap_or_default()
+    }
+
+    pub fn get_selected_community(&self) -> Option<wr::JID> {
+        self.chat_list_state
+            .selected()
+            .and_then(|index| {
+                self.communities
+                    .iter()
+                    .filter(|node| !node.is_root)
+                    .nth(index)
+            })
+            .map(|node| node.jid.clone())
+    }
+
+    fn selected_community_node_jid(&self) -> Option<wr::JID> {
+        self.chat_list_state
+            .selected()
+            .and_then(|index| {
+                self.communities
+                    .iter()
+                    .filter(|node| !node.is_root)
+                    .nth(index)
+                    .or_else(|| {
+                        self.communities
+                            .iter()
+                            .filter(|node| node.is_root)
+                            .nth(index)
+                    })
+            })
+            .map(|node| node.jid.clone())
+    }
+
+    fn select_community_node(&mut self, jid: Option<wr::JID>) {
+        let selected = jid
+            .and_then(|jid| {
+                self.selectable_community_nodes()
+                    .iter()
+                    .position(|node| node.jid == jid)
+            })
+            .or_else(|| (!self.selectable_community_nodes().is_empty()).then_some(0));
+        self.chat_list_state.select(selected);
+    }
+
+    pub(crate) fn selectable_community_nodes(&self) -> Vec<&CommunityNode> {
+        self.communities
+            .iter()
+            .filter(|node| !node.is_root)
+            .collect()
+    }
+
+    fn load_communities(&mut self) {
+        self.refresh_communities(wr::get_communities);
+    }
+
+    pub fn refresh_communities<F>(&mut self, fetch: F)
+    where
+        F: FnOnce() -> Result<Vec<wr::CommunityInfo>, wr::CommunitiesError>,
+    {
+        match fetch() {
+            Ok(records) => {
+                // Communities has its own hierarchy. Never preserve its
+                // selection through the projected Chats rows: those rows may
+                // reorder independently and roots target a different JID.
+                let selected = if self.selected_section == Section::Communities {
+                    self.selected_community_node_jid()
+                } else {
+                    None
+                };
+                // An empty successful result is meaningful: it clears a prior
+                // hierarchy and renders the normal "No communities" state.
+                self.communities = Self::build_community_nodes(&records);
+                self.communities_unavailable = false;
+                self.communities_loaded = true;
+                if self.selected_section == Section::Communities {
+                    self.select_community_node(selected);
+                }
+            }
+            Err(error) => {
+                // Do not turn a transient readiness/reconnect failure into an
+                // empty hierarchy. Keep the last successful snapshot visible.
+                warn!("Could not load communities: {error:?}");
+                self.communities_unavailable = !self.communities_loaded;
+            }
+        }
+    }
+
+    pub(crate) fn build_community_nodes(records: &[wr::CommunityInfo]) -> Vec<CommunityNode> {
+        let mut roots = records
+            .iter()
+            .filter(|record| record.is_parent)
+            .collect::<Vec<_>>();
+        roots.sort_by(|a, b| a.name.cmp(&b.name));
+        let mut nodes = Vec::new();
+        for root in roots {
+            nodes.push(CommunityNode {
+                jid: root.jid.clone(),
+                name: root.name.to_string(),
+                is_root: true,
+                linked_groups: records
+                    .iter()
+                    .filter(|record| record.parent_jid.as_ref() == Some(&root.jid))
+                    .map(|record| record.jid.clone())
+                    .collect(),
+            });
+            let mut children = records
+                .iter()
+                .filter(|record| record.parent_jid.as_ref() == Some(&root.jid))
+                .collect::<Vec<_>>();
+            children.sort_by(|a, b| a.name.cmp(&b.name));
+            nodes.extend(children.into_iter().map(|child| CommunityNode {
+                jid: child.jid.clone(),
+                name: child.name.to_string(),
+                is_root: false,
+                linked_groups: Vec::new(),
+            }));
+        }
+        nodes
     }
 
     pub fn open_chat(&self) -> Option<wr::JID> {
@@ -1705,17 +1928,15 @@ impl App<'_> {
     }
 
     pub fn select_chat(&mut self, jid: Option<wr::JID>) {
-        let target_list = if self.contact_search.input.is_empty() {
-            &self.sorted_chats
-        } else {
-            &self.filtered_chats
-        };
+        let target_list = self.visible_chat_rows();
 
         if let Some(jid) = jid
-            && let Some(index) = target_list.iter().position(|chat_jid| chat_jid == &jid)
+            && let Some(index) = target_list
+                .iter()
+                .position(|row| row.target == jid || row.members.contains(&jid))
         {
             self.chat_list_state.select(Some(index));
-        } else if !self.sorted_chats.is_empty() {
+        } else if !target_list.is_empty() {
             self.chat_list_state.select(Some(0));
         } else {
             self.chat_list_state.select(None);
@@ -1723,15 +1944,10 @@ impl App<'_> {
     }
 
     fn update_filtered_chats(&mut self) {
-        let query = self.contact_search.input.to_lowercase();
         self.filtered_chats = self
-            .sorted_chats
-            .iter()
-            .filter(|chat| {
-                let name = self.contact_name(chat).to_lowercase();
-                name.contains(&query)
-            })
-            .cloned()
+            .visible_chat_rows()
+            .into_iter()
+            .map(|row| row.target)
             .collect();
 
         if !self.filtered_chats.is_empty() {
@@ -1823,6 +2039,7 @@ impl App<'_> {
     }
 
     pub fn sort_chats(&mut self) {
+        let selected = self.get_selected_chat();
         let mut entries: Vec<_> = self.chats.values().cloned().collect();
         entries.sort_by(|a, b| {
             let a_time = a.last_message_time.unwrap_or_default();
@@ -1835,6 +2052,7 @@ impl App<'_> {
             .map(|chat| chat.jid.clone())
             .filter(|jid: &wr::JID| !jid.0.as_ref().ends_with("@broadcast"))
             .collect();
+        self.select_chat(selected);
     }
 
     pub(crate) fn sort_chat_messages(&mut self, chat_jid: wr::JID) {
@@ -2016,6 +2234,7 @@ pub fn unix_now() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::actions::AppAction;
 
     /// Test-only App wrapper: points every storage path at a fresh
     /// tempdir (so tests never open the real user database) and stops
@@ -2112,6 +2331,180 @@ mod tests {
         assert_eq!(app.open_chat(), Some(recipient.clone()));
         assert!(app.chats.contains_key(&recipient));
         assert!(app.sorted_chats.contains(&recipient));
+    }
+
+    #[test]
+    fn community_hierarchy_is_sorted_with_roots_followed_by_children() {
+        let root = wr::JID::from("root@g.us".to_owned());
+        let child = wr::JID::from("child@g.us".to_owned());
+        let records = vec![
+            wr::CommunityInfo {
+                jid: child.clone(),
+                name: "Child".into(),
+                parent_jid: Some(root.clone()),
+                is_parent: false,
+            },
+            wr::CommunityInfo {
+                jid: root.clone(),
+                name: "Community".into(),
+                parent_jid: None,
+                is_parent: true,
+            },
+        ];
+        assert_eq!(
+            App::build_community_nodes(&records),
+            vec![
+                CommunityNode {
+                    jid: root,
+                    name: "Community".into(),
+                    is_root: true,
+                    linked_groups: vec![child.clone()],
+                },
+                CommunityNode {
+                    jid: child,
+                    name: "Child".into(),
+                    is_root: false,
+                    linked_groups: Vec::new(),
+                },
+            ]
+        );
+    }
+
+    fn community(name: &str, jid: &str, is_parent: bool) -> wr::CommunityInfo {
+        wr::CommunityInfo {
+            jid: wr::JID::from(jid.to_owned()),
+            name: name.into(),
+            parent_jid: None,
+            is_parent,
+        }
+    }
+
+    #[test]
+    fn communities_load_after_readiness_event() {
+        let mut app = TestApp::new();
+        let root = community("Community", "root@g.us", true);
+
+        app.refresh_communities(|| Ok(vec![root.clone()]));
+
+        assert_eq!(app.communities.len(), 1);
+        assert!(!app.communities_unavailable);
+    }
+
+    #[test]
+    fn communities_refresh_on_restart_or_reconnect_replaces_snapshot() {
+        let mut app = TestApp::new();
+        app.refresh_communities(|| Ok(vec![community("Old", "old@g.us", true)]));
+        app.refresh_communities(|| Ok(vec![community("New", "new@g.us", true)]));
+
+        assert_eq!(app.communities[0].name, "New");
+        assert_eq!(app.communities[0].jid, wr::JID::from("new@g.us".to_owned()));
+    }
+
+    #[test]
+    fn successful_empty_communities_clears_snapshot() {
+        let mut app = TestApp::new();
+        app.refresh_communities(|| Ok(vec![community("Old", "old@g.us", true)]));
+        app.refresh_communities(|| Ok(Vec::new()));
+
+        assert!(app.communities.is_empty());
+        assert!(!app.communities_unavailable);
+    }
+
+    #[test]
+    fn transient_communities_failure_preserves_last_successful_snapshot() {
+        let mut app = TestApp::new();
+        app.refresh_communities(|| Ok(vec![community("Known", "known@g.us", true)]));
+        app.refresh_communities(|| Err(wr::CommunitiesError::BridgeUnavailable));
+
+        assert_eq!(app.communities[0].name, "Known");
+        assert!(!app.communities_unavailable);
+    }
+
+    #[test]
+    fn communities_refresh_preserves_explicit_node_across_reorder_and_target_change() {
+        let mut app = TestApp::new();
+        let selected = wr::JID::from("selected@g.us".to_owned());
+        let other = wr::JID::from("other@g.us".to_owned());
+        app.selected_section = Section::Communities;
+        app.refresh_communities(|| {
+            Ok(vec![
+                community("Selected", "selected@g.us", true),
+                wr::CommunityInfo {
+                    jid: other.clone(),
+                    name: "Other".into(),
+                    parent_jid: Some(selected.clone()),
+                    is_parent: false,
+                },
+            ])
+        });
+        app.chat_list_state.select(Some(0));
+        app.chats.insert(
+            other.clone(),
+            Chat {
+                jid: other.clone(),
+                last_message_time: None,
+            },
+        );
+        app.refresh_communities(|| {
+            Ok(vec![
+                community("Aardvark", "aardvark@g.us", true),
+                community("Selected", "selected@g.us", true),
+                wr::CommunityInfo {
+                    jid: other.clone(),
+                    name: "Other".into(),
+                    parent_jid: Some(selected.clone()),
+                    is_parent: false,
+                },
+            ])
+        });
+
+        assert_eq!(app.selected_community_node_jid(), Some(other.clone()));
+        assert_eq!(app.get_selected_community(), Some(other));
+    }
+
+    #[test]
+    fn communities_refresh_falls_back_when_selected_node_is_removed() {
+        let mut app = TestApp::new();
+        app.selected_section = Section::Communities;
+        app.refresh_communities(|| {
+            Ok(vec![
+                community("Removed", "removed@g.us", true),
+                community("Kept", "kept@g.us", true),
+            ])
+        });
+        app.chat_list_state.select(Some(0));
+        app.refresh_communities(|| Ok(vec![community("Kept", "kept@g.us", true)]));
+
+        assert_eq!(app.chat_list_state.selected(), None);
+        assert_eq!(app.selected_community_node_jid(), None);
+    }
+
+    #[test]
+    fn community_selection_moves_and_enter_opens_the_selected_group() {
+        let mut app = TestApp::new();
+        let root = wr::JID::from("root@g.us".to_owned());
+        let child = wr::JID::from("child@g.us".to_owned());
+        app.communities = vec![
+            CommunityNode {
+                jid: root,
+                name: "Community".into(),
+                is_root: true,
+                linked_groups: vec![child.clone()],
+            },
+            CommunityNode {
+                jid: child.clone(),
+                name: "Child".into(),
+                is_root: false,
+                linked_groups: Vec::new(),
+            },
+        ];
+        app.selected_section = Section::Communities;
+        app.focus_pane = FocusPane::ChatList;
+        app.chat_list_state.select(Some(0));
+        assert_eq!(app.chat_list_state.selected(), Some(0));
+        app.dispatch_action(AppAction::OpenChat);
+        assert_eq!(app.open_chat(), Some(child));
+        assert_eq!(app.focus_pane, FocusPane::Conversation);
     }
 
     #[test]

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -272,6 +272,11 @@ impl App<'_> {
                             self.message_list_state.select(Some(0));
                         }
                     }
+                } else if self.selected_section == Section::Communities {
+                    if let Some(jid) = self.get_selected_community() {
+                        self.open_chat_by_jid(jid);
+                        self.focus_pane = FocusPane::Conversation;
+                    }
                 } else {
                     let opened = self.get_selected_chat().is_some();
                     self.open_selected_chat();
@@ -1175,6 +1180,9 @@ impl App<'_> {
                 if self.selected_section == Section::Status {
                     self.status_selection.select_next();
                     self.clamp_status_selection();
+                } else if self.selected_section == Section::Communities {
+                    self.chat_list_state.select_next();
+                    self.clamp_community_selection();
                 } else {
                     self.chat_list_state.select_next();
                     self.clamp_chat_selection();
@@ -1209,6 +1217,9 @@ impl App<'_> {
                 if self.selected_section == Section::Status {
                     self.status_selection.select_previous();
                     self.clamp_status_selection();
+                } else if self.selected_section == Section::Communities {
+                    self.chat_list_state.select_previous();
+                    self.clamp_community_selection();
                 } else {
                     self.chat_list_state.select_previous();
                     self.clamp_chat_selection();
@@ -1346,6 +1357,17 @@ impl App<'_> {
             &self.filtered_chats
         };
         match (chats.len(), self.chat_list_state.selected()) {
+            (0, _) => self.chat_list_state.select(None),
+            (len, Some(selected)) if selected >= len => self.chat_list_state.select(Some(len - 1)),
+            _ => {}
+        }
+    }
+
+    fn clamp_community_selection(&mut self) {
+        match (
+            self.selectable_community_nodes().len(),
+            self.chat_list_state.selected(),
+        ) {
             (0, _) => self.chat_list_state.select(None),
             (len, Some(selected)) if selected >= len => self.chat_list_state.select(Some(len - 1)),
             _ => {}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,6 +3,7 @@ mod contacts;
 mod layout;
 pub mod message_list;
 mod navigation;
+mod status;
 pub mod status_list;
 pub mod text_input;
 
@@ -19,7 +20,7 @@ use crate::app::events::{
     ViewerPreviewKey, ViewerPreviewState, ViewerStatus, viewer_preview_request,
 };
 use contacts::render_contacts;
-use message_list::{get_quoted_text, render_messages, render_status_messages};
+use message_list::{get_quoted_text, render_messages};
 use navigation::{
     render_logout_placeholder, render_logs, render_section_rail, render_structural_placeholder,
 };
@@ -29,10 +30,10 @@ use ratatui::{
     style::{Style, Stylize},
     symbols,
     text::{Line, Span},
-    widgets::{Block, Clear, Paragraph, StatefulWidget, Widget, Wrap},
+    widgets::{Block, Clear, Paragraph, StatefulWidget, Wrap},
 };
 use ratatui_image::{Resize, StatefulImage};
-use status_list::{StatusList, StatusListItem};
+use status::{render_status_contacts, render_statuses};
 use whatsrust as wr;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -80,62 +81,6 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     render_url_picker(frame, app);
     render_share_picker(frame, app);
     render_file_picker(frame, app);
-}
-
-fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let items = app
-        .status_contacts
-        .iter()
-        .map(|contact| StatusListItem::from_contact(app, contact))
-        .collect::<Vec<_>>();
-
-    let block = Block::bordered()
-        .title("Status")
-        .border_style(
-            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
-                ratatui::style::Color::Green
-            } else {
-                ratatui::style::Color::White
-            }),
-        );
-    let list_area = block.inner(area);
-    block.render(area, frame.buffer_mut());
-
-    if items.is_empty() {
-        frame.render_widget(Paragraph::new("No statuses yet"), list_area);
-        return;
-    }
-    frame.render_stateful_widget(
-        StatusList::new(&items),
-        list_area,
-        &mut app.status_selection,
-    );
-}
-
-fn render_statuses(frame: &mut Frame, app: &mut App, area: Rect) {
-    let title = app
-        .open_status_contact()
-        .map(|contact| app.contact_name(&contact).to_string())
-        .unwrap_or_else(|| "Status".to_string());
-    let border_color = if app.focus_pane == FocusPane::Conversation {
-        ratatui::style::Color::Green
-    } else {
-        ratatui::style::Color::White
-    };
-    let block = Block::bordered()
-        .title(title)
-        .border_style(Style::default().fg(border_color));
-    let content_area = block.inner(area);
-    block.render(area, frame.buffer_mut());
-
-    if app.open_status_contact().is_none() {
-        frame.render_widget(
-            Paragraph::new("Select a contact to view their statuses"),
-            content_area,
-        );
-        return;
-    }
-    render_status_messages(frame, app, content_area);
 }
 
 const ANDIVELI_LOGO: [&str; 19] = [

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -232,9 +232,8 @@ pub fn render_chats(frame: &mut Frame, app: &mut App, area: Rect) {
         })
     };
     let selected_chat = app.open_chat();
-    let marker = app
-        .selected_presence
-        .marker(selected_chat.as_ref(), crate::app::unix_now());
+    let now = app.now();
+    let marker = app.selected_presence.marker(selected_chat.as_ref(), now);
     let marker_span = marker.map(|marker| match marker {
         crate::app::presence::PresenceMarker::Online => Span::styled("●", Style::default().green()),
         crate::app::presence::PresenceMarker::RecentlyOffline => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,4 @@
+pub mod communities;
 pub mod contact_list;
 mod layout;
 pub mod message_list;
@@ -73,6 +74,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             render_status_contacts(frame, app, area);
         }
         render_statuses(frame, app, areas.conversation);
+    } else if app.selected_section == Section::Communities {
+        if let Some(area) = areas.chat_list {
+            communities::render(frame, app, area);
+        }
+        render_chats(frame, app, areas.conversation);
     } else {
         app.contact_avatars.clear_window();
         if let Some(area) = areas.chat_list {
@@ -87,14 +93,14 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 }
 
 fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let chats = if app.contact_search.input.is_empty() {
-        app.sorted_chats.clone()
-    } else {
-        app.filtered_chats.clone()
-    };
-    let items = chats
+    let rows = app.visible_chat_rows();
+    let targets = rows
         .iter()
-        .map(|chat| ContactListItem::from_chat(app, chat))
+        .map(|row| row.target.clone())
+        .collect::<Vec<_>>();
+    let items = rows
+        .iter()
+        .map(|row| ContactListItem::from_row(app, row))
         .collect::<Vec<_>>();
 
     let mut list_area = area;
@@ -141,11 +147,11 @@ fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
     let visible = contact_visible_range(
         app.chat_list_state.offset(),
         contacts_area.height,
-        chats.len(),
+        rows.len(),
     );
     app.contact_avatars.schedule(
         prioritized_avatar_requests(
-            &chats,
+            &targets,
             app.chat_list_state.selected(),
             visible.start,
             visible.len(),
@@ -167,7 +173,7 @@ fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
         // Partial Kitty placements can leave terminal artifacts after a scroll.
         if avatar_area.width == AVATAR_WIDTH
             && avatar_area.height == AVATAR_HEIGHT
-            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
+            && let Some(protocol) = app.contact_avatars.protocol_mut(&targets[index])
         {
             StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,5 @@
 pub mod contact_list;
+mod contacts;
 mod layout;
 pub mod message_list;
 mod navigation;
@@ -14,21 +15,17 @@ pub(crate) use layout::{composer_visual_layout, truncate_with_ellipsis};
 
 use crate::app::App;
 use crate::app::actions::{ConversationMode, FocusPane, Section};
-use crate::app::contact_avatars::prioritized_avatar_requests;
 use crate::app::events::{
     ViewerPreviewKey, ViewerPreviewState, ViewerStatus, viewer_preview_request,
 };
-use contact_list::{
-    AVATAR_HEIGHT, AVATAR_WIDTH, CONTACT_ITEM_HEIGHT, ContactList, ContactListItem,
-    contact_visible_range,
-};
+use contacts::render_contacts;
 use message_list::{get_quoted_text, render_messages, render_status_messages};
 use navigation::{
     render_logout_placeholder, render_logs, render_section_rail, render_structural_placeholder,
 };
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Layout, Position, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Style, Stylize},
     symbols,
     text::{Line, Span},
@@ -36,7 +33,6 @@ use ratatui::{
 };
 use ratatui_image::{Resize, StatefulImage};
 use status_list::{StatusList, StatusListItem};
-use std::sync::Arc;
 use whatsrust as wr;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -84,94 +80,6 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     render_url_picker(frame, app);
     render_share_picker(frame, app);
     render_file_picker(frame, app);
-}
-
-fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let chats = if app.contact_search.input.is_empty() {
-        app.sorted_chats.clone()
-    } else {
-        app.filtered_chats.clone()
-    };
-    let items = chats
-        .iter()
-        .map(|chat| ContactListItem::from_chat(app, chat))
-        .collect::<Vec<_>>();
-
-    let mut list_area = area;
-    if !app.contact_search.input.is_empty() || app.contact_search_active {
-        let [search_area, new_list_area] =
-            Layout::vertical([Constraint::Length(1), Constraint::Percentage(100)]).areas(area);
-        list_area = new_list_area;
-
-        let text = format!("/{}", app.contact_search.input);
-        frame.render_widget(Paragraph::new(text), search_area);
-
-        if app.contact_search_active {
-            frame.set_cursor_position(Position::new(
-                // Draw the cursor at the current position in the input field.
-                // This position is can be controlled via the left and right arrow key
-                search_area.x + app.contact_search.character_index as u16 + 1,
-                // Move one line down, from the border to the input line
-                search_area.y,
-            ));
-        }
-    }
-
-    let block = Block::bordered()
-        .title(if let Some(p) = app.history_sync_percent {
-            format!("Contacts ({p}%)")
-        } else {
-            "Contacts".to_string()
-        })
-        .border_style(
-            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
-                ratatui::style::Color::Green
-            } else {
-                ratatui::style::Color::White
-            }),
-        );
-    let contacts_area = block.inner(list_area);
-    block.render(list_area, frame.buffer_mut());
-    frame.render_stateful_widget(
-        ContactList::new(&items),
-        contacts_area,
-        &mut app.chat_list_state,
-    );
-
-    let visible = contact_visible_range(
-        app.chat_list_state.offset(),
-        contacts_area.height,
-        chats.len(),
-    );
-    app.contact_avatars.schedule(
-        prioritized_avatar_requests(
-            &chats,
-            app.chat_list_state.selected(),
-            visible.start,
-            visible.len(),
-        ),
-        app.tx.clone(),
-        Arc::clone(&app.picker),
-    );
-    for index in visible {
-        let row = index.saturating_sub(app.chat_list_state.offset());
-        let y = contacts_area
-            .y
-            .saturating_add((row * CONTACT_ITEM_HEIGHT) as u16);
-        let avatar_area = Rect::new(
-            contacts_area.x,
-            y,
-            AVATAR_WIDTH.min(contacts_area.width),
-            AVATAR_HEIGHT.min(contacts_area.bottom().saturating_sub(y)),
-        );
-        // Partial Kitty placements can leave terminal artifacts after a scroll.
-        if avatar_area.width == AVATAR_WIDTH
-            && avatar_area.height == AVATAR_HEIGHT
-            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
-        {
-            StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
-        }
-    }
 }
 
 fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,7 @@
 pub mod contact_list;
 mod layout;
 pub mod message_list;
+mod navigation;
 pub mod status_list;
 pub mod text_input;
 
@@ -22,18 +23,20 @@ use contact_list::{
     contact_visible_range,
 };
 use message_list::{get_quoted_text, render_messages, render_status_messages};
+use navigation::{
+    render_logout_placeholder, render_logs, render_section_rail, render_structural_placeholder,
+};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Layout, Position, Rect},
-    style::{Color, Style, Stylize},
+    style::{Style, Stylize},
     symbols,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, StatefulWidget, Widget, Wrap},
+    widgets::{Block, Clear, Paragraph, StatefulWidget, Widget, Wrap},
 };
 use ratatui_image::{Resize, StatefulImage};
 use status_list::{StatusList, StatusListItem};
 use std::sync::Arc;
-use tui_logger::TuiLoggerWidget;
 use whatsrust as wr;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -81,103 +84,6 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     render_url_picker(frame, app);
     render_share_picker(frame, app);
     render_file_picker(frame, app);
-}
-
-fn render_section_rail(frame: &mut Frame, app: &App, area: Rect) {
-    let mut items = Section::ALL
-        .iter()
-        .map(|section| {
-            ListItem::new(Section::title(*section)).style(Style::default().fg(Color::White))
-        })
-        .collect::<Vec<_>>();
-    items.push(
-        ListItem::new(crate::app::actions::LOGOUT_RAIL_TITLE)
-            .style(Style::default().fg(Color::Red)),
-    );
-    let selected = if app.rail_on_logout {
-        items.len() - 1
-    } else {
-        Section::ALL
-            .iter()
-            .position(|section| *section == app.selected_section)
-            .unwrap_or(0)
-    };
-    let mut state = ratatui::widgets::ListState::default().with_selected(Some(selected));
-    let list = List::new(items)
-        .block(
-            Block::bordered()
-                .title("Sections")
-                .border_style(
-                    Style::default().fg(if app.focus_pane == FocusPane::SectionRail {
-                        ratatui::style::Color::Green
-                    } else {
-                        ratatui::style::Color::White
-                    }),
-                ),
-        )
-        .highlight_symbol("> ")
-        .highlight_style(if app.rail_on_logout {
-            Style::default().red()
-        } else {
-            Style::default().green()
-        });
-    frame.render_stateful_widget(list, area, &mut state);
-}
-
-fn render_structural_placeholder(frame: &mut Frame, app: &App, area: Rect) {
-    let section = app.selected_section.title();
-    frame.render_widget(
-        Paragraph::new(format!("{section} is not available yet."))
-            .block(Block::bordered().title(section)),
-        area,
-    );
-}
-
-fn render_logout_placeholder(frame: &mut Frame, app: &App, area: Rect) {
-    let content = if app.logout_in_progress {
-        "Logging out…\n\nThis removes the device from WhatsApp and clears the local session."
-            .to_string()
-    } else if app.pending_logout {
-        // Reuse the message-menu interaction inside the pane: `>` marks the
-        // selection, j/k move it, Enter confirms, Esc cancels (y/N also work).
-        let menu_lines = ["Confirm logout", "Cancel"]
-            .iter()
-            .enumerate()
-            .map(|(index, label)| {
-                if index == app.logout_menu_index {
-                    format!("> {label}")
-                } else {
-                    format!("  {label}")
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        format!(
-            "This removes the device from WhatsApp and clears the local session.\n\n{menu_lines}\n\nj/k move · Enter confirms · Esc cancels"
-        )
-    } else {
-        "Press Enter to sign out.\nThis removes the device from WhatsApp and clears the local session.".to_string()
-    };
-    frame.render_widget(
-        Paragraph::new(content)
-            .block(
-                Block::bordered()
-                    .title(crate::app::actions::LOGOUT_RAIL_TITLE)
-                    .border_style(Style::default().fg(Color::Red)),
-            )
-            .style(Style::default().fg(Color::Red)),
-        area,
-    );
-}
-
-fn render_logs(frame: &mut Frame, area: Rect) {
-    let log_widget = TuiLoggerWidget::default()
-        .style_trace(Style::new().dark_gray())
-        .style_debug(Style::new().blue())
-        .style_warn(Style::new().yellow())
-        .style_error(Style::new().red().bold())
-        .block(Block::default().title("Logs").borders(Borders::ALL));
-    frame.render_widget(log_widget, area);
 }
 
 fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,18 @@
 pub mod contact_list;
+mod layout;
 pub mod message_list;
 pub mod status_list;
 pub mod text_input;
 
+pub use layout::{
+    NavigationAreas, ViewerPreviewLayout, attachment_preview_lines, centered_modal_layout,
+    composer_cursor_position, composer_height, composer_visual_cursor, composer_visual_rows,
+    conversation_areas, navigation_areas, viewer_preview_layout,
+};
+pub(crate) use layout::{composer_visual_layout, truncate_with_ellipsis};
+
 use crate::app::App;
-use crate::app::actions::{ConversationMode, FocusPane, PaneVisibility, Section};
-use crate::app::composer::PendingAttachment;
+use crate::app::actions::{ConversationMode, FocusPane, Section};
 use crate::app::contact_avatars::prioritized_avatar_requests;
 use crate::app::events::{
     ViewerPreviewKey, ViewerPreviewState, ViewerStatus, viewer_preview_request,
@@ -74,47 +81,6 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     render_url_picker(frame, app);
     render_share_picker(frame, app);
     render_file_picker(frame, app);
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NavigationAreas {
-    pub section_rail: Option<Rect>,
-    pub chat_list: Option<Rect>,
-    pub conversation: Rect,
-}
-
-pub fn navigation_areas(area: Rect, visibility: PaneVisibility) -> NavigationAreas {
-    let rail_width = if visibility.section_rail {
-        14.min(area.width)
-    } else {
-        0
-    };
-    let remaining = area.width.saturating_sub(rail_width);
-    let chat_width = if visibility.chat_list {
-        30.min(remaining)
-    } else {
-        0
-    };
-    let conversation_width = remaining.saturating_sub(chat_width);
-    let rail = Rect::new(area.x, area.y, rail_width, area.height);
-    let chat = Rect::new(
-        area.x.saturating_add(rail_width),
-        area.y,
-        chat_width,
-        area.height,
-    );
-    let conversation = Rect::new(
-        chat.x.saturating_add(chat_width),
-        area.y,
-        conversation_width,
-        area.height,
-    );
-
-    NavigationAreas {
-        section_rail: visibility.section_rail.then_some(rail),
-        chat_list: visibility.chat_list.then_some(chat),
-        conversation,
-    }
 }
 
 fn render_section_rail(frame: &mut Frame, app: &App, area: Rect) {
@@ -202,283 +168,6 @@ fn render_logout_placeholder(frame: &mut Frame, app: &App, area: Rect) {
             .style(Style::default().fg(Color::Red)),
         area,
     );
-}
-
-pub struct ViewerPreviewLayout {
-    pub modal: Rect,
-    pub body: Rect,
-    pub hint: Rect,
-    pub preview: Rect,
-}
-
-pub fn centered_modal_layout(area: Rect) -> Rect {
-    if area.is_empty() {
-        return area;
-    }
-    let width = area.width.min(72).max(1);
-    let height = area.height.min(16).max(1);
-    Rect::new(
-        area.x.saturating_add(area.width.saturating_sub(width) / 2),
-        area.y
-            .saturating_add(area.height.saturating_sub(height) / 2),
-        width,
-        height,
-    )
-}
-
-pub fn viewer_preview_layout(area: Rect, zoom_percent: u16) -> ViewerPreviewLayout {
-    let modal = Rect::new(
-        area.x.saturating_add(2),
-        area.y.saturating_add(2),
-        area.width.saturating_sub(4),
-        area.height.saturating_sub(4),
-    );
-    let inner = Block::bordered().inner(modal);
-    let [body, hint] = Layout::vertical([Constraint::Min(1), Constraint::Length(2)]).areas(inner);
-    let zoom_factor = (zoom_percent as f32 / 100.0).clamp(0.25, 4.0);
-    let pct = (85.0_f32 * zoom_factor).clamp(20.0, 100.0) / 100.0;
-    let width = ((body.width as f32) * pct).round() as u16;
-    let height = ((body.height as f32) * pct).round() as u16;
-    let preview = Rect::new(
-        body.x.saturating_add(body.width.saturating_sub(width) / 2),
-        body.y
-            .saturating_add(body.height.saturating_sub(height) / 2),
-        width,
-        height,
-    );
-    ViewerPreviewLayout {
-        modal,
-        body,
-        hint,
-        preview,
-    }
-}
-
-pub fn composer_cursor_position(input_area: Rect, cursor: (usize, usize)) -> Position {
-    let (row, column) = cursor;
-    Position::new(input_area.x + column as u16, input_area.y + row as u16)
-}
-
-pub fn composer_visual_rows(lines: &[String], width: u16) -> usize {
-    composer_visual_layout(lines, width).rows.len()
-}
-
-pub fn composer_visual_cursor(
-    lines: &[String],
-    cursor: (usize, usize),
-    width: u16,
-) -> (usize, usize) {
-    composer_visual_layout(lines, width).cursor(cursor)
-}
-
-#[derive(Clone, Copy)]
-struct ComposerCell {
-    character: char,
-    logical_column: usize,
-    width: usize,
-}
-
-struct ComposerVisualLayout {
-    rows: Vec<Vec<ComposerCell>>,
-    logical_rows: Vec<(usize, usize)>,
-    width: usize,
-}
-
-impl ComposerVisualLayout {
-    fn text(&self) -> String {
-        self.rows
-            .iter()
-            .map(|row| row.iter().map(|cell| cell.character).collect::<String>())
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
-    fn cursor(&self, cursor: (usize, usize)) -> (usize, usize) {
-        let logical_row = cursor.0.min(self.logical_rows.len().saturating_sub(1));
-        let logical_column = cursor.1;
-        let (first_row, row_count) = self.logical_rows[logical_row];
-
-        for (row_offset, row) in self.rows[first_row..first_row + row_count]
-            .iter()
-            .enumerate()
-        {
-            let mut column = 0;
-            for cell in row {
-                if cell.logical_column >= logical_column {
-                    return (first_row + row_offset, column);
-                }
-                column += cell.width;
-            }
-        }
-
-        let last_row = first_row + row_count - 1;
-        let column = self.rows[last_row].iter().map(|cell| cell.width).sum();
-        if column >= self.width {
-            (last_row + 1, 0)
-        } else {
-            (last_row, column)
-        }
-    }
-}
-
-fn composer_visual_layout(lines: &[String], width: u16) -> ComposerVisualLayout {
-    let mut rows = Vec::new();
-    let mut logical_rows = Vec::new();
-
-    for line in lines {
-        let first_row = rows.len();
-        let wrapped = wrap_composer_line(line, width);
-        let row_count = wrapped.len();
-        rows.extend(wrapped);
-        logical_rows.push((first_row, row_count));
-    }
-
-    if rows.is_empty() {
-        rows.push(Vec::new());
-        logical_rows.push((0, 1));
-    }
-
-    ComposerVisualLayout {
-        rows,
-        logical_rows,
-        width: width as usize,
-    }
-}
-
-fn wrap_composer_line(line: &str, width: u16) -> Vec<Vec<ComposerCell>> {
-    if width == 0 {
-        return vec![Vec::new()];
-    }
-
-    // This mirrors Ratatui's WordWrapper with `trim: false`, which Paragraph used
-    // before the composer switched to precomputed visual rows.
-    let max_width = width as usize;
-    let mut rows = Vec::new();
-    let mut pending_line: Vec<ComposerCell> = Vec::new();
-    let mut pending_word = Vec::new();
-    let mut pending_whitespace = Vec::new();
-    let mut line_width = 0;
-    let mut word_width = 0;
-    let mut whitespace_width = 0;
-    let mut non_whitespace_previous = false;
-
-    for (logical_column, character) in line.chars().enumerate() {
-        let cell = ComposerCell {
-            character,
-            logical_column,
-            width: display_width(character),
-        };
-        if cell.width > max_width {
-            continue;
-        }
-
-        let is_whitespace = character.is_whitespace();
-        let word_found = non_whitespace_previous && is_whitespace;
-        let untrimmed_overflow =
-            pending_line.is_empty() && word_width + whitespace_width + cell.width > max_width;
-
-        if word_found || untrimmed_overflow {
-            pending_line.append(&mut pending_whitespace);
-            line_width += whitespace_width;
-            pending_line.append(&mut pending_word);
-            line_width += word_width;
-            whitespace_width = 0;
-            word_width = 0;
-        }
-
-        let line_full = line_width >= max_width;
-        let pending_word_overflow =
-            cell.width > 0 && line_width + whitespace_width + word_width >= max_width;
-        if line_full || pending_word_overflow {
-            let mut remaining_width = max_width.saturating_sub(line_width);
-            rows.push(std::mem::take(&mut pending_line));
-            line_width = 0;
-
-            while let Some(whitespace) = pending_whitespace.first() {
-                if whitespace.width > remaining_width {
-                    break;
-                }
-                whitespace_width -= whitespace.width;
-                remaining_width -= whitespace.width;
-                pending_whitespace.remove(0);
-            }
-
-            if is_whitespace && pending_whitespace.is_empty() {
-                continue;
-            }
-        }
-
-        if is_whitespace {
-            whitespace_width += cell.width;
-            pending_whitespace.push(cell);
-        } else {
-            word_width += cell.width;
-            pending_word.push(cell);
-        }
-        non_whitespace_previous = !is_whitespace;
-    }
-
-    pending_line.append(&mut pending_whitespace);
-    pending_line.append(&mut pending_word);
-    if pending_line.is_empty() {
-        rows.push(Vec::new());
-    } else {
-        rows.push(pending_line);
-    }
-    rows
-}
-
-fn display_width(character: char) -> usize {
-    let mut buffer = [0; 4];
-    textwrap::core::display_width(character.encode_utf8(&mut buffer))
-}
-
-pub fn composer_height(
-    terminal_height: u16,
-    input_lines: usize,
-    quote_rows: usize,
-    attachment_rows: usize,
-) -> u16 {
-    let desired = 2_u16
-        .saturating_add(input_lines.max(1) as u16)
-        .saturating_add(quote_rows as u16)
-        .saturating_add(attachment_rows as u16);
-    desired
-        .min(12)
-        .min(terminal_height.saturating_sub(1))
-        .max(1)
-}
-
-pub fn conversation_areas(
-    area: Rect,
-    input_lines: usize,
-    quote_rows: usize,
-    attachment_rows: usize,
-) -> (Rect, Rect) {
-    let composer_height = composer_height(area.height, input_lines, quote_rows, attachment_rows);
-    let [messages, _gap, composer] = Layout::vertical([
-        Constraint::Min(1),
-        Constraint::Length(1),
-        Constraint::Length(composer_height),
-    ])
-    .areas(area);
-    (messages, composer)
-}
-
-pub fn attachment_preview_lines(attachments: &[PendingAttachment]) -> Vec<String> {
-    attachments
-        .iter()
-        .map(|attachment| {
-            let kind = match attachment.kind {
-                wr::FileKind::Image => "Image",
-                wr::FileKind::Video => "Video",
-                wr::FileKind::Audio => "Audio",
-                wr::FileKind::Document => "Document",
-                wr::FileKind::Sticker => "Sticker",
-            };
-            format!("{kind}: {}", attachment.display_name())
-        })
-        .collect()
 }
 
 fn render_logs(frame: &mut Frame, area: Rect) {
@@ -822,7 +511,7 @@ pub fn render_chats(frame: &mut Frame, app: &mut App, area: Rect) {
     let composer_layout = composer_visual_layout(app.composer.input.lines(), composer_width);
     let input_cursor = app.composer.input.cursor();
     let composer_cursor = composer_layout.cursor((input_cursor.0, input_cursor.1));
-    let composer_rows = composer_layout.rows.len().max(composer_cursor.0 + 1);
+    let composer_rows = composer_layout.row_count().max(composer_cursor.0 + 1);
     let (chat_area, composer_area) = conversation_areas(
         inner,
         composer_rows,
@@ -1143,29 +832,4 @@ fn render_file_picker(frame: &mut Frame, app: &mut App) {
             .wrap(Wrap { trim: true }),
         hint_area,
     );
-}
-
-/// Truncate `value` to at most `width` terminal cells, appending `…` when
-/// there is content left to cut. Returns `value` unchanged if it already fits.
-/// Returns an empty string for `width <= 1` so callers can detect "no usable
-/// space" without panicking.
-fn truncate_with_ellipsis(value: &str, width: usize) -> String {
-    if width <= 1 || value.is_empty() {
-        return String::new();
-    }
-    if textwrap::core::display_width(value) <= width {
-        return value.to_owned();
-    }
-    let ellipsis_cost = textwrap::core::display_width("…");
-    let budget = width.saturating_sub(ellipsis_cost);
-    let mut result = String::new();
-    for ch in value.chars() {
-        let next = format!("{result}{ch}");
-        if textwrap::core::display_width(&next) > budget {
-            break;
-        }
-        result = next;
-    }
-    result.push('…');
-    result
 }

--- a/src/ui/communities.rs
+++ b/src/ui/communities.rs
@@ -1,0 +1,212 @@
+use crate::app::App;
+use crate::app::actions::FocusPane;
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::{Block, Paragraph},
+};
+
+const BRANCH_WIDTH: u16 = 4;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CommunityRow {
+    node_index: usize,
+    selectable_index: Option<usize>,
+    area: Rect,
+    branch: Rect,
+    text: Rect,
+}
+
+fn community_layout(
+    communities: &[crate::app::CommunityNode],
+    selected: Option<usize>,
+    area: Rect,
+) -> Vec<CommunityRow> {
+    if area.is_empty() {
+        return Vec::new();
+    }
+
+    let mut logical_rows = Vec::new();
+    let mut selectable_index = 0;
+    for (node_index, root) in communities
+        .iter()
+        .enumerate()
+        .filter(|(_, node)| node.is_root)
+    {
+        logical_rows.push((node_index, None));
+        for (node_index, _) in communities
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| !node.is_root && root.linked_groups.contains(&node.jid))
+        {
+            logical_rows.push((node_index, Some(selectable_index)));
+            selectable_index += 1;
+        }
+    }
+
+    let capacity = usize::from(area.height);
+    let selected_row = selected.and_then(|selection| {
+        logical_rows
+            .iter()
+            .position(|(_, selectable)| *selectable == Some(selection))
+    });
+    let start = selected_row
+        .map(|row| row.saturating_sub(capacity.saturating_sub(1)))
+        .unwrap_or(0)
+        .min(logical_rows.len().saturating_sub(capacity));
+
+    logical_rows
+        .into_iter()
+        .skip(start)
+        .take(capacity)
+        .enumerate()
+        .map(|(visible_index, (node_index, selectable_index))| {
+            let y = area.y.saturating_add(visible_index as u16);
+            let row_area = Rect::new(area.x, y, area.width, 1);
+            let branch_x = area.x.min(area.right());
+            let branch = Rect::new(
+                branch_x,
+                y,
+                BRANCH_WIDTH.min(area.right().saturating_sub(branch_x)),
+                1,
+            );
+            let text_x = if selectable_index.is_some() {
+                branch_x.saturating_add(BRANCH_WIDTH).min(area.right())
+            } else {
+                area.x
+            };
+            let text = Rect::new(text_x, y, area.right().saturating_sub(text_x), 1);
+            CommunityRow {
+                node_index,
+                selectable_index,
+                area: row_area,
+                branch,
+                text,
+            }
+        })
+        .collect()
+}
+
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+    let block = Block::bordered()
+        .title("Communities")
+        .border_style(
+            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
+                Color::Green
+            } else {
+                Color::White
+            }),
+        );
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if app.communities_unavailable {
+        frame.render_widget(Paragraph::new("Community data unavailable"), inner);
+        return;
+    }
+    if app.communities.is_empty() {
+        frame.render_widget(Paragraph::new("No communities"), inner);
+        return;
+    }
+
+    let selected = app.chat_list_state.selected();
+    for row in community_layout(&app.communities, selected, inner) {
+        let node = &app.communities[row.node_index];
+        let selected = row.selectable_index == selected;
+        let base = if selected {
+            Style::default().fg(Color::Green).bg(Color::DarkGray)
+        } else {
+            Style::default()
+        };
+        frame.buffer_mut().set_style(row.area, base);
+
+        if row.selectable_index.is_some() {
+            frame.buffer_mut().set_stringn(
+                row.branch.x,
+                row.branch.y,
+                "├─",
+                row.branch.width as usize,
+                base,
+            );
+        }
+        let text_style = if row.selectable_index.is_none() {
+            base.add_modifier(Modifier::BOLD)
+        } else {
+            base
+        };
+        frame.buffer_mut().set_stringn(
+            row.text.x,
+            row.text.y,
+            &node.name,
+            row.text.width as usize,
+            text_style,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::community_layout;
+    use crate::app::CommunityNode;
+    use ratatui::layout::Rect;
+    use whatsrust::JID;
+
+    fn nodes(group_count: usize) -> Vec<CommunityNode> {
+        let groups = (0..group_count)
+            .map(|index| JID::from(format!("group-{index}@g.us")))
+            .collect::<Vec<_>>();
+        let mut result = vec![CommunityNode {
+            jid: JID::from("root@g.us".to_owned()),
+            name: "Community".into(),
+            is_root: true,
+            linked_groups: groups.clone(),
+        }];
+        result.extend(
+            groups
+                .into_iter()
+                .enumerate()
+                .map(|(index, jid)| CommunityNode {
+                    jid,
+                    name: format!("Group {index}"),
+                    is_root: false,
+                    linked_groups: Vec::new(),
+                }),
+        );
+        result
+    }
+
+    #[test]
+    fn root_is_rendered_once_and_groups_are_compact_branch_rows() {
+        let layout = community_layout(&nodes(2), Some(0), Rect::new(0, 0, 40, 12));
+        assert_eq!(layout.len(), 3);
+        assert_eq!(layout[0].selectable_index, None);
+        assert_eq!(layout[0].text.y, 0);
+        assert_eq!(layout[1].selectable_index, Some(0));
+        assert_eq!(layout[1].text.y, 1);
+        assert_eq!(layout[2].selectable_index, Some(1));
+        assert_eq!(layout[2].text.y, 2);
+        assert_eq!(layout[1].text.x, layout[1].branch.right());
+    }
+
+    #[test]
+    fn selected_group_is_visible_and_root_is_not_selectable() {
+        let layout = community_layout(&nodes(6), Some(5), Rect::new(0, 0, 40, 3));
+        assert!(layout.iter().any(|row| row.selectable_index == Some(5)));
+        assert!(layout.iter().all(|row| row.selectable_index.is_some()));
+    }
+
+    #[test]
+    fn narrow_and_short_areas_remain_bounded() {
+        let layout = community_layout(&nodes(2), Some(0), Rect::new(0, 0, 5, 1));
+        assert!(
+            layout
+                .iter()
+                .all(|row| row.area.right() <= 5 && row.area.bottom() <= 1)
+        );
+        assert!(
+            layout
+                .iter()
+                .all(|row| row.branch.right() <= 5 && row.text.right() <= 5)
+        );
+    }
+}

--- a/src/ui/contact_list.rs
+++ b/src/ui/contact_list.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use textwrap::core::display_width;
 use whatsrust as wr;
 
-use crate::app::App;
+use crate::app::{App, ChatRow};
 
 pub const CONTACT_ITEM_HEIGHT: usize = 3;
 pub const AVATAR_WIDTH: u16 = 4;
@@ -21,18 +21,26 @@ pub struct ContactListItem {
     pub initials: String,
     pub preview: String,
     pub local_time: Option<String>,
-    /// The current backend does not expose per-chat unread totals, so this remains absent.
-    pub unread_count: Option<u32>,
 }
 
 impl ContactListItem {
     pub fn from_chat(app: &App<'_>, chat: &wr::JID) -> Self {
-        let name = app.contact_name(chat).to_string();
-        let latest = app
-            .chat_messages
-            .get(chat)
-            .into_iter()
-            .flatten()
+        Self::from_row(
+            app,
+            &ChatRow {
+                label: app.contact_name(chat).to_string(),
+                members: vec![chat.clone()],
+                target: chat.clone(),
+            },
+        )
+    }
+
+    pub fn from_row(app: &App<'_>, row: &ChatRow) -> Self {
+        let name = row.label.clone();
+        let latest = row
+            .members
+            .iter()
+            .flat_map(|chat| app.chat_messages.get(chat).into_iter().flatten())
             .filter_map(|id| app.messages.get(id))
             .max_by(|left, right| {
                 left.info
@@ -40,16 +48,18 @@ impl ContactListItem {
                     .cmp(&right.info.timestamp)
                     .then_with(|| left.info.id.cmp(&right.info.id))
             });
-        let timestamp = latest
-            .map(|message| message.info.timestamp)
-            .or_else(|| app.chats.get(chat).and_then(|chat| chat.last_message_time));
+        let timestamp = latest.map(|message| message.info.timestamp).or_else(|| {
+            row.members
+                .iter()
+                .filter_map(|jid| app.chats.get(jid).and_then(|chat| chat.last_message_time))
+                .max()
+        });
 
         Self {
             initials: initials(&name),
             name,
             preview: latest.map(message_preview).unwrap_or_default(),
             local_time: timestamp.and_then(local_time),
-            unread_count: None,
         }
     }
 }
@@ -182,11 +192,7 @@ impl StatefulWidget for ContactList<'_> {
                 .saturating_add(AVATAR_WIDTH.saturating_add(AVATAR_GAP).min(area.width));
             let text_width = area.right().saturating_sub(text_x) as usize;
             let first = format_row(&item.name, item.local_time.as_deref(), text_width);
-            let unread = item
-                .unread_count
-                .filter(|count| *count > 0)
-                .map(|count| count.to_string());
-            let second = format_row(&item.preview, unread.as_deref(), text_width);
+            let second = format_row(&item.preview, None, text_width);
             if item_area.height > 0 {
                 buf.set_stringn(text_x, y, first, text_width, name_style);
             }

--- a/src/ui/contacts.rs
+++ b/src/ui/contacts.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use super::contact_list::{
+    AVATAR_HEIGHT, AVATAR_WIDTH, CONTACT_ITEM_HEIGHT, ContactList, ContactListItem,
+    contact_visible_range,
+};
+use crate::app::App;
+use crate::app::actions::FocusPane;
+use crate::app::contact_avatars::prioritized_avatar_requests;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Position, Rect},
+    style::{Color, Style},
+    widgets::{Block, Paragraph, StatefulWidget, Widget},
+};
+use ratatui_image::StatefulImage;
+
+pub(super) fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
+    let chats = if app.contact_search.input.is_empty() {
+        app.sorted_chats.clone()
+    } else {
+        app.filtered_chats.clone()
+    };
+    let items = chats
+        .iter()
+        .map(|chat| ContactListItem::from_chat(app, chat))
+        .collect::<Vec<_>>();
+
+    let mut list_area = area;
+    if !app.contact_search.input.is_empty() || app.contact_search_active {
+        let [search_area, new_list_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Percentage(100)]).areas(area);
+        list_area = new_list_area;
+
+        let text = format!("/{}", app.contact_search.input);
+        frame.render_widget(Paragraph::new(text), search_area);
+
+        if app.contact_search_active {
+            frame.set_cursor_position(Position::new(
+                search_area.x + app.contact_search.character_index as u16 + 1,
+                search_area.y,
+            ));
+        }
+    }
+
+    let block = Block::bordered()
+        .title(if let Some(p) = app.history_sync_percent {
+            format!("Contacts ({p}%)")
+        } else {
+            "Contacts".to_string()
+        })
+        .border_style(
+            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
+                Color::Green
+            } else {
+                Color::White
+            }),
+        );
+    let contacts_area = block.inner(list_area);
+    block.render(list_area, frame.buffer_mut());
+    frame.render_stateful_widget(
+        ContactList::new(&items),
+        contacts_area,
+        &mut app.chat_list_state,
+    );
+
+    let visible = contact_visible_range(
+        app.chat_list_state.offset(),
+        contacts_area.height,
+        chats.len(),
+    );
+    app.contact_avatars.schedule(
+        prioritized_avatar_requests(
+            &chats,
+            app.chat_list_state.selected(),
+            visible.start,
+            visible.len(),
+        ),
+        app.tx.clone(),
+        Arc::clone(&app.picker),
+    );
+    for index in visible {
+        let row = index.saturating_sub(app.chat_list_state.offset());
+        let y = contacts_area
+            .y
+            .saturating_add((row * CONTACT_ITEM_HEIGHT) as u16);
+        let avatar_area = Rect::new(
+            contacts_area.x,
+            y,
+            AVATAR_WIDTH.min(contacts_area.width),
+            AVATAR_HEIGHT.min(contacts_area.bottom().saturating_sub(y)),
+        );
+        // Partial Kitty placements can leave terminal artifacts after a scroll.
+        if avatar_area.width == AVATAR_WIDTH
+            && avatar_area.height == AVATAR_HEIGHT
+            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
+        {
+            StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
+        }
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,0 +1,370 @@
+use crate::app::actions::PaneVisibility;
+use crate::app::composer::PendingAttachment;
+use ratatui::{
+    layout::{Constraint, Layout, Position, Rect},
+    widgets::Block,
+};
+use whatsrust as wr;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NavigationAreas {
+    pub section_rail: Option<Rect>,
+    pub chat_list: Option<Rect>,
+    pub conversation: Rect,
+}
+
+pub fn navigation_areas(area: Rect, visibility: PaneVisibility) -> NavigationAreas {
+    let rail_width = if visibility.section_rail {
+        14.min(area.width)
+    } else {
+        0
+    };
+    let remaining = area.width.saturating_sub(rail_width);
+    let chat_width = if visibility.chat_list {
+        30.min(remaining)
+    } else {
+        0
+    };
+    let conversation_width = remaining.saturating_sub(chat_width);
+    let rail = Rect::new(area.x, area.y, rail_width, area.height);
+    let chat = Rect::new(
+        area.x.saturating_add(rail_width),
+        area.y,
+        chat_width,
+        area.height,
+    );
+    let conversation = Rect::new(
+        chat.x.saturating_add(chat_width),
+        area.y,
+        conversation_width,
+        area.height,
+    );
+
+    NavigationAreas {
+        section_rail: visibility.section_rail.then_some(rail),
+        chat_list: visibility.chat_list.then_some(chat),
+        conversation,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ViewerPreviewLayout {
+    pub modal: Rect,
+    pub body: Rect,
+    pub hint: Rect,
+    pub preview: Rect,
+}
+
+pub fn centered_modal_layout(area: Rect) -> Rect {
+    if area.is_empty() {
+        return area;
+    }
+    let width = area.width.clamp(1, 72);
+    let height = area.height.clamp(1, 16);
+    Rect::new(
+        area.x.saturating_add(area.width.saturating_sub(width) / 2),
+        area.y
+            .saturating_add(area.height.saturating_sub(height) / 2),
+        width,
+        height,
+    )
+}
+
+pub fn viewer_preview_layout(area: Rect, zoom_percent: u16) -> ViewerPreviewLayout {
+    let modal = Rect::new(
+        area.x.saturating_add(2),
+        area.y.saturating_add(2),
+        area.width.saturating_sub(4),
+        area.height.saturating_sub(4),
+    );
+    let inner = Block::bordered().inner(modal);
+    let [body, hint] = Layout::vertical([Constraint::Min(1), Constraint::Length(2)]).areas(inner);
+    let zoom_factor = (zoom_percent as f32 / 100.0).clamp(0.25, 4.0);
+    let pct = (85.0_f32 * zoom_factor).clamp(20.0, 100.0) / 100.0;
+    let width = ((body.width as f32) * pct).round() as u16;
+    let height = ((body.height as f32) * pct).round() as u16;
+    let preview = Rect::new(
+        body.x.saturating_add(body.width.saturating_sub(width) / 2),
+        body.y
+            .saturating_add(body.height.saturating_sub(height) / 2),
+        width,
+        height,
+    );
+    ViewerPreviewLayout {
+        modal,
+        body,
+        hint,
+        preview,
+    }
+}
+
+pub fn composer_cursor_position(input_area: Rect, cursor: (usize, usize)) -> Position {
+    let (row, column) = cursor;
+    Position::new(input_area.x + column as u16, input_area.y + row as u16)
+}
+
+pub fn composer_visual_rows(lines: &[String], width: u16) -> usize {
+    composer_visual_layout(lines, width).rows.len()
+}
+
+pub fn composer_visual_cursor(
+    lines: &[String],
+    cursor: (usize, usize),
+    width: u16,
+) -> (usize, usize) {
+    composer_visual_layout(lines, width).cursor(cursor)
+}
+
+#[derive(Clone, Copy)]
+struct ComposerCell {
+    character: char,
+    logical_column: usize,
+    width: usize,
+}
+
+pub(crate) struct ComposerVisualLayout {
+    rows: Vec<Vec<ComposerCell>>,
+    logical_rows: Vec<(usize, usize)>,
+    width: usize,
+}
+
+impl ComposerVisualLayout {
+    pub(crate) fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub(crate) fn text(&self) -> String {
+        self.rows
+            .iter()
+            .map(|row| row.iter().map(|cell| cell.character).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    pub(crate) fn cursor(&self, cursor: (usize, usize)) -> (usize, usize) {
+        let logical_row = cursor.0.min(self.logical_rows.len().saturating_sub(1));
+        let logical_column = cursor.1;
+        let (first_row, row_count) = self.logical_rows[logical_row];
+
+        for (row_offset, row) in self.rows[first_row..first_row + row_count]
+            .iter()
+            .enumerate()
+        {
+            let mut column = 0;
+            for cell in row {
+                if cell.logical_column >= logical_column {
+                    return (first_row + row_offset, column);
+                }
+                column += cell.width;
+            }
+        }
+
+        let last_row = first_row + row_count - 1;
+        let column = self.rows[last_row].iter().map(|cell| cell.width).sum();
+        if column >= self.width {
+            (last_row + 1, 0)
+        } else {
+            (last_row, column)
+        }
+    }
+}
+
+pub(crate) fn composer_visual_layout(lines: &[String], width: u16) -> ComposerVisualLayout {
+    let mut rows = Vec::new();
+    let mut logical_rows = Vec::new();
+
+    for line in lines {
+        let first_row = rows.len();
+        let wrapped = wrap_composer_line(line, width);
+        let row_count = wrapped.len();
+        rows.extend(wrapped);
+        logical_rows.push((first_row, row_count));
+    }
+
+    if rows.is_empty() {
+        rows.push(Vec::new());
+        logical_rows.push((0, 1));
+    }
+
+    ComposerVisualLayout {
+        rows,
+        logical_rows,
+        width: width as usize,
+    }
+}
+
+fn wrap_composer_line(line: &str, width: u16) -> Vec<Vec<ComposerCell>> {
+    if width == 0 {
+        return vec![Vec::new()];
+    }
+
+    // This mirrors Ratatui's WordWrapper with `trim: false`, which Paragraph used
+    // before the composer switched to precomputed visual rows.
+    let max_width = width as usize;
+    let mut rows = Vec::new();
+    let mut pending_line: Vec<ComposerCell> = Vec::new();
+    let mut pending_word = Vec::new();
+    let mut pending_whitespace = Vec::new();
+    let mut line_width = 0;
+    let mut word_width = 0;
+    let mut whitespace_width = 0;
+    let mut non_whitespace_previous = false;
+
+    for (logical_column, character) in line.chars().enumerate() {
+        let cell = ComposerCell {
+            character,
+            logical_column,
+            width: display_width(character),
+        };
+        if cell.width > max_width {
+            continue;
+        }
+
+        let is_whitespace = character.is_whitespace();
+        let word_found = non_whitespace_previous && is_whitespace;
+        let untrimmed_overflow =
+            pending_line.is_empty() && word_width + whitespace_width + cell.width > max_width;
+
+        if word_found || untrimmed_overflow {
+            pending_line.append(&mut pending_whitespace);
+            line_width += whitespace_width;
+            pending_line.append(&mut pending_word);
+            line_width += word_width;
+            whitespace_width = 0;
+            word_width = 0;
+        }
+
+        let line_full = line_width >= max_width;
+        let pending_word_overflow =
+            cell.width > 0 && line_width + whitespace_width + word_width >= max_width;
+        if line_full || pending_word_overflow {
+            let mut remaining_width = max_width.saturating_sub(line_width);
+            rows.push(std::mem::take(&mut pending_line));
+            line_width = 0;
+
+            while let Some(whitespace) = pending_whitespace.first() {
+                if whitespace.width > remaining_width {
+                    break;
+                }
+                whitespace_width -= whitespace.width;
+                remaining_width -= whitespace.width;
+                pending_whitespace.remove(0);
+            }
+
+            if is_whitespace && pending_whitespace.is_empty() {
+                continue;
+            }
+        }
+
+        if is_whitespace {
+            whitespace_width += cell.width;
+            pending_whitespace.push(cell);
+        } else {
+            word_width += cell.width;
+            pending_word.push(cell);
+        }
+        non_whitespace_previous = !is_whitespace;
+    }
+
+    pending_line.append(&mut pending_whitespace);
+    pending_line.append(&mut pending_word);
+    if pending_line.is_empty() {
+        rows.push(Vec::new());
+    } else {
+        rows.push(pending_line);
+    }
+    rows
+}
+
+fn display_width(character: char) -> usize {
+    let mut buffer = [0; 4];
+    textwrap::core::display_width(character.encode_utf8(&mut buffer))
+}
+
+pub fn composer_height(
+    terminal_height: u16,
+    input_lines: usize,
+    quote_rows: usize,
+    attachment_rows: usize,
+) -> u16 {
+    let desired = 2_u16
+        .saturating_add(input_lines.max(1) as u16)
+        .saturating_add(quote_rows as u16)
+        .saturating_add(attachment_rows as u16);
+    desired
+        .min(12)
+        .min(terminal_height.saturating_sub(1))
+        .max(1)
+}
+
+pub fn conversation_areas(
+    area: Rect,
+    input_lines: usize,
+    quote_rows: usize,
+    attachment_rows: usize,
+) -> (Rect, Rect) {
+    let composer_height = composer_height(area.height, input_lines, quote_rows, attachment_rows);
+    let [messages, _gap, composer] = Layout::vertical([
+        Constraint::Min(1),
+        Constraint::Length(1),
+        Constraint::Length(composer_height),
+    ])
+    .areas(area);
+    (messages, composer)
+}
+
+pub fn attachment_preview_lines(attachments: &[PendingAttachment]) -> Vec<String> {
+    attachments
+        .iter()
+        .map(|attachment| {
+            let kind = match attachment.kind {
+                wr::FileKind::Image => "Image",
+                wr::FileKind::Video => "Video",
+                wr::FileKind::Audio => "Audio",
+                wr::FileKind::Document => "Document",
+                wr::FileKind::Sticker => "Sticker",
+            };
+            format!("{kind}: {}", attachment.display_name())
+        })
+        .collect()
+}
+
+pub(crate) fn truncate_with_ellipsis(value: &str, width: usize) -> String {
+    if width <= 1 || value.is_empty() {
+        return String::new();
+    }
+    if textwrap::core::display_width(value) <= width {
+        return value.to_owned();
+    }
+    let ellipsis_cost = textwrap::core::display_width("…");
+    let budget = width.saturating_sub(ellipsis_cost);
+    let mut result = String::new();
+    for ch in value.chars() {
+        let next = format!("{result}{ch}");
+        if textwrap::core::display_width(&next) > budget {
+            break;
+        }
+        result = next;
+    }
+    result.push('…');
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_module_exposes_navigation_and_modal_contracts() {
+        let areas = navigation_areas(Rect::new(0, 0, 100, 20), PaneVisibility::default());
+        assert_eq!(areas.conversation, Rect::new(44, 0, 56, 20));
+        assert_eq!(
+            centered_modal_layout(Rect::new(0, 0, 100, 40)),
+            Rect::new(14, 12, 72, 16)
+        );
+        assert_eq!(
+            composer_cursor_position(Rect::new(2, 3, 10, 4), (1, 2)),
+            Position::new(4, 4)
+        );
+    }
+}

--- a/src/ui/message_helpers.rs
+++ b/src/ui/message_helpers.rs
@@ -1,0 +1,202 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Local};
+use ratatui::{
+    style::Style,
+    text::{Line, Span},
+};
+use unicode_segmentation::UnicodeSegmentation;
+use whatsrust as wr;
+
+pub const AUTHOR_GROUP_MAX_GAP: i64 = 5 * 60;
+const REPLY_EXCERPT_MAX_CHARS: usize = 40;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AuthorGroupContext {
+    starts_group: bool,
+}
+
+impl AuthorGroupContext {
+    pub const STARTS_GROUP: Self = Self { starts_group: true };
+    pub const CONTINUATION: Self = Self {
+        starts_group: false,
+    };
+
+    pub const fn starts_group(self) -> bool {
+        self.starts_group
+    }
+
+    pub(crate) const fn new(starts_group: bool) -> Self {
+        Self { starts_group }
+    }
+}
+
+pub fn starts_author_group(previous: Option<&wr::Message>, current: &wr::Message) -> bool {
+    let Some(previous) = previous else {
+        return true;
+    };
+    let same_author = if previous.info.is_from_me || current.info.is_from_me {
+        previous.info.is_from_me && current.info.is_from_me
+    } else {
+        previous.info.sender == current.info.sender
+    };
+    let Some(previous_time) = DateTime::<chrono::Utc>::from_timestamp(previous.info.timestamp, 0)
+        .map(DateTime::<Local>::from)
+    else {
+        return true;
+    };
+    let Some(current_time) = DateTime::<chrono::Utc>::from_timestamp(current.info.timestamp, 0)
+        .map(DateTime::<Local>::from)
+    else {
+        return true;
+    };
+    let elapsed = current.info.timestamp - previous.info.timestamp;
+
+    !same_author
+        || previous_time.date_naive() != current_time.date_naive()
+        || !(0..AUTHOR_GROUP_MAX_GAP).contains(&elapsed)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ForwardingLabel {
+    Forwarded,
+    ForwardedManyTimes,
+}
+
+impl ForwardingLabel {
+    pub(crate) fn text(self) -> &'static str {
+        match self {
+            Self::Forwarded => "Forwarded",
+            Self::ForwardedManyTimes => "Forwarded many times",
+        }
+    }
+}
+
+pub(crate) fn forwarding_label(message: &wr::Message) -> Option<ForwardingLabel> {
+    message.info.forwarding.is_forwarded.then(|| {
+        if message.info.forwarding.score >= 5 {
+            ForwardingLabel::ForwardedManyTimes
+        } else {
+            ForwardingLabel::Forwarded
+        }
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StatusLabel {
+    Edited,
+    Deleted,
+}
+
+impl StatusLabel {
+    pub(crate) fn text(self) -> &'static str {
+        match self {
+            Self::Edited => "(edited)",
+            Self::Deleted => "(deleted)",
+        }
+    }
+}
+
+pub(crate) fn inline_content_lines(
+    body: &str,
+    status: Option<StatusLabel>,
+    width: usize,
+) -> Vec<Line<'static>> {
+    if matches!(status, Some(StatusLabel::Deleted)) {
+        return textwrap::wrap(crate::app::DELETED_MESSAGE_TEXT, width.max(1))
+            .into_iter()
+            .map(|line| Line::styled(line.into_owned(), Style::default().dark_gray()))
+            .collect();
+    }
+    let status_text = status.map(StatusLabel::text);
+    let content = match (body, status_text) {
+        ("", Some(status)) => status.to_owned(),
+        (_, Some(status)) => format!("{body} {status}"),
+        (_, None) => body.to_owned(),
+    };
+    if content.is_empty() {
+        return Vec::new();
+    }
+    let wrapped = textwrap::wrap(&content, width.max(1))
+        .into_iter()
+        .map(|line| line.into_owned())
+        .collect::<Vec<_>>();
+    let mut status_starts = vec![None; wrapped.len()];
+    if let Some(status) = status_text {
+        let mut remaining = status.graphemes(true).collect::<Vec<_>>();
+        for (index, line) in wrapped.iter().enumerate().rev() {
+            let graphemes = line.graphemes(true).collect::<Vec<_>>();
+            if remaining.ends_with(&graphemes) {
+                status_starts[index] = Some(0);
+                remaining.truncate(remaining.len().saturating_sub(graphemes.len()));
+            } else if let Some(start) =
+                (0..graphemes.len()).find(|start| remaining.starts_with(&graphemes[*start..]))
+            {
+                status_starts[index] = Some(start);
+                break;
+            }
+        }
+    }
+    wrapped
+        .iter()
+        .zip(status_starts)
+        .map(|(line, status_start)| {
+            let graphemes = line
+                .graphemes(true)
+                .enumerate()
+                .map(|(index, grapheme)| {
+                    (grapheme, status_start.is_some_and(|start| index >= start))
+                })
+                .collect::<Vec<_>>();
+            inline_line(&graphemes)
+        })
+        .collect()
+}
+
+fn inline_line(graphemes: &[(&str, bool)]) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    for (grapheme, is_status) in graphemes {
+        let style = if *is_status {
+            Style::default().dark_gray()
+        } else {
+            Style::default()
+        };
+        match spans.last_mut() {
+            Some(span) if span.style == style => span.content.to_mut().push_str(grapheme),
+            _ => spans.push(Span::styled((*grapheme).to_owned(), style)),
+        }
+    }
+    Line::from(spans)
+}
+
+pub(crate) fn forwarding_indicator_lines(label: Option<ForwardingLabel>, width: usize) -> usize {
+    label.map_or(0, |label| textwrap::wrap(label.text(), width.max(1)).len())
+}
+
+pub fn reply_summary(message: &wr::Message, author: &str) -> String {
+    format!("> {author}: {}", reply_excerpt(&get_quoted_text(message)))
+}
+
+fn reply_excerpt(text: &str) -> String {
+    let normalized = text.replace(['\n', '\r'], " ");
+    let mut characters = normalized.chars();
+    let excerpt = characters
+        .by_ref()
+        .take(REPLY_EXCERPT_MAX_CHARS)
+        .collect::<String>();
+
+    if characters.next().is_some() {
+        format!("{excerpt}…")
+    } else {
+        excerpt
+    }
+}
+
+pub fn get_quoted_text(msg: &wr::Message) -> Arc<str> {
+    match &msg.message {
+        wr::MessageContent::Text(text) => text.clone(),
+        wr::MessageContent::File(data) => {
+            format!("{}: {}", data.path, data.caption.as_deref().unwrap_or("")).into()
+        }
+    }
+}

--- a/src/ui/message_layout.rs
+++ b/src/ui/message_layout.rs
@@ -1,0 +1,381 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+
+use whatsrust::{self as wr, FileKind};
+
+use super::message_helpers::{
+    AuthorGroupContext, ForwardingLabel, StatusLabel, forwarding_indicator_lines,
+    inline_content_lines,
+};
+
+pub const IMAGE_HEIGHT: usize = 12;
+pub const IMAGE_WIDTH: usize = IMAGE_HEIGHT * 3;
+pub const VIDEO_HEIGHT: usize = IMAGE_HEIGHT;
+pub const VIDEO_WIDTH: usize = 72;
+pub const MESSAGE_HEIGHT_CACHE_CAPACITY: usize = 256;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum OwnedHeightContent {
+    Text {
+        body: Arc<str>,
+        forwarding: Option<ForwardingLabel>,
+        status: Option<StatusLabel>,
+    },
+    File {
+        kind: HeightFileKind,
+        caption: Option<Arc<str>>,
+        preview_loaded: bool,
+        forwarding: Option<ForwardingLabel>,
+        status: Option<StatusLabel>,
+    },
+}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HeightContent<'a> {
+    Text {
+        body: &'a str,
+        forwarding: Option<ForwardingLabel>,
+        status: Option<StatusLabel>,
+    },
+    File {
+        kind: HeightFileKind,
+        caption: Option<&'a str>,
+        preview_loaded: bool,
+        forwarding: Option<ForwardingLabel>,
+        status: Option<StatusLabel>,
+    },
+}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HeightFileKind {
+    Image,
+    Video,
+    Audio,
+    Document,
+    Sticker,
+}
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LayoutInput<'a> {
+    pub(crate) width: usize,
+    pub(crate) is_selected: bool,
+    pub(crate) has_quote: bool,
+    pub(crate) has_reactions: bool,
+    pub(crate) author_group: AuthorGroupContext,
+    pub(crate) content: HeightContent<'a>,
+}
+#[derive(Clone, Debug)]
+struct MessageHeightEntry {
+    input: OwnedLayoutInput,
+    height: usize,
+}
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct OwnedLayoutInput {
+    width: usize,
+    is_selected: bool,
+    has_quote: bool,
+    has_reactions: bool,
+    author_group: AuthorGroupContext,
+    content: OwnedHeightContent,
+}
+impl<'a> From<&LayoutInput<'a>> for OwnedLayoutInput {
+    fn from(input: &LayoutInput<'a>) -> Self {
+        Self {
+            width: input.width,
+            is_selected: input.is_selected,
+            has_quote: input.has_quote,
+            has_reactions: input.has_reactions,
+            author_group: input.author_group,
+            content: match input.content {
+                HeightContent::Text {
+                    body,
+                    forwarding,
+                    status,
+                } => OwnedHeightContent::Text {
+                    body: body.into(),
+                    forwarding,
+                    status,
+                },
+                HeightContent::File {
+                    kind,
+                    caption,
+                    preview_loaded,
+                    forwarding,
+                    status,
+                } => OwnedHeightContent::File {
+                    kind,
+                    caption: caption.map(Into::into),
+                    preview_loaded,
+                    forwarding,
+                    status,
+                },
+            },
+        }
+    }
+}
+impl OwnedLayoutInput {
+    fn matches(&self, input: &LayoutInput<'_>) -> bool {
+        self.width == input.width
+            && self.is_selected == input.is_selected
+            && self.has_quote == input.has_quote
+            && self.has_reactions == input.has_reactions
+            && self.author_group == input.author_group
+            && match (&self.content, input.content) {
+                (
+                    OwnedHeightContent::Text {
+                        body,
+                        forwarding,
+                        status,
+                    },
+                    HeightContent::Text {
+                        body: other,
+                        forwarding: other_forwarding,
+                        status: other_status,
+                    },
+                ) => {
+                    body.as_ref() == other
+                        && *forwarding == other_forwarding
+                        && *status == other_status
+                }
+                (
+                    OwnedHeightContent::File {
+                        kind,
+                        caption,
+                        preview_loaded,
+                        forwarding,
+                        status,
+                    },
+                    HeightContent::File {
+                        kind: other_kind,
+                        caption: other_caption,
+                        preview_loaded: other_preview,
+                        forwarding: other_forwarding,
+                        status: other_status,
+                    },
+                ) => {
+                    *kind == other_kind
+                        && caption.as_deref() == other_caption
+                        && *preview_loaded == other_preview
+                        && *forwarding == other_forwarding
+                        && *status == other_status
+                }
+                _ => false,
+            }
+    }
+}
+#[derive(Debug, Default)]
+pub struct MessageHeightCache {
+    entries: HashMap<wr::MessageId, MessageHeightEntry>,
+    order: VecDeque<wr::MessageId>,
+}
+
+impl MessageHeightCache {
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn contains(&self, id: &str) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    pub fn invalidate(&mut self, id: &wr::MessageId) {
+        self.entries.remove(id);
+        self.order.retain(|cached| cached != id);
+    }
+
+    pub fn retain_messages(&mut self, ids: &[wr::MessageId]) {
+        let retained: HashSet<_> = ids.iter().cloned().collect();
+        self.entries.retain(|id, _| retained.contains(id));
+        self.order.retain(|id| retained.contains(id));
+    }
+
+    fn get(&mut self, id: &wr::MessageId, input: &LayoutInput<'_>) -> Option<usize> {
+        let height = self
+            .entries
+            .get(id)
+            .filter(|entry| entry.input.matches(input))
+            .map(|entry| entry.height)?;
+        self.order.retain(|cached| cached != id);
+        self.order.push_back(id.clone());
+        Some(height)
+    }
+
+    fn insert(&mut self, id: wr::MessageId, input: &LayoutInput<'_>, height: usize) {
+        if !self.entries.contains_key(&id)
+            && self.entries.len() >= MESSAGE_HEIGHT_CACHE_CAPACITY
+            && let Some(oldest) = self.order.pop_front()
+        {
+            self.entries.remove(&oldest);
+        }
+        self.order.retain(|cached| cached != &id);
+        self.order.push_back(id.clone());
+        self.entries.insert(
+            id,
+            MessageHeightEntry {
+                input: input.into(),
+                height,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn text_height(body: &str, width: usize) -> usize {
+    inline_content_lines(body, None, width).len()
+}
+
+pub(crate) fn height(
+    cache: &mut MessageHeightCache,
+    id: &wr::MessageId,
+    input: &LayoutInput<'_>,
+) -> usize {
+    if let Some(height) = cache.get(id, &input) {
+        return height;
+    }
+
+    let content_width = if input.is_selected {
+        input.width.saturating_sub(3)
+    } else {
+        input.width
+    }
+    .max(1);
+    let content_height = match &input.content {
+        HeightContent::Text {
+            body,
+            status,
+            forwarding,
+        } => {
+            inline_content_lines(body, *status, content_width).len()
+                + forwarding_indicator_lines(*forwarding, content_width)
+        }
+        HeightContent::File {
+            kind,
+            caption,
+            preview_loaded,
+            forwarding,
+            status,
+        } => {
+            let caption_height = caption.as_ref().map_or_else(
+                || inline_content_lines("", *status, content_width).len(),
+                |caption| inline_content_lines(caption, *status, content_width).len(),
+            );
+            let file_height = match kind {
+                HeightFileKind::Video if *preview_loaded => VIDEO_HEIGHT,
+                HeightFileKind::Image | HeightFileKind::Sticker if *preview_loaded => IMAGE_HEIGHT,
+                HeightFileKind::Audio => 2,
+                HeightFileKind::Image
+                | HeightFileKind::Video
+                | HeightFileKind::Document
+                | HeightFileKind::Sticker => 1,
+            };
+            file_height + caption_height + forwarding_indicator_lines(*forwarding, content_width)
+        }
+    };
+
+    let height = usize::from(input.author_group.starts_group() || input.is_selected)
+        + usize::from(input.has_quote)
+        + content_height
+        + usize::from(input.has_reactions)
+        + usize::from(input.is_selected);
+    cache.insert(id.clone(), input, height);
+    height
+}
+
+pub(crate) fn file_kind(kind: FileKind) -> HeightFileKind {
+    match kind {
+        FileKind::Image => HeightFileKind::Image,
+        FileKind::Video => HeightFileKind::Video,
+        FileKind::Audio => HeightFileKind::Audio,
+        FileKind::Document => HeightFileKind::Document,
+        FileKind::Sticker => HeightFileKind::Sticker,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(body: &str) -> LayoutInput<'_> {
+        LayoutInput {
+            width: 20,
+            is_selected: false,
+            has_quote: false,
+            has_reactions: false,
+            author_group: AuthorGroupContext::STARTS_GROUP,
+            content: HeightContent::Text {
+                body,
+                forwarding: None,
+                status: None,
+            },
+        }
+    }
+    #[test]
+    fn cache_hit_refreshes_recency_before_eviction() {
+        let mut cache = MessageHeightCache::default();
+        for index in 0..MESSAGE_HEIGHT_CACHE_CAPACITY {
+            let id: Arc<str> = format!("message-{index}").into();
+            height(&mut cache, &id, &text("cached"));
+        }
+        height(&mut cache, &Arc::from("message-0"), &text("cached"));
+        height(&mut cache, &Arc::from("new"), &text("cached"));
+
+        assert!(cache.contains("message-0"));
+        assert!(!cache.contains("message-1"));
+    }
+    #[test]
+    fn same_id_changed_input_replaces_snapshot_and_recalculates() {
+        let mut cache = MessageHeightCache::default();
+        let id: Arc<str> = "same-id".into();
+
+        assert_eq!(height(&mut cache, &id, &text("short")), 2);
+        assert_eq!(
+            height(&mut cache, &id, &text("a body that definitely wraps")),
+            3
+        );
+    }
+    #[test]
+    fn every_file_kind_and_preview_state_has_a_deterministic_height() {
+        let kinds = [
+            HeightFileKind::Image,
+            HeightFileKind::Video,
+            HeightFileKind::Audio,
+            HeightFileKind::Document,
+            HeightFileKind::Sticker,
+        ];
+        let mut cache = MessageHeightCache::default();
+        for (index, kind) in kinds.into_iter().enumerate() {
+            let id: Arc<str> = format!("file-{index}").into();
+            let input = LayoutInput {
+                content: HeightContent::File {
+                    kind,
+                    caption: Some("caption"),
+                    preview_loaded: false,
+                    forwarding: None,
+                    status: None,
+                },
+                ..text("")
+            };
+            assert_eq!(
+                height(&mut cache, &id, &input),
+                if kind == HeightFileKind::Audio { 4 } else { 3 }
+            );
+            if matches!(
+                kind,
+                HeightFileKind::Image | HeightFileKind::Video | HeightFileKind::Sticker
+            ) {
+                let loaded = LayoutInput {
+                    content: HeightContent::File {
+                        kind,
+                        caption: Some("caption"),
+                        preview_loaded: true,
+                        forwarding: None,
+                        status: None,
+                    },
+                    ..text("")
+                };
+                assert!(height(&mut cache, &id, &loaded) > 3);
+            }
+        }
+    }
+}

--- a/src/ui/message_layout.rs
+++ b/src/ui/message_layout.rs
@@ -96,13 +96,13 @@ impl<'a> From<&LayoutInput<'a>> for OwnedLayoutInput {
                 HeightContent::File {
                     kind,
                     caption,
-                    preview_loaded,
+                    preview_loaded: _,
                     forwarding,
                     status,
                 } => OwnedHeightContent::File {
                     kind,
                     caption: caption.map(Into::into),
-                    preview_loaded,
+                    preview_loaded: false,
                     forwarding,
                     status,
                 },
@@ -138,21 +138,20 @@ impl OwnedLayoutInput {
                     OwnedHeightContent::File {
                         kind,
                         caption,
-                        preview_loaded,
+                        preview_loaded: _,
                         forwarding,
                         status,
                     },
                     HeightContent::File {
                         kind: other_kind,
                         caption: other_caption,
-                        preview_loaded: other_preview,
+                        preview_loaded: _,
                         forwarding: other_forwarding,
                         status: other_status,
                     },
                 ) => {
                     *kind == other_kind
                         && caption.as_deref() == other_caption
-                        && *preview_loaded == other_preview
                         && *forwarding == other_forwarding
                         && *status == other_status
                 }
@@ -252,7 +251,7 @@ pub(crate) fn height(
         HeightContent::File {
             kind,
             caption,
-            preview_loaded,
+            preview_loaded: _,
             forwarding,
             status,
         } => {
@@ -261,13 +260,12 @@ pub(crate) fn height(
                 |caption| inline_content_lines(caption, *status, content_width).len(),
             );
             let file_height = match kind {
-                HeightFileKind::Video if *preview_loaded => VIDEO_HEIGHT,
-                HeightFileKind::Image | HeightFileKind::Sticker if *preview_loaded => IMAGE_HEIGHT,
+                // Reserve media geometry independently of the asynchronous
+                // preview lifecycle so the message list cannot reflow.
+                HeightFileKind::Video => VIDEO_HEIGHT,
+                HeightFileKind::Image | HeightFileKind::Sticker => IMAGE_HEIGHT,
                 HeightFileKind::Audio => 2,
-                HeightFileKind::Image
-                | HeightFileKind::Video
-                | HeightFileKind::Document
-                | HeightFileKind::Sticker => 1,
+                HeightFileKind::Document => 1,
             };
             file_height + caption_height + forwarding_indicator_lines(*forwarding, content_width)
         }
@@ -335,7 +333,7 @@ mod tests {
         );
     }
     #[test]
-    fn every_file_kind_and_preview_state_has_a_deterministic_height() {
+    fn every_file_kind_and_preview_state_has_a_stable_height() {
         let kinds = [
             HeightFileKind::Image,
             HeightFileKind::Video,
@@ -358,24 +356,30 @@ mod tests {
             };
             assert_eq!(
                 height(&mut cache, &id, &input),
-                if kind == HeightFileKind::Audio { 4 } else { 3 }
+                match kind {
+                    HeightFileKind::Audio => 4,
+                    HeightFileKind::Image | HeightFileKind::Video | HeightFileKind::Sticker => 14,
+                    HeightFileKind::Document => 3,
+                }
             );
-            if matches!(
-                kind,
-                HeightFileKind::Image | HeightFileKind::Video | HeightFileKind::Sticker
-            ) {
-                let loaded = LayoutInput {
-                    content: HeightContent::File {
-                        kind,
-                        caption: Some("caption"),
-                        preview_loaded: true,
-                        forwarding: None,
-                        status: None,
-                    },
-                    ..text("")
-                };
-                assert!(height(&mut cache, &id, &loaded) > 3);
-            }
+            let loaded = LayoutInput {
+                content: HeightContent::File {
+                    kind,
+                    caption: Some("caption"),
+                    preview_loaded: true,
+                    forwarding: None,
+                    status: None,
+                },
+                ..text("")
+            };
+            assert_eq!(
+                height(&mut cache, &id, &loaded),
+                match kind {
+                    HeightFileKind::Audio => 4,
+                    HeightFileKind::Image | HeightFileKind::Video | HeightFileKind::Sticker => 14,
+                    HeightFileKind::Document => 3,
+                }
+            );
         }
     }
 }

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::{max, min},
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap},
     sync::Arc,
 };
 
@@ -16,22 +16,45 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, StatefulWidget, Widget, Wrap},
 };
 use ratatui_image::StatefulImage;
-use unicode_segmentation::UnicodeSegmentation;
 use whatsrust::{self as wr, FileKind};
 
 use crate::app::events::{AppEvent, AppInput};
 use crate::app::{App, FileMeta, Metadata};
 
-pub const IMAGE_HEIGHT: usize = 12;
-pub const IMAGE_WIDTH: usize = IMAGE_HEIGHT * 3;
-/// Video thumbnails are rendered wider than images (like Concord's 72-column
-/// inline previews) so the play marker and the frame are actually visible.
-/// Height matches image previews so video messages don't tower over photos.
-pub const VIDEO_HEIGHT: usize = IMAGE_HEIGHT;
-pub const VIDEO_WIDTH: usize = 72;
-pub const MESSAGE_HEIGHT_CACHE_CAPACITY: usize = 256;
-pub const AUTHOR_GROUP_MAX_GAP: i64 = 5 * 60;
-const REPLY_EXCERPT_MAX_CHARS: usize = 40;
+#[path = "message_helpers.rs"]
+mod message_helpers;
+#[path = "message_layout.rs"]
+mod message_layout;
+
+pub use message_helpers::{
+    AUTHOR_GROUP_MAX_GAP, AuthorGroupContext, get_quoted_text, reply_summary, starts_author_group,
+};
+use message_helpers::{
+    StatusLabel, forwarding_indicator_lines, forwarding_label, inline_content_lines,
+};
+pub use message_layout::{
+    IMAGE_HEIGHT, IMAGE_WIDTH, MESSAGE_HEIGHT_CACHE_CAPACITY, MessageHeightCache, VIDEO_HEIGHT,
+    VIDEO_WIDTH,
+};
+use message_layout::{LayoutInput, file_kind};
+
+fn status_label(app: &App, message_id: &wr::MessageId) -> Option<StatusLabel> {
+    let status = app.message_status(message_id);
+    status
+        .deleted
+        .then_some(StatusLabel::Deleted)
+        .or_else(|| status.edited.then_some(StatusLabel::Edited))
+}
+
+#[cfg(test)]
+mod layout_contract_tests {
+    #[test]
+    fn text_height_contract_handles_unicode_and_narrow_widths() {
+        assert_eq!(super::message_layout::text_height("café 👩‍💻", 20), 1);
+        assert_eq!(super::message_layout::text_height("café 👩‍💻", 4), 2);
+    }
+}
+
 /// Number of bars in the static audio waveform.
 const AUDIO_WIDGET_BARS: usize = 16;
 
@@ -62,264 +85,6 @@ fn author_color(sender: &wr::JID) -> Color {
         hash = hash.wrapping_mul(0x100_0000_01b3);
     }
     AUTHOR_PALETTE[(hash as usize) % AUTHOR_PALETTE.len()]
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct AuthorGroupContext {
-    starts_group: bool,
-}
-
-impl AuthorGroupContext {
-    pub const STARTS_GROUP: Self = Self { starts_group: true };
-    pub const CONTINUATION: Self = Self {
-        starts_group: false,
-    };
-
-    pub const fn starts_group(self) -> bool {
-        self.starts_group
-    }
-}
-
-pub fn starts_author_group(previous: Option<&wr::Message>, current: &wr::Message) -> bool {
-    let Some(previous) = previous else {
-        return true;
-    };
-    let same_author = if previous.info.is_from_me || current.info.is_from_me {
-        previous.info.is_from_me && current.info.is_from_me
-    } else {
-        previous.info.sender == current.info.sender
-    };
-    let Some(previous_time) = DateTime::<chrono::Utc>::from_timestamp(previous.info.timestamp, 0)
-        .map(DateTime::<Local>::from)
-    else {
-        return true;
-    };
-    let Some(current_time) = DateTime::<chrono::Utc>::from_timestamp(current.info.timestamp, 0)
-        .map(DateTime::<Local>::from)
-    else {
-        return true;
-    };
-    let elapsed = current.info.timestamp - previous.info.timestamp;
-
-    !same_author
-        || previous_time.date_naive() != current_time.date_naive()
-        || !(0..AUTHOR_GROUP_MAX_GAP).contains(&elapsed)
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum HeightContent {
-    Text {
-        body: Arc<str>,
-        forwarding: Option<ForwardingLabel>,
-        status: Option<StatusLabel>,
-    },
-    File {
-        kind: HeightFileKind,
-        caption: Option<Arc<str>>,
-        preview_loaded: bool,
-        forwarding: Option<ForwardingLabel>,
-        status: Option<StatusLabel>,
-    },
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ForwardingLabel {
-    Forwarded,
-    ForwardedManyTimes,
-}
-
-impl ForwardingLabel {
-    fn text(self) -> &'static str {
-        match self {
-            Self::Forwarded => "Forwarded",
-            Self::ForwardedManyTimes => "Forwarded many times",
-        }
-    }
-}
-
-fn forwarding_label(message: &wr::Message) -> Option<ForwardingLabel> {
-    message.info.forwarding.is_forwarded.then(|| {
-        if message.info.forwarding.score >= 5 {
-            ForwardingLabel::ForwardedManyTimes
-        } else {
-            ForwardingLabel::Forwarded
-        }
-    })
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum StatusLabel {
-    Edited,
-    Deleted,
-}
-
-impl StatusLabel {
-    fn text(self) -> &'static str {
-        match self {
-            Self::Edited => "(edited)",
-            Self::Deleted => "(deleted)",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum HeightFileKind {
-    Image,
-    Video,
-    Audio,
-    Document,
-    Sticker,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct MessageHeightInput {
-    width: usize,
-    is_selected: bool,
-    has_quote: bool,
-    has_reactions: bool,
-    author_group: AuthorGroupContext,
-    content: HeightContent,
-}
-
-fn status_label(app: &App, message_id: &wr::MessageId) -> Option<StatusLabel> {
-    let status = app.message_status(message_id);
-    status
-        .deleted
-        .then_some(StatusLabel::Deleted)
-        .or_else(|| status.edited.then_some(StatusLabel::Edited))
-}
-
-fn inline_content_lines(
-    body: &str,
-    status: Option<StatusLabel>,
-    width: usize,
-) -> Vec<Line<'static>> {
-    if matches!(status, Some(StatusLabel::Deleted)) {
-        return textwrap::wrap(crate::app::DELETED_MESSAGE_TEXT, width.max(1))
-            .into_iter()
-            .map(|line| Line::styled(line.into_owned(), Style::default().dark_gray()))
-            .collect();
-    }
-    let status_text = status.map(StatusLabel::text);
-    let content = match (body, status_text) {
-        ("", Some(status)) => status.to_owned(),
-        (_, Some(status)) => format!("{body} {status}"),
-        (_, None) => body.to_owned(),
-    };
-    if content.is_empty() {
-        return Vec::new();
-    }
-    let wrapped = textwrap::wrap(&content, width.max(1))
-        .into_iter()
-        .map(|line| line.into_owned())
-        .collect::<Vec<_>>();
-    let mut status_starts = vec![None; wrapped.len()];
-    if let Some(status) = status_text {
-        let mut remaining = status.graphemes(true).collect::<Vec<_>>();
-        for (index, line) in wrapped.iter().enumerate().rev() {
-            let graphemes = line.graphemes(true).collect::<Vec<_>>();
-            if remaining.ends_with(&graphemes) {
-                status_starts[index] = Some(0);
-                remaining.truncate(remaining.len().saturating_sub(graphemes.len()));
-            } else if let Some(start) =
-                (0..graphemes.len()).find(|start| remaining.starts_with(&graphemes[*start..]))
-            {
-                status_starts[index] = Some(start);
-                break;
-            }
-        }
-    }
-    wrapped
-        .iter()
-        .zip(status_starts)
-        .map(|(line, status_start)| {
-            let graphemes = line
-                .graphemes(true)
-                .enumerate()
-                .map(|(index, grapheme)| {
-                    (grapheme, status_start.is_some_and(|start| index >= start))
-                })
-                .collect::<Vec<_>>();
-            inline_line(&graphemes)
-        })
-        .collect()
-}
-
-fn inline_line(graphemes: &[(&str, bool)]) -> Line<'static> {
-    let mut spans: Vec<Span<'static>> = Vec::new();
-    for (grapheme, is_status) in graphemes {
-        let style = if *is_status {
-            Style::default().dark_gray()
-        } else {
-            Style::default()
-        };
-        match spans.last_mut() {
-            Some(span) if span.style == style => span.content.to_mut().push_str(grapheme),
-            _ => spans.push(Span::styled((*grapheme).to_owned(), style)),
-        }
-    }
-    Line::from(spans)
-}
-
-#[derive(Clone, Debug)]
-struct MessageHeightEntry {
-    input: MessageHeightInput,
-    height: usize,
-}
-
-#[derive(Debug, Default)]
-pub struct MessageHeightCache {
-    entries: HashMap<wr::MessageId, MessageHeightEntry>,
-    order: VecDeque<wr::MessageId>,
-}
-
-impl MessageHeightCache {
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
-    pub fn contains(&self, id: &str) -> bool {
-        self.entries.contains_key(id)
-    }
-
-    pub fn invalidate(&mut self, id: &wr::MessageId) {
-        self.entries.remove(id);
-        self.order.retain(|cached| cached != id);
-    }
-
-    pub fn retain_messages(&mut self, ids: &[wr::MessageId]) {
-        let retained: HashSet<_> = ids.iter().cloned().collect();
-        self.entries.retain(|id, _| retained.contains(id));
-        self.order.retain(|id| retained.contains(id));
-    }
-
-    fn get(&mut self, id: &wr::MessageId, input: &MessageHeightInput) -> Option<usize> {
-        let height = self
-            .entries
-            .get(id)
-            .filter(|entry| entry.input == *input)
-            .map(|entry| entry.height)?;
-        self.order.retain(|cached| cached != id);
-        self.order.push_back(id.clone());
-        Some(height)
-    }
-
-    fn insert(&mut self, id: wr::MessageId, input: MessageHeightInput, height: usize) {
-        if !self.entries.contains_key(&id)
-            && self.entries.len() >= MESSAGE_HEIGHT_CACHE_CAPACITY
-            && let Some(oldest) = self.order.pop_front()
-        {
-            self.entries.remove(&oldest);
-        }
-        self.order.retain(|cached| cached != &id);
-        self.order.push_back(id.clone());
-        self.entries
-            .insert(id, MessageHeightEntry { input, height });
-    }
 }
 
 fn message_block<'a>(
@@ -356,25 +121,6 @@ fn message_content_area(area: Rect, is_selected: bool) -> Rect {
         )
     } else {
         area
-    }
-}
-
-pub fn reply_summary(message: &wr::Message, author: &str) -> String {
-    format!("> {author}: {}", reply_excerpt(&get_quoted_text(message)))
-}
-
-fn reply_excerpt(text: &str) -> String {
-    let normalized = text.replace(['\n', '\r'], " ");
-    let mut characters = normalized.chars();
-    let excerpt = characters
-        .by_ref()
-        .take(REPLY_EXCERPT_MAX_CHARS)
-        .collect::<String>();
-
-    if characters.next().is_some() {
-        format!("{excerpt}…")
-    } else {
-        excerpt
     }
 }
 
@@ -421,10 +167,6 @@ pub fn reaction_chips(reactions: Option<&HashMap<wr::JID, Arc<str>>>) -> Vec<Str
         .collect()
 }
 
-fn forwarding_indicator_lines(label: Option<ForwardingLabel>, width: usize) -> usize {
-    label.map_or(0, |label| textwrap::wrap(label.text(), width.max(1)).len())
-}
-
 pub fn message_height(
     message: &wr::Message,
     width: usize,
@@ -432,33 +174,21 @@ pub fn message_height(
     author_group: AuthorGroupContext,
     app: &mut App,
 ) -> usize {
-    let content_width = if is_selected {
-        width.saturating_sub(3)
-    } else {
-        width
-    }
-    .max(1);
-    let input = MessageHeightInput {
+    let input = LayoutInput {
         width,
         is_selected,
         has_quote: message.info.quote_id.is_some(),
         has_reactions: app.reactions.contains_key(&message.info.id),
         author_group,
         content: match &message.message {
-            wr::MessageContent::Text(text) => HeightContent::Text {
-                body: text.clone(),
+            wr::MessageContent::Text(text) => message_layout::HeightContent::Text {
+                body: text,
                 forwarding: forwarding_label(message),
                 status: status_label(app, &message.info.id),
             },
-            wr::MessageContent::File(file) => HeightContent::File {
-                kind: match file.kind {
-                    FileKind::Image => HeightFileKind::Image,
-                    FileKind::Video => HeightFileKind::Video,
-                    FileKind::Audio => HeightFileKind::Audio,
-                    FileKind::Document => HeightFileKind::Document,
-                    FileKind::Sticker => HeightFileKind::Sticker,
-                },
-                caption: file.caption.clone(),
+            wr::MessageContent::File(file) => message_layout::HeightContent::File {
+                kind: file_kind(file.kind.clone()),
+                caption: file.caption.as_deref(),
                 forwarding: forwarding_label(message),
                 preview_loaded: matches!(
                     app.metadata.get(&message.info.id),
@@ -468,52 +198,7 @@ pub fn message_height(
             },
         },
     };
-    if let Some(height) = app.message_height_cache.get(&message.info.id, &input) {
-        return height;
-    }
-
-    let content_height = match &input.content {
-        HeightContent::Text {
-            body,
-            status,
-            forwarding,
-        } => {
-            inline_content_lines(body, *status, content_width).len()
-                + forwarding_indicator_lines(*forwarding, content_width)
-        }
-        HeightContent::File {
-            kind,
-            caption,
-            preview_loaded,
-            forwarding,
-            status,
-        } => {
-            let caption_height = caption.as_ref().map_or_else(
-                || inline_content_lines("", *status, content_width).len(),
-                |caption| inline_content_lines(caption, *status, content_width).len(),
-            );
-            let file_height = match kind {
-                HeightFileKind::Video if *preview_loaded => VIDEO_HEIGHT,
-                HeightFileKind::Image | HeightFileKind::Sticker if *preview_loaded => IMAGE_HEIGHT,
-                // Audio keeps the file line plus a static play bar.
-                HeightFileKind::Audio => 2,
-                HeightFileKind::Image
-                | HeightFileKind::Video
-                | HeightFileKind::Document
-                | HeightFileKind::Sticker => 1,
-            };
-            file_height + caption_height + forwarding_indicator_lines(*forwarding, content_width)
-        }
-    };
-
-    let height = usize::from(input.author_group.starts_group() || input.is_selected)
-        + usize::from(input.has_quote)
-        + content_height
-        + usize::from(input.has_reactions)
-        + usize::from(input.is_selected);
-    app.message_height_cache
-        .insert(message.info.id.clone(), input, height);
-    height
+    message_layout::height(&mut app.message_height_cache, &message.info.id, &input)
 }
 
 fn spacing_after_message(
@@ -921,8 +606,8 @@ fn render_message_items(
     let author_groups = items
         .iter()
         .enumerate()
-        .map(|(index, message)| AuthorGroupContext {
-            starts_group: starts_author_group(items.get(index + 1), message),
+        .map(|(index, message)| {
+            AuthorGroupContext::new(starts_author_group(items.get(index + 1), message))
         })
         .collect::<Vec<_>>();
 
@@ -1254,15 +939,6 @@ impl MessageListState {
             self.update_selected = false;
         } else {
             self.select(Some(index.min(item_count - 1)));
-        }
-    }
-}
-
-pub fn get_quoted_text(msg: &wr::Message) -> Arc<str> {
-    match &msg.message {
-        wr::MessageContent::Text(text) => text.clone(),
-        wr::MessageContent::File(data) => {
-            format!("{}: {}", data.path, data.caption.as_deref().unwrap_or("")).into()
         }
     }
 }

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -124,19 +124,12 @@ fn message_content_area(area: Rect, is_selected: bool) -> Rect {
     }
 }
 
-fn file_content_height(id: &wr::MessageId, file: &wr::FileContent, app: &mut App) -> usize {
+fn file_content_height(_id: &wr::MessageId, file: &wr::FileContent, _app: &mut App) -> usize {
     match file.kind {
-        FileKind::Image | FileKind::Sticker | FileKind::Video => match app.metadata.get(id) {
-            None => 1,
-            Some(Metadata::File(meta)) => match meta {
-                FileMeta::Downloading
-                | FileMeta::DownloadFailed
-                | FileMeta::Downloaded
-                | FileMeta::LoadFailed
-                | FileMeta::Loading => 1,
-                FileMeta::Loaded => preview_height(&file.kind),
-            },
-        },
+        // Media previews occupy their final block from the first render. The
+        // preview lifecycle changes only the contents of this block, never its
+        // geometry.
+        FileKind::Image | FileKind::Sticker | FileKind::Video => preview_height(&file.kind),
         // Audio renders a static play bar under the file line, so it takes
         // two rows. Must stay in sync with `message_height`.
         FileKind::Audio => 2,

--- a/src/ui/navigation.rs
+++ b/src/ui/navigation.rs
@@ -1,0 +1,108 @@
+use crate::app::App;
+use crate::app::actions::{FocusPane, Section};
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, List, ListItem, Paragraph},
+};
+use tui_logger::TuiLoggerWidget;
+
+pub(super) fn render_section_rail(frame: &mut Frame, app: &App, area: Rect) {
+    let mut items = Section::ALL
+        .iter()
+        .map(|section| {
+            ListItem::new(Section::title(*section)).style(Style::default().fg(Color::White))
+        })
+        .collect::<Vec<_>>();
+    items.push(
+        ListItem::new(crate::app::actions::LOGOUT_RAIL_TITLE)
+            .style(Style::default().fg(Color::Red)),
+    );
+    let selected = if app.rail_on_logout {
+        items.len() - 1
+    } else {
+        Section::ALL
+            .iter()
+            .position(|section| *section == app.selected_section)
+            .unwrap_or(0)
+    };
+    let mut state = ratatui::widgets::ListState::default().with_selected(Some(selected));
+    let list = List::new(items)
+        .block(
+            Block::bordered()
+                .title("Sections")
+                .border_style(
+                    Style::default().fg(if app.focus_pane == FocusPane::SectionRail {
+                        ratatui::style::Color::Green
+                    } else {
+                        ratatui::style::Color::White
+                    }),
+                ),
+        )
+        .highlight_symbol("> ")
+        .highlight_style(if app.rail_on_logout {
+            Style::default().red()
+        } else {
+            Style::default().green()
+        });
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+pub(super) fn render_structural_placeholder(frame: &mut Frame, app: &App, area: Rect) {
+    let section = app.selected_section.title();
+    frame.render_widget(
+        Paragraph::new(format!("{section} is not available yet."))
+            .block(Block::bordered().title(section)),
+        area,
+    );
+}
+
+pub(super) fn render_logout_placeholder(frame: &mut Frame, app: &App, area: Rect) {
+    let content = if app.logout_in_progress {
+        "Logging out…\n\nThis removes the device from WhatsApp and clears the local session."
+            .to_string()
+    } else if app.pending_logout {
+        let menu_lines = ["Confirm logout", "Cancel"]
+            .iter()
+            .enumerate()
+            .map(|(index, label)| {
+                if index == app.logout_menu_index {
+                    format!("> {label}")
+                } else {
+                    format!("  {label}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "This removes the device from WhatsApp and clears the local session.\n\n{menu_lines}\n\nj/k move · Enter confirms · Esc cancels"
+        )
+    } else {
+        "Press Enter to sign out.\nThis removes the device from WhatsApp and clears the local session.".to_string()
+    };
+    frame.render_widget(
+        Paragraph::new(content)
+            .block(
+                Block::bordered()
+                    .title(crate::app::actions::LOGOUT_RAIL_TITLE)
+                    .border_style(Style::default().fg(Color::Red)),
+            )
+            .style(Style::default().fg(Color::Red)),
+        area,
+    );
+}
+
+pub(super) fn render_logs(frame: &mut Frame, area: Rect) {
+    let log_widget = TuiLoggerWidget::default()
+        .style_trace(Style::new().dark_gray())
+        .style_debug(Style::new().blue())
+        .style_warn(Style::new().yellow())
+        .style_error(Style::new().red().bold())
+        .block(
+            Block::default()
+                .title("Logs")
+                .borders(ratatui::widgets::Borders::ALL),
+        );
+    frame.render_widget(log_widget, area);
+}

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -1,0 +1,66 @@
+use super::status_list::{StatusList, StatusListItem};
+use crate::app::App;
+use crate::app::actions::FocusPane;
+use crate::ui::message_list::render_status_messages;
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Paragraph, Widget},
+};
+
+pub(super) fn render_status_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
+    let items = app
+        .status_contacts
+        .iter()
+        .map(|contact| StatusListItem::from_contact(app, contact))
+        .collect::<Vec<_>>();
+
+    let block = Block::bordered()
+        .title("Status")
+        .border_style(
+            Style::default().fg(if app.focus_pane == FocusPane::ChatList {
+                Color::Green
+            } else {
+                Color::White
+            }),
+        );
+    let list_area = block.inner(area);
+    block.render(area, frame.buffer_mut());
+
+    if items.is_empty() {
+        frame.render_widget(Paragraph::new("No statuses yet"), list_area);
+        return;
+    }
+    frame.render_stateful_widget(
+        StatusList::new(&items),
+        list_area,
+        &mut app.status_selection,
+    );
+}
+
+pub(super) fn render_statuses(frame: &mut Frame, app: &mut App, area: Rect) {
+    let title = app
+        .open_status_contact()
+        .map(|contact| app.contact_name(&contact).to_string())
+        .unwrap_or_else(|| "Status".to_string());
+    let border_color = if app.focus_pane == FocusPane::Conversation {
+        Color::Green
+    } else {
+        Color::White
+    };
+    let block = Block::bordered()
+        .title(title)
+        .border_style(Style::default().fg(border_color));
+    let content_area = block.inner(area);
+    block.render(area, frame.buffer_mut());
+
+    if app.open_status_contact().is_none() {
+        frame.render_widget(
+            Paragraph::new("Select a contact to view their statuses"),
+            content_area,
+        );
+        return;
+    }
+    render_status_messages(frame, app, content_area);
+}

--- a/tests/communities.rs
+++ b/tests/communities.rs
@@ -1,0 +1,244 @@
+mod common;
+
+use common::TestApp;
+use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+use whatsrust as wr;
+use wp_tui::{
+    app::{
+        Chat, CommunityNode,
+        actions::{AppAction, FocusPane, Section},
+    },
+    ui::message_list::render_messages,
+};
+
+fn jid(value: &str) -> wr::JID {
+    wr::JID::from(value.to_owned())
+}
+
+fn message(chat: &wr::JID, id: &str, timestamp: i64, text: &str, read_by: u16) -> wr::Message {
+    wr::Message {
+        info: wr::MessageInfo {
+            id: id.into(),
+            chat: chat.clone(),
+            sender: jid("member@s.whatsapp.net"),
+            timestamp,
+            is_from_me: false,
+            quote_id: None,
+            read_by,
+            forwarding: Default::default(),
+        },
+        message: wr::MessageContent::Text(text.into()),
+    }
+}
+
+#[test]
+fn opening_selected_community_renders_the_existing_chat_context() {
+    let mut test_app = TestApp::new();
+    let group = wr::JID::from("child@g.us".to_owned());
+    test_app.communities = vec![CommunityNode {
+        jid: group.clone(),
+        name: "Announcements".into(),
+        is_root: false,
+        linked_groups: Vec::new(),
+    }];
+    test_app.selected_section = Section::Communities;
+    test_app.focus_pane = FocusPane::ChatList;
+    test_app.chat_list_state.select(Some(0));
+    test_app.add_message(wr::Message {
+        info: wr::MessageInfo {
+            id: "community-message".into(),
+            chat: group.clone(),
+            sender: group.clone(),
+            timestamp: 1_700_000_000,
+            is_from_me: false,
+            quote_id: None,
+            read_by: 0,
+            forwarding: Default::default(),
+        },
+        message: wr::MessageContent::Text("community context".into()),
+    });
+
+    test_app.dispatch_action(AppAction::OpenChat);
+    assert_eq!(test_app.open_chat(), Some(group));
+    assert_eq!(test_app.focus_pane, FocusPane::Conversation);
+
+    let mut terminal = Terminal::new(TestBackend::new(40, 8)).unwrap();
+    terminal
+        .draw(|frame| {
+            render_messages(frame, &mut test_app, Rect::new(0, 0, 40, 8));
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer();
+    let rendered = (0..buffer.area().height)
+        .map(|y| {
+            (0..buffer.area().width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("community context"), "{rendered}");
+}
+
+#[test]
+fn community_row_collapses_linked_groups_and_preserves_latest_target() {
+    let mut app = TestApp::new();
+    let root = jid("community@g.us");
+    let first = jid("first@g.us");
+    let second = jid("second@g.us");
+    app.contacts.insert(first.clone(), "First Group".into());
+    app.contacts.insert(second.clone(), "Second Group".into());
+    app.chats.insert(
+        first.clone(),
+        Chat {
+            jid: first.clone(),
+            last_message_time: Some(10),
+        },
+    );
+    app.chats.insert(
+        second.clone(),
+        Chat {
+            jid: second.clone(),
+            last_message_time: Some(20),
+        },
+    );
+    app.sorted_chats = vec![first.clone(), second.clone()];
+    app.communities = vec![CommunityNode {
+        jid: root,
+        name: "Project Team".into(),
+        is_root: true,
+        linked_groups: vec![first.clone(), second.clone()],
+    }];
+    app.add_message(message(&first, "one", 10, "old", 0));
+    app.add_message(message(&second, "two", 20, "new", 0));
+
+    let rows = app.chat_rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].label, "Project Team");
+    assert_eq!(rows[0].target, second);
+    assert!(app.chats.contains_key(&first));
+    assert!(app.chats.contains_key(&second));
+}
+
+#[test]
+fn community_search_matches_community_and_member_names_without_hiding_normal_chats() {
+    let mut app = TestApp::new();
+    let group = jid("group@g.us");
+    let direct = jid("direct@s.whatsapp.net");
+    app.contacts.insert(group.clone(), "Release Crew".into());
+    app.contacts.insert(direct.clone(), "Alice".into());
+    app.chats.insert(
+        group.clone(),
+        Chat {
+            jid: group.clone(),
+            last_message_time: Some(10),
+        },
+    );
+    app.chats.insert(
+        direct.clone(),
+        Chat {
+            jid: direct.clone(),
+            last_message_time: Some(5),
+        },
+    );
+    app.sorted_chats = vec![group.clone(), direct.clone()];
+    app.communities = vec![CommunityNode {
+        jid: jid("community@g.us"),
+        name: "Engineering".into(),
+        is_root: true,
+        linked_groups: vec![group],
+    }];
+
+    app.contact_search.input = "engineering".into();
+    assert_eq!(app.visible_chat_rows().len(), 1);
+    app.contact_search.input = "release".into();
+    assert_eq!(app.visible_chat_rows().len(), 1);
+    app.contact_search.input = "alice".into();
+    assert_eq!(app.visible_chat_rows()[0].target, direct);
+}
+
+#[test]
+fn latest_message_changes_community_order_and_activation_target() {
+    let mut app = TestApp::new();
+    let first = jid("first@g.us");
+    let second = jid("second@g.us");
+    let other = jid("other@s.whatsapp.net");
+    for chat in [&first, &second, &other] {
+        app.chats.insert(
+            chat.clone(),
+            Chat {
+                jid: chat.clone(),
+                last_message_time: Some(1),
+            },
+        );
+    }
+    app.sorted_chats = vec![first.clone(), second.clone(), other];
+    app.communities = vec![CommunityNode {
+        jid: jid("community@g.us"),
+        name: "Community".into(),
+        is_root: true,
+        linked_groups: vec![first.clone(), second.clone()],
+    }];
+    app.add_message(message(&first, "first-message", 100, "first", 1));
+    app.add_message(message(&second, "second-message", 200, "second", 1));
+    let row = &app.chat_rows()[0];
+    assert_eq!(row.target, second);
+    app.chat_list_state.select(Some(0));
+    app.dispatch_action(AppAction::OpenChat);
+    assert_eq!(app.open_chat(), Some(second));
+}
+
+#[test]
+fn hierarchy_refresh_keeps_selection_on_a_linked_group_when_target_changes() {
+    let mut app = TestApp::new();
+    let first = jid("first@g.us");
+    let second = jid("second@g.us");
+    let root = jid("community@g.us");
+    app.chats.insert(
+        first.clone(),
+        Chat {
+            jid: first.clone(),
+            last_message_time: Some(10),
+        },
+    );
+    app.chats.insert(
+        second.clone(),
+        Chat {
+            jid: second.clone(),
+            last_message_time: Some(20),
+        },
+    );
+    app.sorted_chats = vec![first.clone(), second.clone()];
+    app.communities = vec![CommunityNode {
+        jid: root.clone(),
+        name: "Community".into(),
+        is_root: true,
+        linked_groups: vec![first.clone(), second.clone()],
+    }];
+    app.chat_list_state.select(Some(0));
+    let selected = app.get_selected_chat();
+    app.refresh_communities(|| {
+        Ok(vec![
+            wr::CommunityInfo {
+                jid: root.clone(),
+                name: "Community".into(),
+                parent_jid: None,
+                is_parent: true,
+            },
+            wr::CommunityInfo {
+                jid: first.clone(),
+                name: "First".into(),
+                parent_jid: Some(root.clone()),
+                is_parent: false,
+            },
+            wr::CommunityInfo {
+                jid: second.clone(),
+                name: "Second".into(),
+                parent_jid: Some(root),
+                is_parent: false,
+            },
+        ])
+    });
+    assert_eq!(app.get_selected_chat(), selected);
+    assert_eq!(app.chat_rows()[0].target, second);
+}

--- a/tests/contact_list_rows.rs
+++ b/tests/contact_list_rows.rs
@@ -7,6 +7,8 @@ use ratatui::{
     widgets::{ListState, StatefulWidget},
 };
 use whatsrust::{JID, Message, MessageContent, MessageInfo};
+use wp_tui::app::actions::{PaneVisibility, Section};
+use wp_tui::app::contact_avatars::prioritized_avatar_requests;
 use wp_tui::ui::{
     self,
     contact_list::{
@@ -15,6 +17,9 @@ use wp_tui::ui::{
 };
 mod common;
 use common::TestApp;
+
+const UI_SOURCE: &str = include_str!("../src/ui.rs");
+const CONTACTS_SOURCE: &str = include_str!("../src/ui/contacts.rs");
 
 #[test]
 fn initials_are_deterministic_for_names_and_unicode() {
@@ -149,6 +154,122 @@ fn search_list_renders_the_same_two_row_item_and_preserves_its_selection() {
     assert!(rows.iter().any(|row| row.contains("Visible Contact")));
     assert!(rows.iter().any(|row| row.contains("preview")));
     assert!(!rows.iter().any(|row| row.contains("Hidden Contact")));
+}
+
+#[test]
+fn visible_chats_preserve_search_geometry_and_selected_contact_rendering() {
+    let mut app = TestApp::new();
+    let selected = JID::from("selected@example.test".to_owned());
+    app.contacts
+        .insert(selected.clone(), "Selected Contact".into());
+    app.sorted_chats = vec![selected.clone()];
+    app.filtered_chats = vec![selected.clone()];
+    app.contact_search.input = "sel".to_owned();
+    app.contact_search.character_index = 2;
+    app.contact_search_active = true;
+    app.chat_list_state.select(Some(0));
+
+    let mut terminal = Terminal::new(TestBackend::new(100, 10)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    let rows = terminal
+        .backend()
+        .buffer()
+        .content()
+        .chunks(100)
+        .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+        .collect::<Vec<_>>();
+
+    assert!(rows.iter().any(|row| row.contains("/sel")));
+    assert!(rows.iter().any(|row| row.contains("Selected Contact")));
+    assert_eq!(app.chat_list_state.selected(), Some(0));
+}
+
+#[test]
+fn avatar_requests_are_selected_first_then_visible_then_overscan() {
+    let chats = (0..8)
+        .map(|index| JID::from(format!("chat-{index}@example.test")))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        prioritized_avatar_requests(&chats, Some(6), 3, 2),
+        vec![
+            chats[6].clone(),
+            chats[3].clone(),
+            chats[4].clone(),
+            chats[0].clone(),
+            chats[1].clone(),
+            chats[2].clone(),
+            chats[5].clone(),
+            chats[7].clone()
+        ]
+    );
+}
+
+#[test]
+fn contacts_module_owns_orchestration_and_preserves_draw_guards() {
+    for symbol in [
+        "render_contacts",
+        "contact_visible_range",
+        "prioritized_avatar_requests",
+        "app.contact_avatars.schedule",
+        "AVATAR_WIDTH",
+        "AVATAR_HEIGHT",
+        "protocol_mut",
+    ] {
+        assert!(CONTACTS_SOURCE.contains(symbol), "contacts owns {symbol}");
+        assert_eq!(UI_SOURCE.matches(&format!("fn {symbol}")).count(), 0);
+    }
+    assert!(CONTACTS_SOURCE.contains("if avatar_area.width == AVATAR_WIDTH"));
+    assert!(CONTACTS_SOURCE.contains("&& avatar_area.height == AVATAR_HEIGHT"));
+    assert!(UI_SOURCE.contains("app.contact_avatars.clear_window();"));
+    assert!(!CONTACTS_SOURCE.contains("pub fn"));
+}
+
+#[test]
+fn hidden_chats_clear_avatar_window_before_rendering_without_invalid_placement() {
+    let mut app = TestApp::new();
+    app.selected_section = Section::Chats;
+    app.pane_visibility = PaneVisibility {
+        section_rail: true,
+        chat_list: false,
+    };
+    app.sorted_chats = vec![JID::from("hidden@example.test".to_owned())];
+
+    let mut terminal = Terminal::new(TestBackend::new(24, 8)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    assert!(
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .any(|cell| cell.symbol() == "C")
+    );
+    assert!(UI_SOURCE.contains("if let Some(area) = areas.chat_list"));
+    assert!(UI_SOURCE.contains("else {\n            app.contact_avatars.clear_window();"));
+}
+
+#[test]
+fn composition_root_keeps_chats_before_overlays() {
+    let draw_source = UI_SOURCE
+        .split_once("pub fn draw")
+        .and_then(|(_, source)| source.split_once("pub fn render_chats"))
+        .map(|(source, _)| source)
+        .expect("draw source should remain in ui.rs");
+    let order = [
+        "render_contacts",
+        "render_chats",
+        "render_attachment_viewer",
+        "render_url_picker",
+        "render_share_picker",
+        "render_file_picker",
+    ];
+    let mut previous = 0;
+    for symbol in order {
+        let current = draw_source.find(symbol).expect("draw call should remain");
+        assert!(current >= previous, "draw order changed at {symbol}");
+        previous = current;
+    }
 }
 
 fn item(name: &str, preview: &str) -> ContactListItem {

--- a/tests/contact_list_rows.rs
+++ b/tests/contact_list_rows.rs
@@ -93,7 +93,7 @@ fn zero_narrow_and_one_row_areas_do_not_panic_or_move_by_terminal_row() {
 }
 
 #[test]
-fn item_uses_latest_message_preview_and_local_time_without_inventing_unread_state() {
+fn item_uses_latest_message_preview_and_local_time_without_an_unread_counter() {
     let mut app = TestApp::new();
     let chat = JID::from("chat@example.test".to_owned());
     app.contacts.insert(chat.clone(), "Alice Example".into());
@@ -109,8 +109,6 @@ fn item_uses_latest_message_preview_and_local_time_without_inventing_unread_stat
     assert_eq!(item.name, "Alice Example");
     assert_eq!(item.preview, "newest");
     assert!(item.local_time.is_some());
-    // Unread totals are optional until the backend exposes truthful per-chat read state.
-    assert_eq!(item.unread_count, None);
 }
 
 #[test]
@@ -157,7 +155,6 @@ fn item(name: &str, preview: &str) -> ContactListItem {
         initials: initials(name),
         preview: preview.to_owned(),
         local_time: None,
-        unread_count: None,
     }
 }
 

--- a/tests/conversation_layout.rs
+++ b/tests/conversation_layout.rs
@@ -117,6 +117,14 @@ fn composer_wraps_visually_without_mutating_its_logical_lines() {
 }
 
 #[test]
+fn empty_composer_input_keeps_one_visual_row_and_origin_cursor() {
+    let lines = vec![String::new()];
+
+    assert_eq!(composer_visual_rows(&lines, 8), 1);
+    assert_eq!(composer_visual_cursor(&lines, (0, 0), 8), (0, 0));
+}
+
+#[test]
 fn composer_cursor_follows_a_word_moved_to_the_next_visual_row() {
     let width = 8;
     let mut line = "hello wo".to_owned();
@@ -244,6 +252,41 @@ fn composer_renders_a_word_on_the_same_row_as_its_cursor() {
         (1, 5)
     );
     assert_eq!(app.composer.text(), "hello world");
+}
+
+#[test]
+fn composer_scrolls_to_keep_the_selected_cursor_row_visible() {
+    let mut app = TestApp::new();
+    let chat = JID::from("chat@example.test".to_owned());
+    app.sorted_chats.push(chat.clone());
+    app.open_chat = Some(chat);
+    app.chat_list_state.select(Some(0));
+    app.conversation_mode = wp_tui::app::actions::ConversationMode::ComposerEditing;
+    app.pane_visibility = PaneVisibility {
+        section_rail: false,
+        chat_list: false,
+    };
+    app.composer.insert_text("one\ntwo\nthree\nfour\nfive");
+
+    let backend = TestBackend::new(20, 8);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| ui::draw(frame, &mut app))
+        .expect("chat should render");
+
+    let rows = terminal
+        .backend()
+        .buffer()
+        .content()
+        .chunks(20)
+        .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+        .collect::<Vec<_>>();
+
+    assert!(rows.iter().any(|row| row.contains("four")), "{rows:?}");
+    assert!(rows.iter().any(|row| row.contains("five")), "{rows:?}");
+    assert!(!rows.iter().any(|row| row.contains("one")), "{rows:?}");
+    assert!(!rows.iter().any(|row| row.contains("two")), "{rows:?}");
+    assert!(!rows.iter().any(|row| row.contains("three")), "{rows:?}");
 }
 
 #[test]
@@ -408,4 +451,16 @@ fn chat_border_truncates_long_action_notice_with_ellipsis() {
 
     assert!(row.contains("Alice"), "name still on the left: {row:?}");
     assert!(row.contains("…"), "notice should be truncated: {row:?}");
+}
+
+#[test]
+fn chat_border_truncates_unicode_action_notice_within_cell_width() {
+    let payload = "界".repeat(60);
+    let row = draw_top_row(100, |app| {
+        app.action_notice = Some(wp_tui::app::actions::ActionNotice::CopiedText(payload));
+    });
+
+    assert!(row.contains("界"), "{row:?}");
+    assert!(row.contains("…"), "notice should be truncated: {row:?}");
+    assert!(row.matches("界").count() <= 40, "{row:?}");
 }

--- a/tests/conversation_layout.rs
+++ b/tests/conversation_layout.rs
@@ -365,8 +365,7 @@ fn navigation_layout_supports_each_single_visible_navigation_pane() {
 
 #[test]
 fn structural_placeholders_do_not_render_chat_or_contact_content() {
-    // Status now renders real panes (see tests/status_section.rs), so only
-    // Communities keeps the structural placeholder.
+    // Communities now renders its approved hierarchy and real chat pane.
     for section in [Section::Communities] {
         let mut app = TestApp::new();
         let chat = JID::from("chat@example.test".to_owned());
@@ -388,7 +387,7 @@ fn structural_placeholders_do_not_render_chat_or_contact_content() {
             .iter()
             .map(|cell| cell.symbol())
             .collect::<String>();
-        assert!(output.contains(&format!("{} is not available yet.", section.title())));
+        assert!(output.contains("Communities"));
         assert!(!output.contains("CHAT_CONTACT_SENTINEL"));
         assert!(!output.contains("Contacts"));
         assert!(!output.contains("Message input"));

--- a/tests/media_lifecycle.rs
+++ b/tests/media_lifecycle.rs
@@ -62,6 +62,41 @@ fn viewer_layout_centers_and_clamps_preview_after_resize() {
 }
 
 #[test]
+fn viewer_layout_clamps_zoom_below_the_minimum() {
+    let minimum = viewer_preview_layout(ratatui::layout::Rect::new(0, 0, 100, 40), 25);
+    let below_minimum = viewer_preview_layout(ratatui::layout::Rect::new(0, 0, 100, 40), 0);
+
+    assert_eq!(below_minimum, minimum);
+    assert_eq!(
+        below_minimum.preview,
+        ratatui::layout::Rect::new(40, 15, 20, 7)
+    );
+}
+
+#[test]
+fn viewer_layout_keeps_tiny_and_empty_areas_inside_the_parent() {
+    for area in [
+        ratatui::layout::Rect::new(0, 0, 0, 0),
+        ratatui::layout::Rect::new(0, 0, 3, 3),
+        ratatui::layout::Rect::new(5, 7, 4, 2),
+    ] {
+        let layout = viewer_preview_layout(area, 400);
+        let inside = |rect: ratatui::layout::Rect| {
+            rect.is_empty()
+                || (rect.x >= area.x
+                    && rect.y >= area.y
+                    && rect.right() <= area.right()
+                    && rect.bottom() <= area.bottom())
+        };
+
+        assert!(inside(layout.modal));
+        assert!(inside(layout.body));
+        assert!(inside(layout.hint));
+        assert!(inside(layout.preview));
+    }
+}
+
+#[test]
 fn composer_cursor_position_is_relative_to_the_final_input_area() {
     assert_eq!(
         composer_cursor_position(ratatui::layout::Rect::new(10, 20, 30, 4), (2, 7)),

--- a/tests/message_height_cache.rs
+++ b/tests/message_height_cache.rs
@@ -51,17 +51,72 @@ fn reply_context_presence_cannot_reuse_stale_height() {
 }
 
 #[test]
-fn media_state_changes_cannot_reuse_stale_height() {
+fn delayed_media_preview_keeps_height_and_cache_stable() {
     let mut app = TestApp::new();
-    let message = file_message("image", FileKind::Image, Some("caption"));
+    let messages = [
+        file_message("image", FileKind::Image, Some("caption")),
+        file_message("video", FileKind::Video, Some("caption")),
+        file_message("sticker", FileKind::Sticker, None),
+    ];
+
+    for message in &messages {
+        app.metadata
+            .insert(message.info.id.clone(), Metadata::File(FileMeta::Loading));
+        let loading_height = height(message, 20, false, &mut app);
+        assert_eq!(loading_height, height(message, 20, false, &mut app));
+
+        app.metadata
+            .insert(message.info.id.clone(), Metadata::File(FileMeta::Loaded));
+        assert_eq!(height(message, 20, false, &mut app), loading_height);
+    }
+}
+
+#[test]
+fn delayed_media_preview_preserves_offsets_visible_range_anchor_and_selection() {
+    let mut app = TestApp::new();
+    let messages = [
+        file_message("older", FileKind::Document, None),
+        file_message("media", FileKind::Image, Some("caption")),
+        text_message("newer", "hello"),
+    ];
+
+    let offsets = |app: &mut App<'_>| {
+        messages
+            .iter()
+            .map(|message| height(message, 20, false, app))
+            .scan(0, |offset, height| {
+                *offset += height;
+                Some(*offset)
+            })
+            .collect::<Vec<_>>()
+    };
 
     app.metadata
-        .insert(message.info.id.clone(), Metadata::File(FileMeta::Loading));
-    assert_eq!(height(&message, 20, false, &mut app), 3);
+        .insert("media".into(), Metadata::File(FileMeta::Loading));
+    let before = offsets(&mut app);
+    let before_anchor = before[1];
+    let before_visible = before
+        .iter()
+        .enumerate()
+        .filter(|(_, bottom)| **bottom > before_anchor.saturating_sub(2))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
 
     app.metadata
-        .insert(message.info.id.clone(), Metadata::File(FileMeta::Loaded));
-    assert_eq!(height(&message, 20, false, &mut app), 14);
+        .insert("media".into(), Metadata::File(FileMeta::Loaded));
+    let after = offsets(&mut app);
+    let after_anchor = after[1];
+    let after_visible = after
+        .iter()
+        .enumerate()
+        .filter(|(_, bottom)| **bottom > after_anchor.saturating_sub(2))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+
+    assert_eq!(before, after);
+    assert_eq!(before_anchor, after_anchor);
+    assert_eq!(before_visible, after_visible);
+    assert_eq!(messages[1].info.id.as_ref(), "media");
 }
 
 #[test]

--- a/tests/navigation_rendering.rs
+++ b/tests/navigation_rendering.rs
@@ -80,7 +80,7 @@ fn navigation_renders_labels_logs_logout_and_placeholders() {
         "Status",
         "Communities",
         "Logs",
-        "not available yet",
+        "No communities",
     ] {
         assert!(rendered.contains(expected), "missing {expected}");
     }

--- a/tests/navigation_rendering.rs
+++ b/tests/navigation_rendering.rs
@@ -1,6 +1,11 @@
+use std::fs;
+
 use ratatui::{Terminal, backend::TestBackend};
+use whatsrust as wr;
 use wp_tui::{
     app::actions::{FocusPane, Section},
+    app::events::{AttachmentViewerState, ViewerAttachment, ViewerStatus},
+    file_picker::FilePickerState,
     ui,
 };
 
@@ -42,7 +47,7 @@ fn navigation_symbols_have_bounded_module_ownership() {
 fn draw_keeps_navigation_branch_and_overlay_order() {
     let draw_source = UI_SOURCE
         .split_once("pub fn draw")
-        .and_then(|(_, source)| source.split_once("fn render_contacts"))
+        .and_then(|(_, source)| source.split_once("pub fn render_chats"))
         .map(|(source, _)| source)
         .expect("draw source should be present");
     let order = [
@@ -102,4 +107,68 @@ fn navigation_is_safe_in_a_narrow_frame() {
     let mut terminal = Terminal::new(TestBackend::new(24, 8)).unwrap();
     terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
     assert!(rows(&terminal).join("\n").contains("Sections"));
+}
+
+#[test]
+fn runtime_overlay_layering_keeps_logs_and_branch_below_final_file_picker() {
+    let mut app = TestApp::new();
+    app.focus_pane = FocusPane::SectionRail;
+    app.selected_section = Section::Communities;
+    app.show_logs = true;
+    app.attachment_viewer = Some(AttachmentViewerState::from_attachments(
+        vec![ViewerAttachment {
+            message_id: "overlay-message".into(),
+            kind: wr::FileKind::Document,
+            path: "attachment-marker.bin".into(),
+            status: ViewerStatus::Missing,
+        }],
+        0,
+    ));
+    app.url_picker = Some((vec!["url-marker".to_owned()], 0));
+    let recipient = "share-marker@s.whatsapp.net".to_owned().into();
+    app.share_picker = Some(wp_tui::app::SharePicker::new(
+        vec![recipient],
+        [(
+            "share-marker@s.whatsapp.net".to_owned().into(),
+            "share-marker".to_owned(),
+        )]
+        .into_iter()
+        .collect(),
+        Default::default(),
+    ));
+
+    let directory = tempfile::tempdir().unwrap();
+    fs::write(directory.path().join("file-marker.txt"), "overlay").unwrap();
+    app.file_picker = Some(FilePickerState::open(directory.path()).unwrap());
+
+    let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    let rendered = rows(&terminal).join("\n");
+
+    assert!(
+        rendered.contains("Logs"),
+        "logs must remain rendered: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Communities"),
+        "selected branch must remain rendered: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Attach file:"),
+        "final file picker must win over the picker overlays: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("file-marker.txt"),
+        "final picker contents must render: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("attachment-marker.bin"),
+        "attachment viewer must remain layered below the final picker: {rendered:?}"
+    );
+    for covered in ["url-marker", "share-marker"] {
+        assert!(
+            !rendered.contains(covered),
+            "later overlay must cover {covered}: {rendered:?}"
+        );
+    }
 }

--- a/tests/navigation_rendering.rs
+++ b/tests/navigation_rendering.rs
@@ -1,0 +1,105 @@
+use ratatui::{Terminal, backend::TestBackend};
+use wp_tui::{
+    app::actions::{FocusPane, Section},
+    ui,
+};
+
+mod common;
+use common::TestApp;
+
+const UI_SOURCE: &str = include_str!("../src/ui.rs");
+const NAVIGATION_SOURCE: &str = include_str!("../src/ui/navigation.rs");
+
+fn rows(terminal: &Terminal<TestBackend>) -> Vec<String> {
+    let buffer = terminal.backend().buffer();
+    (0..buffer.area().height)
+        .map(|y| {
+            (0..buffer.area().width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn navigation_symbols_have_bounded_module_ownership() {
+    for symbol in [
+        "render_section_rail",
+        "render_structural_placeholder",
+        "render_logout_placeholder",
+        "render_logs",
+    ] {
+        assert!(
+            NAVIGATION_SOURCE.contains(symbol),
+            "navigation owns {symbol}"
+        );
+        assert_eq!(UI_SOURCE.matches(&format!("fn {symbol}")).count(), 0);
+    }
+    assert!(!NAVIGATION_SOURCE.contains("pub fn"));
+}
+
+#[test]
+fn draw_keeps_navigation_branch_and_overlay_order() {
+    let draw_source = UI_SOURCE
+        .split_once("pub fn draw")
+        .and_then(|(_, source)| source.split_once("fn render_contacts"))
+        .map(|(source, _)| source)
+        .expect("draw source should be present");
+    let order = [
+        "render_logs",
+        "render_section_rail",
+        "render_logout_placeholder",
+        "render_chats",
+        "render_statuses",
+        "render_attachment_viewer",
+        "render_url_picker",
+        "render_share_picker",
+        "render_file_picker",
+    ];
+    let mut previous = 0;
+    for symbol in order {
+        let current = draw_source.find(symbol).expect("draw call should remain");
+        assert!(current >= previous, "draw order changed at {symbol}");
+        previous = current;
+    }
+}
+
+#[test]
+fn navigation_renders_labels_logs_logout_and_placeholders() {
+    let mut app = TestApp::new();
+    app.focus_pane = FocusPane::SectionRail;
+    app.selected_section = Section::Communities;
+    app.show_logs = true;
+
+    let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    let rendered = rows(&terminal).join("\n");
+    for expected in [
+        "Sections",
+        "Chats",
+        "Status",
+        "Communities",
+        "Logs",
+        "not available yet",
+    ] {
+        assert!(rendered.contains(expected), "missing {expected}");
+    }
+
+    app.rail_on_logout = true;
+    app.show_logs = false;
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    assert!(
+        rows(&terminal)
+            .join("\n")
+            .contains("Press Enter to sign out")
+    );
+}
+
+#[test]
+fn navigation_is_safe_in_a_narrow_frame() {
+    let mut app = TestApp::new();
+    app.selected_section = Section::Communities;
+    let mut terminal = Terminal::new(TestBackend::new(24, 8)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    assert!(rows(&terminal).join("\n").contains("Sections"));
+}

--- a/tests/selected_message_card.rs
+++ b/tests/selected_message_card.rs
@@ -243,6 +243,32 @@ fn moving_selection_moves_the_card_without_stale_layout() {
     assert!(!second.iter().any(|row| row.contains("│ newer body")));
 }
 
+#[test]
+fn selected_message_scrolls_viewport_to_keep_the_card_with_padding() {
+    let mut app = app_with_messages(&[
+        text_message("first", "first body"),
+        text_message("second", "second body"),
+        text_message("third", "third body"),
+        text_message("fourth", "fourth body"),
+        text_message("fifth", "fifth body"),
+    ]);
+    app.message_list_state.set_selected_message("third".into());
+    app.message_list_state.offset = 6;
+
+    let first_rows = render_rows(&mut app, 34, 8);
+
+    assert_eq!(app.message_list_state.offset, 0);
+    assert!(first_rows.iter().any(|row| row.contains("│ third body")));
+
+    app.message_list_state.set_selected_message("first".into());
+    app.message_list_state.offset = 0;
+
+    let third_rows = render_rows(&mut app, 34, 8);
+
+    assert_eq!(app.message_list_state.offset, 4);
+    assert!(third_rows.iter().any(|row| row.contains("│ first body")));
+}
+
 fn render_rows(app: &mut App<'_>, width: u16, height: u16) -> Vec<String> {
     let buffer = render_buffer(app, width, height);
     (0..height)

--- a/tests/status_section.rs
+++ b/tests/status_section.rs
@@ -363,3 +363,50 @@ fn chats_section_still_lists_only_real_conversations() {
             .any(|jid| jid.0.as_ref() == "status@broadcast")
     );
 }
+
+#[test]
+fn status_renderers_have_a_dedicated_owner_and_ui_keeps_composition() {
+    let source = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ui.rs"))
+        .expect("ui source should be readable");
+    let status_source =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ui/status.rs"))
+            .expect("status renderer module should exist");
+
+    assert!(status_source.contains("pub(super) fn render_status_contacts"));
+    assert!(status_source.contains("pub(super) fn render_statuses"));
+    assert!(!source.contains("fn render_status_contacts"));
+    assert!(!source.contains("fn render_statuses"));
+    assert!(source.contains("render_status_contacts(frame, app, area)"));
+    assert!(source.contains("render_statuses(frame, app, areas.conversation)"));
+}
+
+#[test]
+fn status_empty_and_opened_states_are_safe_in_tiny_supported_frames() {
+    let mut app = TestApp::new();
+    app.selected_section = Section::Status;
+    let empty_output = render(&mut app, 20, 6);
+    assert!(
+        empty_output.contains("No s"),
+        "empty state missing: {empty_output:?}"
+    );
+
+    let mut opened_app = TestApp::new();
+    opened_app.selected_section = Section::Status;
+    opened_app.focus_pane = FocusPane::ChatList;
+    let alice = JID::from("alice@s.whatsapp.net".to_owned());
+    opened_app.contacts.insert(alice.clone(), "Alice".into());
+    opened_app.add_message(status_message(
+        &alice,
+        "tiny-status",
+        unix_now(),
+        "tiny message",
+    ));
+    opened_app.status_contacts = vec![alice.clone()];
+    opened_app.status_selection.select(Some(0));
+    opened_app.open_selected_status();
+    let opened_output = render(&mut opened_app, 60, 8);
+    assert!(
+        opened_output.contains("tiny") || opened_output.contains("Alice"),
+        "opened state missing: {opened_output:?}"
+    );
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -23,6 +23,13 @@ typedef struct {
 } ContactEntry;
 
 typedef struct {
+	JID jid;
+	const char* name;
+	JID parent_jid;
+	bool is_parent;
+} CommunityEntry;
+
+typedef struct {
 	bool found;
 	int64_t muted_until;
 	bool pinned;
@@ -33,6 +40,12 @@ typedef struct {
 	ContactEntry* entries;
 	uint32_t size;
 } GetContactsResult;
+
+typedef struct {
+	CommunityEntry* entries;
+	uint32_t size;
+	uint8_t status;
+} GetCommunitiesResult;
 
 typedef struct {
 	uint8_t status;
@@ -2789,6 +2802,65 @@ func C_GetContacts() C.GetContactsResult {
 		entries: (*C.ContactEntry)(c_entries),
 		size:    C.uint32_t(n),
 	}
+}
+
+// C_GetCommunities transfers ownership of entries and every pointed-to string
+// to the caller. The caller must invoke C_FreeCommunities exactly once for
+// every returned result, including empty and error results. C_FreeCommunities
+// is nil-safe, but repeating it for the same non-nil result is not supported.
+//
+//export C_GetCommunities
+func C_GetCommunities() C.GetCommunitiesResult {
+	ctx := context.Background()
+	groups, err := client.GetJoinedGroups(ctx)
+	if err != nil {
+		LOG_WARN("Could not load communities: %v", err)
+		return C.GetCommunitiesResult{status: 1}
+	}
+	entries := make([]C.CommunityEntry, 0)
+	for _, group := range groups {
+		parent := group.LinkedParentJID
+		if !communityEntryIncluded(group.IsParent, parent.IsEmpty()) {
+			continue
+		}
+		entries = append(entries, C.CommunityEntry{
+			jid:        jidToC(group.JID),
+			name:       C.CString(group.GroupName.Name),
+			parent_jid: jidToC(parent),
+			is_parent:  C.bool(group.IsParent),
+		})
+	}
+	n := len(entries)
+	if n == 0 {
+		return C.GetCommunitiesResult{status: 0}
+	}
+	cEntries := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.CommunityEntry{})))
+	entryList := unsafe.Slice((*C.CommunityEntry)(cEntries), n)
+	for i := range n {
+		entryList[i] = entries[i]
+	}
+	return C.GetCommunitiesResult{entries: (*C.CommunityEntry)(cEntries), size: C.uint32_t(n), status: 0}
+}
+
+//export C_FreeCommunities
+func C_FreeCommunities(result C.GetCommunitiesResult) {
+	if result.entries == nil {
+		return
+	}
+	freeCommunityEntries(unsafe.Slice(result.entries, int(result.size)))
+	C.free(unsafe.Pointer(result.entries))
+}
+
+func freeCommunityEntries(entries []C.CommunityEntry) {
+	for _, entry := range entries {
+		C.free(unsafe.Pointer(entry.jid))
+		C.free(unsafe.Pointer(entry.name))
+		C.free(unsafe.Pointer(entry.parent_jid))
+	}
+}
+
+func communityEntryIncluded(isParent, parentEmpty bool) bool {
+	return isParent || !parentEmpty
 }
 
 const (

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -2059,6 +2059,14 @@ func dispatchIncomingMessageWithDecrypt(
 		dispatchAction(action)
 		return
 	}
+	rawMessage := evt.RawMessage
+	if rawMessage == nil && evt.SourceWebMsg != nil {
+		rawMessage = evt.SourceWebMsg.GetMessage()
+	}
+	if message, ok := unavailableViewOnceMessage(rawMessage); ok {
+		dispatchMessage(evt.Info, message, false)
+		return
+	}
 	dispatchMessage(evt.Info, evt.Message, false)
 }
 
@@ -2948,7 +2956,7 @@ func C_GetChatSettings(cjid C.JID) C.ChatSettings {
 		mutedUntil = settings.MutedUntil.Unix()
 	}
 
-return C.ChatSettings{
+	return C.ChatSettings{
 		found:       C.bool(settings.Found),
 		muted_until: C.int64_t(mutedUntil),
 		pinned:      C.bool(settings.Pinned),

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -51,6 +51,30 @@ func TestPinnedPresenceContractAndNarrowSubscription(t *testing.T) {
 	}
 }
 
+func TestCommunityEntryIncludedDistinguishesRootsAndLinkedGroups(t *testing.T) {
+	tests := []struct {
+		name        string
+		isParent    bool
+		parentEmpty bool
+		want        bool
+	}{
+		{name: "community root", isParent: true, parentEmpty: true, want: true},
+		{name: "linked group", parentEmpty: false, want: true},
+		{name: "ordinary group", parentEmpty: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := communityEntryIncluded(tt.isParent, tt.parentEmpty); got != tt.want {
+				t.Fatalf("communityEntryIncluded(%t, %t) = %t, want %t", tt.isParent, tt.parentEmpty, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFreeCommunitiesNilResultIsSafe(t *testing.T) {
+	freeCommunityEntries(nil)
+}
+
 func TestRawPresenceDiagnosticsDisabledIsNoOp(t *testing.T) {
 	var diagnostics rawPresenceDiagnostics
 	diagnostics.reset(false)

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -869,6 +869,96 @@ func TestIncomingMessageDispatchesNormalizedEditBeforeOrdinaryMessage(t *testing
 	}
 }
 
+func TestIncomingMessageDispatchesViewOncePlaceholderFromAuthoritativeEnvelope(t *testing.T) {
+	chat := types.NewJID("1234567890", types.DefaultUserServer)
+	sender := types.NewJID("0987654321", types.DefaultUserServer)
+	info := types.MessageInfo{
+		MessageSource: types.MessageSource{Chat: chat, Sender: sender},
+		ID:            "view-once-message",
+		Timestamp:     time.Unix(42, 0),
+	}
+	viewOnce := func(message *waE2E.Message) *waE2E.Message {
+		return &waE2E.Message{ViewOnceMessage: &waE2E.FutureProofMessage{Message: message}}
+	}
+
+	cases := []struct {
+		name  string
+		event *events.Message
+	}{
+		{
+			name: "live raw envelope",
+			event: &events.Message{
+				Info:       info,
+				Message:    &waE2E.Message{ImageMessage: &waE2E.ImageMessage{}},
+				RawMessage: viewOnce(&waE2E.Message{ImageMessage: &waE2E.ImageMessage{}}),
+			},
+		},
+		{
+			name: "history source envelope",
+			event: &events.Message{
+				Info:    info,
+				Message: &waE2E.Message{VideoMessage: &waE2E.VideoMessage{}},
+				SourceWebMsg: &waWeb.WebMessageInfo{
+					Message: viewOnce(&waE2E.Message{VideoMessage: &waE2E.VideoMessage{}}),
+				},
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var actions []messageActionEvent
+			var dispatched []struct {
+				info    types.MessageInfo
+				message *waE2E.Message
+				isRetry bool
+			}
+			dispatchIncomingMessageWithDecrypt(testCase.event, func(action messageActionEvent) {
+				actions = append(actions, action)
+			}, func(info types.MessageInfo, message *waE2E.Message, isRetry bool) {
+				dispatched = append(dispatched, struct {
+					info    types.MessageInfo
+					message *waE2E.Message
+					isRetry bool
+				}{info, message, isRetry})
+			}, nil)
+
+			if len(actions) != 0 || len(dispatched) != 1 {
+				t.Fatalf("actions=%d dispatched=%d, want actions=0 dispatched=1", len(actions), len(dispatched))
+			}
+			if dispatched[0].info.ID != info.ID || dispatched[0].info.Chat != info.Chat || dispatched[0].info.Sender != info.Sender {
+				t.Fatalf("message info was not preserved: %#v", dispatched[0].info)
+			}
+			if dispatched[0].isRetry || dispatched[0].message.GetConversation() != viewOnceUnavailablePlaceholder {
+				t.Fatalf("unexpected placeholder dispatch: %#v", dispatched[0])
+			}
+		})
+	}
+}
+
+func TestIncomingMessageDispatchKeepsOrdinaryMessageWithoutRawViewOnce(t *testing.T) {
+	info := types.MessageInfo{ID: "ordinary-message"}
+	ordinary := &waE2E.Message{Conversation: stringPointer("ordinary")}
+	event := &events.Message{Info: info, Message: ordinary}
+
+	actions := 0
+	dispatched := 0
+	var got *waE2E.Message
+	dispatchIncomingMessageWithDecrypt(event, func(messageActionEvent) {
+		actions++
+	}, func(_ types.MessageInfo, message *waE2E.Message, isRetry bool) {
+		dispatched++
+		got = message
+		if isRetry {
+			t.Fatal("ordinary message was marked as a retry")
+		}
+	}, nil)
+
+	if actions != 0 || dispatched != 1 || got != ordinary {
+		t.Fatalf("actions=%d dispatched=%d got=%p, want actions=0 dispatched=1 original=%p", actions, dispatched, got, ordinary)
+	}
+}
+
 func TestIncomingSecretEncryptedMessageEditDispatch(t *testing.T) {
 	chat := types.NewJID("1234567890", types.DefaultUserServer)
 	editor := types.NewJID("0987654321", types.DefaultUserServer)

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -60,9 +60,24 @@ struct CContactEntry {
 }
 
 #[repr(C)]
+struct CCommunityEntry {
+    jid: CJID,
+    name: *const c_char,
+    parent_jid: CJID,
+    is_parent: bool,
+}
+
+#[repr(C)]
 struct CGetContactsResult {
     entries: *const CContactEntry,
     size: u32,
+}
+
+#[repr(C)]
+struct CGetCommunitiesResult {
+    entries: *const CCommunityEntry,
+    size: u32,
+    status: u8,
 }
 
 #[repr(C)]
@@ -605,6 +620,19 @@ pub struct GroupInfo {
     pub name: Arc<str>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommunityInfo {
+    pub jid: JID,
+    pub name: Arc<str>,
+    pub parent_jid: Option<JID>,
+    pub is_parent: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommunitiesError {
+    BridgeUnavailable,
+}
+
 impl From<&CContact> for Contact {
     fn from(ccontact: &CContact) -> Self {
         let first_name = unsafe { CStr::from_ptr(ccontact.first_name) }
@@ -675,6 +703,8 @@ unsafe extern "C" {
         forward_source_len: usize,
     ) -> CForwardResult;
     fn C_GetContacts() -> CGetContactsResult;
+    fn C_GetCommunities() -> CGetCommunitiesResult;
+    fn C_FreeCommunities(result: CGetCommunitiesResult);
     fn C_GetProfilePicture(jid: CJID) -> CProfilePictureResult;
     fn C_FreeProfilePicture(result: CProfilePictureResult);
     fn C_GetChatSettings(jid: CJID) -> CChatSettings;
@@ -1026,9 +1056,7 @@ impl CallbackTranslator<*const CEvent> for Event {
             EventType::MessageAction => unsafe {
                 message_action_event_from_ffi(&*(event.data as *const CMessageActionEvent))
             },
-            EventType::Chat => unsafe {
-                chat_event_from_ffi(&*(event.data as *const CChatEvent))
-            },
+            EventType::Chat => unsafe { chat_event_from_ffi(&*(event.data as *const CChatEvent)) },
             EventType::LogoutResult => unsafe {
                 let result = &(*(event.data as *const CLogoutResultEvent));
                 Event::LogoutResult(
@@ -1535,6 +1563,40 @@ pub fn get_contacts() -> Vec<(JID, Arc<str>)> {
         .collect()
 }
 
+/// Returns real community roots and linked groups reported by WhatsApp.
+pub fn get_communities() -> Result<Vec<CommunityInfo>, CommunitiesError> {
+    let result = unsafe { C_GetCommunities() };
+    if result.status != 0 {
+        // C_GetCommunities transfers ownership even when the bridge reports
+        // an error; the current error result is empty, but freeing it here
+        // keeps that contract correct if it ever carries partial data.
+        unsafe { C_FreeCommunities(result) };
+        return Err(CommunitiesError::BridgeUnavailable);
+    }
+    if result.entries.is_null() || result.size == 0 {
+        unsafe { C_FreeCommunities(result) };
+        return Ok(Vec::new());
+    }
+    let entries = unsafe { std::slice::from_raw_parts(result.entries, result.size as usize) };
+    let communities = entries
+        .iter()
+        .map(|entry| {
+            let parent = unsafe { CStr::from_ptr(entry.parent_jid) }.to_string_lossy();
+            CommunityInfo {
+                jid: (&entry.jid).into(),
+                name: unsafe { CStr::from_ptr(entry.name) }
+                    .to_string_lossy()
+                    .into_owned()
+                    .into(),
+                parent_jid: (!parent.is_empty()).then(|| parent.to_string().into()),
+                is_parent: entry.is_parent,
+            }
+        })
+        .collect::<Vec<_>>();
+    unsafe { C_FreeCommunities(result) };
+    Ok(communities)
+}
+
 pub fn get_chat_settings(jid: &JID) -> ChatSettings {
     let jid_c = CJID::from(jid);
     let settings = unsafe { C_GetChatSettings(jid_c) };
@@ -1555,10 +1617,7 @@ pub fn get_chat_settings(jid: &JID) -> ChatSettings {
 /// JID is unusable.
 pub fn resolve_dm_chat(jid: &JID) -> Option<JID> {
     unsafe {
-        take_owned_c_string(
-            C_ResolveDmChatId(CJID::from(jid)),
-            C_FreeResolveDmChatId,
-        )
-        .map(JID::from)
+        take_owned_c_string(C_ResolveDmChatId(CJID::from(jid)), C_FreeResolveDmChatId)
+            .map(JID::from)
     }
 }


### PR DESCRIPTION
## Summary

- Merge the completed modular UI and hexagonal architecture refactor chain into `main`.
- Deliver Communities navigation, view-once fallback handling, stable media preview heights, extracted UI renderers, and injected application ports as one integrated tracker release.

## Changes

- Extract shared layout, navigation, Contacts, and Status rendering responsibilities.
- Add Communities hierarchy navigation.
- Preserve unavailable view-once messages and stabilize media preview heights.
- Inject notification and clock/presence ports at the application boundary.
- Add focused regression and integration coverage across the completed slices.

## Testing

- [x] `cargo test -- --test-threads=1` (323 passed on the final integration candidate)
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cargo fmt --check`
- [x] `cargo check --all-targets`
- [x] Integration PR CI passed
- [ ] Manual testing done

Closes #29
Closes #31
Closes #32
Closes #35
Closes #37
Closes #39
Closes #40