### PR TITLE
refactor(app): extract message actions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ pub mod events;
 pub mod inputs;
 pub mod media_support;
 pub mod message_action_diagnostics;
+pub mod message_actions;
 pub mod notifications;
 pub mod presence;
 pub mod share_picker;
@@ -37,6 +38,9 @@ use crate::app::media_support::{
 };
 pub use crate::app::media_support::{remove_owned_media_files, remove_status_media_files};
 use crate::app::message_action_diagnostics::{MessageActionDiagnostics, identifier_for_log};
+pub use crate::app::message_actions::{
+    DELETED_MESSAGE_TEXT, MessageAction, MessageActionKind, MessageStatus,
+};
 pub use crate::app::notifications::{
     Clock, NotificationProjection, Notifier, NotifyRustNotifier, SystemClock, now_or, unix_now,
 };
@@ -100,31 +104,6 @@ pub struct ChatRow {
     pub label: String,
     pub members: Vec<wr::JID>,
     pub target: wr::JID,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum MessageActionKind {
-    Edit { replacement: Arc<str> },
-    Delete,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MessageAction {
-    pub action_id: Arc<str>,
-    pub target_message_id: wr::MessageId,
-    pub chat: wr::JID,
-    pub sender: wr::JID,
-    pub kind: MessageActionKind,
-    pub occurred_at: i64,
-    pub arrival_order: u64,
-}
-
-pub const DELETED_MESSAGE_TEXT: &str = "This message was deleted.";
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct MessageStatus {
-    pub edited: bool,
-    pub deleted: bool,
 }
 
 #[derive(Debug)]
@@ -1679,42 +1658,6 @@ impl App<'_> {
         self.message_list_state.reset();
     }
 
-    pub fn selected_message(&self) -> Option<&wr::Message> {
-        self.message_list_state
-            .get_selected_message()
-            .and_then(|message_id| self.messages.get(&message_id))
-    }
-
-    pub fn message_status(&self, message_id: &wr::MessageId) -> MessageStatus {
-        self.message_actions
-            .get(message_id)
-            .map(|actions| MessageStatus {
-                edited: actions
-                    .iter()
-                    .any(|action| matches!(action.kind, MessageActionKind::Edit { .. })),
-                deleted: actions
-                    .iter()
-                    .any(|action| matches!(action.kind, MessageActionKind::Delete)),
-            })
-            .unwrap_or_default()
-    }
-
-    fn sorted_message_actions(&self, message_id: &wr::MessageId) -> Vec<MessageAction> {
-        let mut actions = self
-            .message_actions
-            .get(message_id)
-            .cloned()
-            .unwrap_or_default();
-        actions.sort_by(|left, right| {
-            (left.occurred_at, left.arrival_order, &left.action_id).cmp(&(
-                right.occurred_at,
-                right.arrival_order,
-                &right.action_id,
-            ))
-        });
-        actions
-    }
-
     pub fn apply_message_action(&mut self, action: MessageAction) {
         let target = action.target_message_id.clone();
         let base_exists = self.messages.contains_key(&target);
@@ -1779,72 +1722,6 @@ impl App<'_> {
         );
     }
 
-    fn pending_local_action_for(&self, action: &MessageAction) -> Option<Arc<str>> {
-        if action.action_id.starts_with("local-")
-            || !self
-                .messages
-                .get(&action.target_message_id)
-                .is_some_and(|message| message.info.is_from_me)
-        {
-            return None;
-        }
-        let prefix = match &action.kind {
-            MessageActionKind::Edit { .. } => "local-edit:",
-            MessageActionKind::Delete => "local-delete:",
-        };
-        let matches = self
-            .message_actions
-            .get(&action.target_message_id)?
-            .iter()
-            .filter(|local| {
-                local.action_id.starts_with(prefix)
-                    && local.chat == action.chat
-                    && local.kind == action.kind
-            });
-        let mut matches = matches.map(|local| local.action_id.clone());
-        let local = matches.next()?;
-        matches.next().is_none().then_some(local)
-    }
-
-    fn refresh_message_projection(&mut self, id: &wr::MessageId) -> Option<&'static str> {
-        let Some(current) = self.messages.get(id).cloned() else {
-            return None;
-        };
-        let mut projected = current;
-        if self.message_status(id).deleted {
-            if let wr::MessageContent::File(file) = &projected.message {
-                remove_owned_media_files(&self.media_path, &[PathBuf::from(file.path.as_ref())]);
-            }
-            projected.message = wr::MessageContent::Text(DELETED_MESSAGE_TEXT.into());
-            projected.info.quote_id = None;
-            projected.info.forwarding = Default::default();
-            self.metadata.remove(id);
-            self.image_cache.remove(id);
-        } else if let wr::MessageContent::Text(body) = &mut projected.message {
-            // Delete and edit mark the status; the displayed body remains
-            // the current effective text, re-projected for live edits.
-            for action in self.sorted_message_actions(id) {
-                if let MessageActionKind::Edit { replacement } = action.kind
-                    && !replacement.is_empty()
-                {
-                    *body = replacement;
-                }
-            }
-        }
-        self.messages.insert(id.clone(), projected.clone());
-        self.message_height_cache.invalidate(id);
-        // Persist the current effective body when the message has ever been
-        // acted on, so a restart shows current content.
-        if self
-            .message_actions
-            .get(id)
-            .is_some_and(|actions| !actions.is_empty())
-        {
-            self.db_handler.add_message(&projected);
-        }
-        Some("refreshed")
-    }
-
     pub(crate) fn record_local_message_edit(
         &mut self,
         message: &wr::Message,
@@ -1883,26 +1760,6 @@ impl App<'_> {
             occurred_at,
             arrival_order: self.local_action_sequence,
         });
-    }
-
-    pub fn follow_selected_reference(&mut self) -> bool {
-        let Some(reference_id) = self
-            .selected_message()
-            .and_then(|message| message.info.quote_id.clone())
-            .filter(|reference_id| self.messages.contains_key(reference_id))
-        else {
-            return false;
-        };
-
-        self.message_list_state.set_selected_message(reference_id);
-        self.message_list_state.update_selected = true;
-        true
-    }
-
-    pub fn message_menu_actions(&self) -> Option<Vec<MessageMenuAction>> {
-        self.message_menu
-            .as_ref()
-            .map(|(actions, _)| actions.clone())
     }
 
     pub fn select_chat(&mut self, jid: Option<wr::JID>) {

--- a/src/app/message_actions.rs
+++ b/src/app/message_actions.rs
@@ -1,0 +1,165 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use super::{App, MessageMenuAction};
+use crate::app::media_support::remove_owned_media_files;
+use whatsrust as wr;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MessageActionKind {
+    Edit { replacement: Arc<str> },
+    Delete,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MessageAction {
+    pub action_id: Arc<str>,
+    pub target_message_id: wr::MessageId,
+    pub chat: wr::JID,
+    pub sender: wr::JID,
+    pub kind: MessageActionKind,
+    pub occurred_at: i64,
+    pub arrival_order: u64,
+}
+
+pub const DELETED_MESSAGE_TEXT: &str = "This message was deleted.";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct MessageStatus {
+    pub edited: bool,
+    pub deleted: bool,
+}
+
+fn status_for_actions(actions: &[MessageAction]) -> MessageStatus {
+    MessageStatus {
+        edited: actions
+            .iter()
+            .any(|action| matches!(action.kind, MessageActionKind::Edit { .. })),
+        deleted: actions
+            .iter()
+            .any(|action| matches!(action.kind, MessageActionKind::Delete)),
+    }
+}
+
+fn sorted_actions(mut actions: Vec<MessageAction>) -> Vec<MessageAction> {
+    actions.sort_by(|left, right| {
+        (left.occurred_at, left.arrival_order, &left.action_id).cmp(&(
+            right.occurred_at,
+            right.arrival_order,
+            &right.action_id,
+        ))
+    });
+    actions
+}
+
+impl App<'_> {
+    pub fn selected_message(&self) -> Option<&wr::Message> {
+        self.message_list_state
+            .get_selected_message()
+            .and_then(|message_id| self.messages.get(&message_id))
+    }
+
+    pub fn message_status(&self, message_id: &wr::MessageId) -> MessageStatus {
+        self.message_actions
+            .get(message_id)
+            .map(|actions| status_for_actions(actions))
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn sorted_message_actions(&self, message_id: &wr::MessageId) -> Vec<MessageAction> {
+        sorted_actions(
+            self.message_actions
+                .get(message_id)
+                .cloned()
+                .unwrap_or_default(),
+        )
+    }
+
+    pub(crate) fn pending_local_action_for(&self, action: &MessageAction) -> Option<Arc<str>> {
+        if action.action_id.starts_with("local-")
+            || !self
+                .messages
+                .get(&action.target_message_id)
+                .is_some_and(|message| message.info.is_from_me)
+        {
+            return None;
+        }
+        let prefix = match &action.kind {
+            MessageActionKind::Edit { .. } => "local-edit:",
+            MessageActionKind::Delete => "local-delete:",
+        };
+        let matches = self
+            .message_actions
+            .get(&action.target_message_id)?
+            .iter()
+            .filter(|local| {
+                local.action_id.starts_with(prefix)
+                    && local.chat == action.chat
+                    && local.kind == action.kind
+            });
+        let mut matches = matches.map(|local| local.action_id.clone());
+        let local = matches.next()?;
+        matches.next().is_none().then_some(local)
+    }
+
+    pub(crate) fn refresh_message_projection(
+        &mut self,
+        id: &wr::MessageId,
+    ) -> Option<&'static str> {
+        let Some(current) = self.messages.get(id).cloned() else {
+            return None;
+        };
+        let mut projected = current;
+        if self.message_status(id).deleted {
+            if let wr::MessageContent::File(file) = &projected.message {
+                remove_owned_media_files(&self.media_path, &[PathBuf::from(file.path.as_ref())]);
+            }
+            projected.message = wr::MessageContent::Text(DELETED_MESSAGE_TEXT.into());
+            projected.info.quote_id = None;
+            projected.info.forwarding = Default::default();
+            self.metadata.remove(id);
+            self.image_cache.remove(id);
+        } else if let wr::MessageContent::Text(body) = &mut projected.message {
+            for action in self.sorted_message_actions(id) {
+                if let MessageActionKind::Edit { replacement } = action.kind
+                    && !replacement.is_empty()
+                {
+                    *body = replacement;
+                }
+            }
+        }
+        self.messages.insert(id.clone(), projected.clone());
+        self.message_height_cache.invalidate(id);
+        if self
+            .message_actions
+            .get(id)
+            .is_some_and(|actions| !actions.is_empty())
+        {
+            self.db_handler.add_message(&projected);
+        }
+        Some("refreshed")
+    }
+
+    pub fn follow_selected_reference(&mut self) -> bool {
+        let Some(reference_id) = self
+            .selected_message()
+            .and_then(|message| message.info.quote_id.clone())
+            .filter(|reference_id| self.messages.contains_key(reference_id))
+        else {
+            return false;
+        };
+
+        self.message_list_state.set_selected_message(reference_id);
+        self.message_list_state.update_selected = true;
+        true
+    }
+
+    pub fn message_menu_actions(&self) -> Option<Vec<MessageMenuAction>> {
+        self.message_menu
+            .as_ref()
+            .map(|(actions, _)| actions.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/message_actions/tests.rs
+++ b/src/app/message_actions/tests.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+fn action(
+    id: &str,
+    kind: MessageActionKind,
+    occurred_at: i64,
+    arrival_order: u64,
+) -> MessageAction {
+    MessageAction {
+        action_id: id.into(),
+        target_message_id: "target".into(),
+        chat: wr::JID::from("chat@example.test".to_owned()),
+        sender: wr::JID::from("chat@example.test".to_owned()),
+        kind,
+        occurred_at,
+        arrival_order,
+    }
+}
+
+#[test]
+fn actions_are_ordered_by_timestamp_arrival_and_id() {
+    let sorted = sorted_actions(vec![
+        action("same-b", MessageActionKind::Delete, 2, 1),
+        action("later", MessageActionKind::Delete, 3, 1),
+        action("same-a", MessageActionKind::Delete, 2, 1),
+        action("earlier-arrival", MessageActionKind::Delete, 2, 0),
+    ]);
+
+    assert_eq!(
+        sorted
+            .iter()
+            .map(|item| item.action_id.as_ref())
+            .collect::<Vec<_>>(),
+        ["earlier-arrival", "same-a", "same-b", "later"]
+    );
+}
+
+#[test]
+fn delete_status_takes_precedence_over_edit_status() {
+    let status = status_for_actions(&[
+        action(
+            "edit",
+            MessageActionKind::Edit {
+                replacement: "new".into(),
+            },
+            1,
+            1,
+        ),
+        action("delete", MessageActionKind::Delete, 2, 2),
+    ]);
+
+    assert_eq!(
+        status,
+        MessageStatus {
+            edited: true,
+            deleted: true
+        }
+    );
+}


### PR DESCRIPTION
## Summary

- Extract message-action domain types and projection behavior from the central `App` module.
- Colocate deterministic ordering and status unit tests with the responsibility.
- Preserve App-level persistence orchestration and public compatibility.

## Changes

| File | Change |
|---|---|
| `src/app/message_actions.rs` | Owns action types, status projection, ordering, and reference navigation |
| `src/app/message_actions/tests.rs` | Covers deterministic ordering and projected status |
| `src/app.rs` | Retains persistence coordination and re-exports message-action API |

## Testing

- [x] `cargo test --lib app::message_actions` (2 passed)
- [x] `cargo test --test message_actions` (19 passed)
- [x] `cargo test --test edit_action_persistence` (9 passed)
- [x] `cargo test --test selected_message_card` (11 passed)
- [x] `cargo test --test media_cleanup` (3 passed)
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Fourth responsibility in the chained `App` modularization refactor.

Depends on #47.