### PR TITLE
refactor(app): extract share picker

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,7 @@ pub mod events;
 pub mod inputs;
 pub mod message_action_diagnostics;
 pub mod presence;
+pub mod share_picker;
 
 pub use crate::app;
 use crate::app::actions::{
@@ -31,6 +32,7 @@ use crate::app::contact_avatars::ContactAvatars;
 use crate::app::events::{AppEvent, AppInput, AttachmentViewerState, ViewerPreviewState};
 use crate::app::message_action_diagnostics::{MessageActionDiagnostics, identifier_for_log};
 use crate::app::presence::{PresenceDiagnostics, SelectedPresence, jid_for_log};
+pub use crate::app::share_picker::SharePicker;
 use crate::db;
 use crate::file_picker::FilePickerState;
 use crate::key_handler::KeybindHandler;
@@ -165,97 +167,6 @@ pub enum FileMeta {
 
 pub enum Metadata {
     File(FileMeta),
-}
-
-pub struct SharePicker {
-    contacts: Vec<wr::JID>,
-    labels: HashMap<wr::JID, String>,
-    pub query: String,
-    pub selected: usize,
-    pub offset: usize,
-    viewport_height: usize,
-    selected_contacts: HashSet<wr::JID>,
-}
-
-impl SharePicker {
-    pub fn new(
-        mut contacts: Vec<wr::JID>,
-        labels: HashMap<wr::JID, String>,
-        recency: HashMap<wr::JID, i64>,
-    ) -> Self {
-        contacts.sort_by(|left, right| {
-            recency
-                .get(right)
-                .unwrap_or(&i64::MIN)
-                .cmp(recency.get(left).unwrap_or(&i64::MIN))
-                .then_with(|| left.0.cmp(&right.0))
-        });
-        Self {
-            contacts,
-            labels,
-            query: String::new(),
-            selected: 0,
-            offset: 0,
-            viewport_height: 1,
-            selected_contacts: HashSet::new(),
-        }
-    }
-    pub fn visible_contacts(&self) -> Vec<&wr::JID> {
-        let query = self.query.to_lowercase();
-        self.contacts
-            .iter()
-            .filter(|jid| {
-                query.is_empty()
-                    || jid.0.to_lowercase().contains(&query)
-                    || self
-                        .labels
-                        .get(*jid)
-                        .is_some_and(|name| name.to_lowercase().contains(&query))
-            })
-            .collect()
-    }
-    pub fn selected_count(&self) -> usize {
-        self.selected_contacts.len()
-    }
-    pub fn is_selected(&self, jid: &wr::JID) -> bool {
-        self.selected_contacts.contains(jid)
-    }
-    pub fn destinations(&self) -> Vec<wr::JID> {
-        self.contacts
-            .iter()
-            .filter(|jid| self.is_selected(jid))
-            .cloned()
-            .collect()
-    }
-    pub fn viewport(&self) -> std::ops::Range<usize> {
-        let end = self.visible_contacts().len();
-        let height = self.viewport_height.max(1).min(end);
-        let start = self.offset.min(end.saturating_sub(height));
-        start..start.saturating_add(height)
-    }
-    fn clamp_selection(&mut self) {
-        self.selected = self
-            .selected
-            .min(self.visible_contacts().len().saturating_sub(1));
-        self.offset = self.offset.min(self.selected);
-    }
-    pub fn set_viewport_height(&mut self, height: usize) {
-        self.viewport_height = height.max(1);
-        self.keep_selected_visible();
-    }
-    pub fn keep_selected_visible(&mut self) {
-        let height = self.viewport_height.max(1);
-        if self.selected < self.offset {
-            self.offset = self.selected;
-        }
-        if self.selected >= self.offset.saturating_add(height) {
-            self.offset = self.selected + 1 - height;
-        }
-    }
-    pub fn reset_search_position(&mut self) {
-        self.selected = 0;
-        self.offset = 0;
-    }
 }
 
 pub struct App<'a> {

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -866,9 +866,7 @@ impl App<'_> {
 
     fn move_share_picker(&mut self, delta: isize) {
         if let Some(picker) = self.share_picker.as_mut() {
-            picker.selected = picker.selected.saturating_add_signed(delta);
-            picker.clamp_selection();
-            picker.keep_selected_visible();
+            picker.move_selection(delta);
         }
     }
 
@@ -876,31 +874,18 @@ impl App<'_> {
         let Some(picker) = self.share_picker.as_mut() else {
             return;
         };
-        let selected = picker
-            .visible_contacts()
-            .get(picker.selected)
-            .cloned()
-            .cloned();
-        if let Some(jid) = selected {
-            if !picker.selected_contacts.insert(jid.clone()) {
-                picker.selected_contacts.remove(&jid);
-            }
-        }
+        picker.toggle_selected();
     }
 
     fn share_search_backspace(&mut self) {
         if let Some(picker) = self.share_picker.as_mut() {
-            picker.query.pop();
-            picker.reset_search_position();
-            picker.clamp_selection();
+            picker.search_backspace();
         }
     }
 
     fn share_search_character(&mut self, character: char) {
         if let Some(picker) = self.share_picker.as_mut() {
-            picker.query.push(character);
-            picker.reset_search_position();
-            picker.clamp_selection();
+            picker.search_character(character);
         }
     }
 

--- a/src/app/share_picker.rs
+++ b/src/app/share_picker.rs
@@ -1,0 +1,133 @@
+use std::collections::{HashMap, HashSet};
+
+use whatsrust as wr;
+
+#[cfg(test)]
+mod tests;
+
+pub struct SharePicker {
+    contacts: Vec<wr::JID>,
+    labels: HashMap<wr::JID, String>,
+    pub query: String,
+    pub selected: usize,
+    pub offset: usize,
+    viewport_height: usize,
+    selected_contacts: HashSet<wr::JID>,
+}
+
+impl SharePicker {
+    pub fn new(
+        mut contacts: Vec<wr::JID>,
+        labels: HashMap<wr::JID, String>,
+        recency: HashMap<wr::JID, i64>,
+    ) -> Self {
+        contacts.sort_by(|left, right| {
+            recency
+                .get(right)
+                .unwrap_or(&i64::MIN)
+                .cmp(recency.get(left).unwrap_or(&i64::MIN))
+                .then_with(|| left.0.cmp(&right.0))
+        });
+        Self {
+            contacts,
+            labels,
+            query: String::new(),
+            selected: 0,
+            offset: 0,
+            viewport_height: 1,
+            selected_contacts: HashSet::new(),
+        }
+    }
+
+    pub fn visible_contacts(&self) -> Vec<&wr::JID> {
+        let query = self.query.to_lowercase();
+        self.contacts
+            .iter()
+            .filter(|jid| {
+                query.is_empty()
+                    || jid.0.to_lowercase().contains(&query)
+                    || self
+                        .labels
+                        .get(*jid)
+                        .is_some_and(|name| name.to_lowercase().contains(&query))
+            })
+            .collect()
+    }
+
+    pub fn selected_count(&self) -> usize {
+        self.selected_contacts.len()
+    }
+
+    pub fn is_selected(&self, jid: &wr::JID) -> bool {
+        self.selected_contacts.contains(jid)
+    }
+
+    pub fn destinations(&self) -> Vec<wr::JID> {
+        self.contacts
+            .iter()
+            .filter(|jid| self.is_selected(jid))
+            .cloned()
+            .collect()
+    }
+
+    pub fn viewport(&self) -> std::ops::Range<usize> {
+        let end = self.visible_contacts().len();
+        let height = self.viewport_height.max(1).min(end);
+        let start = self.offset.min(end.saturating_sub(height));
+        start..start.saturating_add(height)
+    }
+
+    pub fn move_selection(&mut self, delta: isize) {
+        self.selected = self.selected.saturating_add_signed(delta);
+        self.clamp_selection();
+        self.keep_selected_visible();
+    }
+
+    pub fn toggle_selected(&mut self) {
+        let Some(jid) = self.visible_contacts().get(self.selected).cloned().cloned() else {
+            return;
+        };
+        if !self.selected_contacts.insert(jid.clone()) {
+            self.selected_contacts.remove(&jid);
+        }
+    }
+
+    pub fn search_backspace(&mut self) {
+        self.query.pop();
+        self.reset_search_position();
+        self.clamp_selection();
+    }
+
+    pub fn search_character(&mut self, character: char) {
+        self.query.push(character);
+        self.reset_search_position();
+        self.clamp_selection();
+    }
+
+    fn clamp_selection(&mut self) {
+        self.selected = self
+            .selected
+            .min(self.visible_contacts().len().saturating_sub(1));
+        self.offset = self.offset.min(self.selected);
+    }
+
+    pub fn set_viewport_height(&mut self, height: usize) {
+        self.viewport_height = height.max(1);
+        self.keep_selected_visible();
+    }
+
+    pub fn keep_selected_visible(&mut self) {
+        let height = self.viewport_height.max(1);
+        if self.selected < self.offset {
+            self.offset = self.selected;
+        }
+        if self.selected >= self.offset.saturating_add(height) {
+            self.offset = self.selected + 1 - height;
+        }
+    }
+
+    pub fn reset_search_position(&mut self) {
+        self.selected = 0;
+        self.offset = 0;
+    }
+}

--- a/src/app/share_picker/tests.rs
+++ b/src/app/share_picker/tests.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use whatsrust::JID;
+
+use super::SharePicker;
+
+fn jid(value: &str) -> JID {
+    JID::from(value.to_owned())
+}
+
+fn picker() -> SharePicker {
+    let contacts = vec![
+        jid("zed@s.whatsapp.net"),
+        jid("alice@s.whatsapp.net"),
+        jid("bob@s.whatsapp.net"),
+    ];
+    let labels = HashMap::from([
+        (jid("zed@s.whatsapp.net"), "Zed".to_owned()),
+        (jid("alice@s.whatsapp.net"), "Alice".to_owned()),
+        (jid("bob@s.whatsapp.net"), "Bob".to_owned()),
+    ]);
+    let recency = HashMap::from([
+        (jid("zed@s.whatsapp.net"), 1),
+        (jid("alice@s.whatsapp.net"), 3),
+        (jid("bob@s.whatsapp.net"), 2),
+    ]);
+    SharePicker::new(contacts, labels, recency)
+}
+
+#[test]
+fn sorts_by_recency_then_filters_by_jid_or_label() {
+    let mut picker = picker();
+    assert_eq!(
+        picker.visible_contacts()[0].0.as_ref(),
+        "alice@s.whatsapp.net"
+    );
+    picker.search_character('z');
+    assert_eq!(picker.visible_contacts(), vec![&jid("zed@s.whatsapp.net")]);
+}
+
+#[test]
+fn destinations_preserve_contact_order_and_selection_across_search() {
+    let mut picker = picker();
+    picker.toggle_selected();
+    picker.move_selection(1);
+    picker.toggle_selected();
+    picker.search_character('a');
+    assert_eq!(picker.selected_count(), 2);
+    assert_eq!(
+        picker.destinations(),
+        vec![jid("alice@s.whatsapp.net"), jid("bob@s.whatsapp.net")]
+    );
+}
+
+#[test]
+fn viewport_clamps_and_keeps_selected_row_visible() {
+    let mut picker = picker();
+    picker.set_viewport_height(2);
+    picker.move_selection(2);
+    assert_eq!(picker.selected, 2);
+    assert_eq!(picker.viewport(), 1..3);
+    picker.move_selection(10);
+    assert_eq!(picker.selected, 2);
+    assert!(picker.viewport().contains(&picker.selected));
+}
+
+#[test]
+fn search_reset_returns_to_first_visible_row() {
+    let mut picker = picker();
+    picker.set_viewport_height(1);
+    picker.move_selection(2);
+    picker.search_character('b');
+    assert_eq!((picker.selected, picker.offset), (0, 0));
+    picker.search_backspace();
+    assert_eq!((picker.selected, picker.offset), (0, 0));
+}


### PR DESCRIPTION
## Summary

- Extract the share-recipient picker from the central `App` module into a cohesive responsibility.
- Encapsulate selection, search, viewport, and destination behavior behind explicit methods.
- Colocate focused unit tests with the extracted module.

## Changes

| File | Change |
|---|---|
| `src/app/share_picker.rs` | Owns share-picker state and behavior |
| `src/app/share_picker/tests.rs` | Covers ordering, filtering, selection, viewport, and search reset |
| `src/app.rs` | Re-exports the extracted responsibility |
| `src/app/inputs.rs` | Delegates picker interactions through behavior methods |

## Testing

- [x] `cargo test app::share_picker` (4 passed)
- [x] `cargo test --test share_message` (7 passed)
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`

First responsibility in the chained `App` modularization refactor.