### PR TITLE
refactor(app): extract notification policy

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
@@ -16,6 +16,7 @@ pub mod events;
 pub mod inputs;
 pub mod media_support;
 pub mod message_action_diagnostics;
+pub mod notifications;
 pub mod presence;
 pub mod share_picker;
 
@@ -36,6 +37,12 @@ use crate::app::media_support::{
 };
 pub use crate::app::media_support::{remove_owned_media_files, remove_status_media_files};
 use crate::app::message_action_diagnostics::{MessageActionDiagnostics, identifier_for_log};
+pub use crate::app::notifications::{
+    Clock, NotificationProjection, Notifier, NotifyRustNotifier, SystemClock, now_or, unix_now,
+};
+pub(crate) use crate::app::notifications::{
+    notification_eligibility, notification_is_muted, notification_projection,
+};
 use crate::app::presence::{PresenceDiagnostics, SelectedPresence, jid_for_log};
 pub use crate::app::share_picker::SharePicker;
 use crate::db;
@@ -49,7 +56,6 @@ use arboard::Clipboard;
 use db::{DatabaseHandler, MessageActionPersistence};
 use directories::ProjectDirs;
 use log::{debug, error, info, trace, warn};
-use notify_rust::Notification;
 use ratatui::crossterm::event;
 use ratatui::layout::Rect;
 use ratatui::widgets::ListState;
@@ -66,45 +72,6 @@ use crate::ui::text_input::TextInput;
 /// `info.sender` is the contact who posted the status.
 pub const STATUS_BROADCAST_CHAT: &str = "status@broadcast";
 pub const ADMIN_ONLY_GROUP_MESSAGE: &str = "Only group admins can send messages in this group.";
-
-pub trait Clock {
-    fn unix_seconds(&self) -> Option<i64>;
-}
-
-#[derive(Debug, Default)]
-pub struct SystemClock;
-
-impl Clock for SystemClock {
-    fn unix_seconds(&self) -> Option<i64> {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .ok()
-            .map(|duration| duration.as_secs() as i64)
-    }
-}
-
-pub struct NotificationProjection {
-    pub summary: Arc<str>,
-    pub body: String,
-}
-
-pub trait Notifier {
-    fn show(&self, notification: &NotificationProjection) -> Result<(), String>;
-}
-
-#[derive(Debug, Default)]
-pub struct NotifyRustNotifier;
-
-impl Notifier for NotifyRustNotifier {
-    fn show(&self, notification: &NotificationProjection) -> Result<(), String> {
-        Notification::new()
-            .summary(&notification.summary)
-            .body(&notification.body)
-            .show()
-            .map(|_| ())
-            .map_err(|error| error.to_string())
-    }
-}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum InputReaderState {
@@ -2081,45 +2048,6 @@ impl App<'_> {
     }
 }
 
-fn notification_eligibility(message: &wr::Message) -> bool {
-    !message.info.is_from_me && !App::is_status_chat(&message.info.chat)
-}
-
-fn notification_is_muted(found: bool, muted_until: i64, now: i64) -> bool {
-    found && muted_until > now
-}
-
-fn notification_projection(message: &wr::Message, summary: Arc<str>) -> NotificationProjection {
-    let body = match &message.message {
-        wr::MessageContent::Text(text) => text.to_string(),
-        wr::MessageContent::File(file) => {
-            if let Some(caption) = &file.caption {
-                caption.to_string()
-            } else {
-                match file.kind {
-                    wr::FileKind::Image => "Sent an image".to_string(),
-                    wr::FileKind::Video => "Sent a video".to_string(),
-                    wr::FileKind::Audio => "Sent an audio message".to_string(),
-                    wr::FileKind::Document => "Sent a document".to_string(),
-                    wr::FileKind::Sticker => "Sent a sticker".to_string(),
-                }
-            }
-        }
-    };
-    NotificationProjection { summary, body }
-}
-
-fn now_or(fallback: i64, clock: &dyn Clock) -> i64 {
-    clock.unix_seconds().unwrap_or(fallback)
-}
-
-pub fn unix_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2908,24 +2836,6 @@ mod tests {
 
         let status = status_message(&broadcast, "status", 3);
         assert!(!app.should_notify(&status));
-    }
-
-    #[test]
-    fn notification_projection_preserves_untrusted_message_text() {
-        let sender = wr::JID::from("alice@s.whatsapp.net".to_owned());
-        let message = message(&sender, "ignored", 1);
-        let projection = notification_projection(&message, Arc::from("Alice"));
-
-        assert_eq!(projection.summary.as_ref(), "Alice");
-        assert_eq!(projection.body, "ignored");
-
-        let message = wr::Message {
-            message: wr::MessageContent::Text("こんにちは\n\"quoted\"\u{0007}".into()),
-            ..message
-        };
-        let projection = notification_projection(&message, Arc::from("名前\n\"sender\""));
-        assert_eq!(projection.summary.as_ref(), "名前\n\"sender\"");
-        assert_eq!(projection.body, "こんにちは\n\"quoted\"\u{0007}");
     }
 
     #[test]

--- a/src/app/notifications.rs
+++ b/src/app/notifications.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use notify_rust::Notification;
+use whatsrust as wr;
+
+use super::STATUS_BROADCAST_CHAT;
+
+pub trait Clock {
+    fn unix_seconds(&self) -> Option<i64>;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn unix_seconds(&self) -> Option<i64> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|duration| duration.as_secs() as i64)
+    }
+}
+
+pub struct NotificationProjection {
+    pub summary: Arc<str>,
+    pub body: String,
+}
+
+pub trait Notifier {
+    fn show(&self, notification: &NotificationProjection) -> Result<(), String>;
+}
+
+#[derive(Debug, Default)]
+pub struct NotifyRustNotifier;
+
+impl Notifier for NotifyRustNotifier {
+    fn show(&self, notification: &NotificationProjection) -> Result<(), String> {
+        Notification::new()
+            .summary(&notification.summary)
+            .body(&notification.body)
+            .show()
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+}
+
+pub(crate) fn notification_eligibility(message: &wr::Message) -> bool {
+    !message.info.is_from_me && message.info.chat.0.as_ref() != STATUS_BROADCAST_CHAT
+}
+
+pub(crate) fn notification_is_muted(found: bool, muted_until: i64, now: i64) -> bool {
+    found && muted_until > now
+}
+
+pub(crate) fn notification_projection(
+    message: &wr::Message,
+    summary: Arc<str>,
+) -> NotificationProjection {
+    let body = match &message.message {
+        wr::MessageContent::Text(text) => text.to_string(),
+        wr::MessageContent::File(file) => file.caption.as_ref().map_or_else(
+            || match file.kind {
+                wr::FileKind::Image => "Sent an image".to_string(),
+                wr::FileKind::Video => "Sent a video".to_string(),
+                wr::FileKind::Audio => "Sent an audio message".to_string(),
+                wr::FileKind::Document => "Sent a document".to_string(),
+                wr::FileKind::Sticker => "Sent a sticker".to_string(),
+            },
+            ToString::to_string,
+        ),
+    };
+    NotificationProjection { summary, body }
+}
+
+pub fn now_or(fallback: i64, clock: &dyn Clock) -> i64 {
+    clock.unix_seconds().unwrap_or(fallback)
+}
+
+pub fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/notifications/tests.rs
+++ b/src/app/notifications/tests.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use super::*;
+
+fn message(chat: &str, text: &str) -> wr::Message {
+    wr::Message {
+        info: wr::MessageInfo {
+            id: "id".into(),
+            chat: chat.to_owned().into(),
+            sender: chat.to_owned().into(),
+            timestamp: 1,
+            is_from_me: false,
+            quote_id: None,
+            read_by: 0,
+            forwarding: Default::default(),
+        },
+        message: wr::MessageContent::Text(text.into()),
+    }
+}
+
+#[test]
+fn eligibility_skips_status_and_own_messages() {
+    assert!(notification_eligibility(&message("chat@g.us", "incoming")));
+
+    let mut own = message("chat@g.us", "own");
+    own.info.is_from_me = true;
+    assert!(!notification_eligibility(&own));
+    assert!(!notification_eligibility(&message(
+        STATUS_BROADCAST_CHAT,
+        "status"
+    )));
+}
+
+#[test]
+fn mute_policy_excludes_expired_boundary() {
+    assert!(notification_is_muted(true, 1_001, 1_000));
+    assert!(!notification_is_muted(true, 1_000, 1_000));
+    assert!(!notification_is_muted(false, 2_000, 1_000));
+}
+
+#[test]
+fn projection_preserves_untrusted_message_text() {
+    let projection =
+        notification_projection(&message("alice@s.whatsapp.net", "ignored"), "Alice".into());
+    assert_eq!(projection.summary.as_ref(), "Alice");
+    assert_eq!(projection.body, "ignored");
+
+    let message = wr::Message {
+        message: wr::MessageContent::Text("こんにちは\n\"quoted\"\u{0007}".into()),
+        ..message("alice@s.whatsapp.net", "ignored")
+    };
+    let projection = notification_projection(&message, Arc::from("名前\n\"sender\""));
+    assert_eq!(projection.summary.as_ref(), "名前\n\"sender\"");
+    assert_eq!(projection.body, "こんにちは\n\"quoted\"\u{0007}");
+}
+
+struct FixedClock(Option<i64>);
+
+impl Clock for FixedClock {
+    fn unix_seconds(&self) -> Option<i64> {
+        self.0
+    }
+}
+
+#[test]
+fn now_or_uses_clock_or_fallback() {
+    assert_eq!(now_or(0, &FixedClock(Some(42))), 42);
+    assert_eq!(now_or(7, &FixedClock(None)), 7);
+}


### PR DESCRIPTION
## Summary

- Extract notification and clock contracts, production adapters, and pure policy from `App`.
- Colocate notification/time unit tests with the responsibility.
- Preserve existing imports through compatibility re-exports.

## Changes

| File | Change |
|---|---|
| `src/app/notifications.rs` | Owns clock/notifier ports, adapters, and notification policy |
| `src/app/notifications/tests.rs` | Covers eligibility, mute boundaries, projection, and clock fallback |
| `src/app.rs` | Keeps cross-boundary orchestration and re-exports contracts |

## Testing

- [x] `cargo test app::notifications` (4 passed)
- [x] `cargo test app::tests::` (35 passed)
- [x] `cargo test --test conversation_layout` (21 passed)
- [x] `cargo test --test reaction_persistence` (5 passed)
- [x] `cargo test --test status_section` (12 passed)
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Third responsibility in the chained `App` modularization refactor.

Depends on #46.