### PR TITLE
refactor(app): extract chat ordering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,8 @@ pub mod message_ingestion;
 pub mod notifications;
 pub mod presence;
 pub mod share_picker;
+#[cfg(test)]
+pub(crate) mod test_support;
 
 pub use crate::app;
 use crate::app::actions::{

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use std::{
 use std::{fs, thread};
 
 pub mod actions;
+pub mod chat_ordering;
 pub mod composer;
 pub mod contact_avatars;
 pub mod events;
@@ -1726,27 +1727,6 @@ impl App<'_> {
         }
     }
 
-    /// Keeps the highlighted message stable when a new message shifts the
-    /// rendered list: re-derives the selected index from the ID anchor
-    /// (selected_message) instead of trusting the now-stale index. The index
-    /// is set directly so the viewport does not jump (no update_selected).
-    fn reanchor_message_selection(&mut self, chat_jid: &wr::JID) {
-        let Some(anchor) = self.message_list_state.get_selected_message() else {
-            return;
-        };
-        let Some(messages) = self.chat_messages.get(chat_jid) else {
-            return;
-        };
-        if let Some(index) = messages
-            .iter()
-            .rev()
-            .filter(|id| self.messages.contains_key(*id))
-            .position(|id| id == &anchor)
-        {
-            self.message_list_state.selected = Some(index);
-        }
-    }
-
     fn add_message_without_sort(&mut self, message: wr::Message) {
         let chat_jid = message.info.chat.clone();
         self.add_or_update_chat(
@@ -1794,37 +1774,6 @@ impl App<'_> {
         for (jid, name) in wr::get_contacts() {
             self.contacts.insert(jid.clone(), name.clone());
             self.db_handler.add_contact(&jid, name.as_ref());
-        }
-    }
-
-    pub fn sort_chats(&mut self) {
-        let selected = self.get_selected_chat();
-        let mut entries: Vec<_> = self.chats.values().cloned().collect();
-        entries.sort_by(|a, b| {
-            let a_time = a.last_message_time.unwrap_or_default();
-            let b_time = b.last_message_time.unwrap_or_default();
-            b_time.cmp(&a_time)
-        });
-
-        self.sorted_chats = entries
-            .iter()
-            .map(|chat| chat.jid.clone())
-            .filter(|jid: &wr::JID| !jid.0.as_ref().ends_with("@broadcast"))
-            .collect();
-        self.select_chat(selected);
-    }
-
-    pub(crate) fn sort_chat_messages(&mut self, chat_jid: wr::JID) {
-        if let Some(messages) = self.chat_messages.get_mut(&chat_jid) {
-            messages.sort_by_cached_key(|msg_id| {
-                (
-                    self.messages
-                        .get(msg_id)
-                        .map(|m| m.info.timestamp)
-                        .unwrap_or(i64::MIN),
-                    msg_id.clone(),
-                )
-            });
         }
     }
 }
@@ -1952,27 +1901,6 @@ mod tests {
         fn deref_mut(&mut self) -> &mut Self::Target {
             &mut self.app
         }
-    }
-
-    #[test]
-    fn add_message_orders_out_of_order_history_for_newest_first_consumers() {
-        let mut app = TestApp::new();
-        let chat = wr::JID::from("chat@example.test".to_owned());
-
-        app.add_message(message(&chat, "newest", 30));
-        app.add_message(message(&chat, "oldest", 10));
-        app.add_message(message(&chat, "middle", 20));
-
-        let ids = &app.chat_messages[&chat];
-        assert_eq!(
-            ids.iter().map(|id| id.as_ref()).collect::<Vec<_>>(),
-            ["oldest", "middle", "newest"]
-        );
-        assert_eq!(ids.iter().next_back().map(AsRef::as_ref), Some("newest"));
-
-        app.add_message(message(&chat, "middle", 40));
-        let ids = &app.chat_messages[&chat];
-        assert_eq!(ids.last().map(AsRef::as_ref), Some("middle"));
     }
 
     #[test]
@@ -2273,57 +2201,6 @@ mod tests {
     }
 
     #[test]
-    fn new_message_preserves_selected_message_by_id() {
-        let mut app = TestApp::new();
-        let chat = wr::JID::from("chat@example.test".to_owned());
-        app.open_chat = Some(chat.clone());
-
-        app.add_message(message(&chat, "oldest", 10));
-        app.add_message(message(&chat, "middle", 20));
-        app.add_message(message(&chat, "newest", 30));
-
-        // Rendered order (render_messages reverses) is [newest, middle,
-        // oldest]; select "middle" and anchor the selection by ID.
-        app.message_list_state.select(Some(1));
-        app.message_list_state.set_selected_message("middle".into());
-
-        app.add_message(message(&chat, "newest-2", 40));
-
-        // The new message shifts the list, but the highlight stays on
-        // "middle" (now rendered index 2), not on the stale index.
-        assert_eq!(app.message_list_state.selected, Some(2));
-        assert_eq!(
-            app.message_list_state.get_selected_message(),
-            Some("middle".into())
-        );
-    }
-
-    #[test]
-    fn new_message_in_other_chat_leaves_selection_untouched() {
-        let mut app = TestApp::new();
-        let chat = wr::JID::from("chat@example.test".to_owned());
-        let other = wr::JID::from("other@example.test".to_owned());
-        app.open_chat = Some(chat.clone());
-
-        app.add_message(message(&chat, "oldest", 10));
-        app.add_message(message(&chat, "middle", 20));
-        app.add_message(message(&chat, "newest", 30));
-
-        app.message_list_state.select(Some(1));
-        app.message_list_state.set_selected_message("middle".into());
-        // Simulate the post-render state: index and ID anchor are consistent.
-        app.message_list_state.selected = Some(1);
-
-        app.add_message(message(&other, "other-msg", 40));
-
-        assert_eq!(app.message_list_state.selected, Some(1));
-        assert_eq!(
-            app.message_list_state.get_selected_message(),
-            Some("middle".into())
-        );
-    }
-
-    #[test]
     fn evicted_loaded_preview_becomes_reloadable() {
         let mut app = TestApp::new();
         let chat = wr::JID::from("chat@example.test".to_owned());
@@ -2343,24 +2220,6 @@ mod tests {
             app.metadata.get(&wr::MessageId::from("preview")),
             Some(Metadata::File(FileMeta::Downloaded))
         ));
-    }
-
-    #[test]
-    fn add_message_breaks_equal_timestamp_ties_by_message_id() {
-        let mut app = TestApp::new();
-        let chat = wr::JID::from("chat@example.test".to_owned());
-
-        app.add_message(message(&chat, "message-c", 10));
-        app.add_message(message(&chat, "message-a", 10));
-        app.add_message(message(&chat, "message-b", 10));
-
-        assert_eq!(
-            app.chat_messages[&chat]
-                .iter()
-                .map(|id| id.as_ref())
-                .collect::<Vec<_>>(),
-            ["message-a", "message-b", "message-c"]
-        );
     }
 
     #[test]

--- a/src/app/chat_ordering.rs
+++ b/src/app/chat_ordering.rs
@@ -1,0 +1,55 @@
+use super::App;
+use whatsrust as wr;
+
+impl App<'_> {
+    pub(crate) fn reanchor_message_selection(&mut self, chat_jid: &wr::JID) {
+        let Some(anchor) = self.message_list_state.get_selected_message() else {
+            return;
+        };
+        let Some(messages) = self.chat_messages.get(chat_jid) else {
+            return;
+        };
+        if let Some(index) = messages
+            .iter()
+            .rev()
+            .filter(|id| self.messages.contains_key(*id))
+            .position(|id| id == &anchor)
+        {
+            self.message_list_state.selected = Some(index);
+        }
+    }
+
+    pub fn sort_chats(&mut self) {
+        let selected = self.get_selected_chat();
+        let mut entries: Vec<_> = self.chats.values().cloned().collect();
+        entries.sort_by(|a, b| {
+            let a_time = a.last_message_time.unwrap_or_default();
+            let b_time = b.last_message_time.unwrap_or_default();
+            b_time.cmp(&a_time)
+        });
+
+        self.sorted_chats = entries
+            .iter()
+            .map(|chat| chat.jid.clone())
+            .filter(|jid: &wr::JID| !jid.0.as_ref().ends_with("@broadcast"))
+            .collect();
+        self.select_chat(selected);
+    }
+
+    pub(crate) fn sort_chat_messages(&mut self, chat_jid: wr::JID) {
+        if let Some(messages) = self.chat_messages.get_mut(&chat_jid) {
+            messages.sort_by_cached_key(|msg_id| {
+                (
+                    self.messages
+                        .get(msg_id)
+                        .map(|m| m.info.timestamp)
+                        .unwrap_or(i64::MIN),
+                    msg_id.clone(),
+                )
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/chat_ordering/tests.rs
+++ b/src/app/chat_ordering/tests.rs
@@ -1,10 +1,8 @@
 use super::*;
+use crate::app::test_support::TestApp;
 
-fn app() -> (App<'static>, tempfile::TempDir) {
-    let dir = tempfile::tempdir().unwrap();
-    let app = App::with_data_dir(dir.path(), dir.path());
-    app.db_handler.init();
-    (app, dir)
+fn app() -> TestApp {
+    TestApp::new()
 }
 
 fn message(chat: &wr::JID, id: &str, timestamp: i64) -> wr::Message {
@@ -25,7 +23,7 @@ fn message(chat: &wr::JID, id: &str, timestamp: i64) -> wr::Message {
 
 #[test]
 fn out_of_order_history_is_sorted_oldest_first() {
-    let (mut app, _dir) = app();
+    let mut app = app();
     let chat = wr::JID::from("chat@example.test".to_owned());
     for item in [("newest", 30), ("oldest", 10), ("middle", 20)] {
         app.add_message(message(&chat, item.0, item.1));
@@ -46,7 +44,7 @@ fn out_of_order_history_is_sorted_oldest_first() {
 
 #[test]
 fn equal_timestamps_are_tied_by_message_id() {
-    let (mut app, _dir) = app();
+    let mut app = app();
     let chat = wr::JID::from("chat@example.test".to_owned());
     for id in ["message-c", "message-a", "message-b"] {
         app.add_message(message(&chat, id, 10));
@@ -62,7 +60,7 @@ fn equal_timestamps_are_tied_by_message_id() {
 
 #[test]
 fn new_message_preserves_selected_message_by_id() {
-    let (mut app, _dir) = app();
+    let mut app = app();
     let chat = wr::JID::from("chat@example.test".to_owned());
     app.open_chat = Some(chat.clone());
     for item in [("oldest", 10), ("middle", 20), ("newest", 30)] {
@@ -80,7 +78,7 @@ fn new_message_preserves_selected_message_by_id() {
 
 #[test]
 fn new_message_in_other_chat_leaves_selection_untouched() {
-    let (mut app, _dir) = app();
+    let mut app = app();
     let chat = wr::JID::from("chat@example.test".to_owned());
     let other = wr::JID::from("other@example.test".to_owned());
     app.open_chat = Some(chat.clone());

--- a/src/app/chat_ordering/tests.rs
+++ b/src/app/chat_ordering/tests.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+fn app() -> (App<'static>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let app = App::with_data_dir(dir.path(), dir.path());
+    app.db_handler.init();
+    (app, dir)
+}
+
+fn message(chat: &wr::JID, id: &str, timestamp: i64) -> wr::Message {
+    wr::Message {
+        info: wr::MessageInfo {
+            id: id.into(),
+            chat: chat.clone(),
+            sender: chat.clone(),
+            timestamp,
+            forwarding: Default::default(),
+            is_from_me: false,
+            quote_id: None,
+            read_by: 0,
+        },
+        message: wr::MessageContent::Text(id.into()),
+    }
+}
+
+#[test]
+fn out_of_order_history_is_sorted_oldest_first() {
+    let (mut app, _dir) = app();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+    for item in [("newest", 30), ("oldest", 10), ("middle", 20)] {
+        app.add_message(message(&chat, item.0, item.1));
+    }
+    assert_eq!(
+        app.chat_messages[&chat]
+            .iter()
+            .map(|id| id.as_ref())
+            .collect::<Vec<_>>(),
+        ["oldest", "middle", "newest"]
+    );
+    app.add_message(message(&chat, "middle", 40));
+    assert_eq!(
+        app.chat_messages[&chat].last().map(AsRef::as_ref),
+        Some("middle")
+    );
+}
+
+#[test]
+fn equal_timestamps_are_tied_by_message_id() {
+    let (mut app, _dir) = app();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+    for id in ["message-c", "message-a", "message-b"] {
+        app.add_message(message(&chat, id, 10));
+    }
+    assert_eq!(
+        app.chat_messages[&chat]
+            .iter()
+            .map(|id| id.as_ref())
+            .collect::<Vec<_>>(),
+        ["message-a", "message-b", "message-c"]
+    );
+}
+
+#[test]
+fn new_message_preserves_selected_message_by_id() {
+    let (mut app, _dir) = app();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+    app.open_chat = Some(chat.clone());
+    for item in [("oldest", 10), ("middle", 20), ("newest", 30)] {
+        app.add_message(message(&chat, item.0, item.1));
+    }
+    app.message_list_state.select(Some(1));
+    app.message_list_state.set_selected_message("middle".into());
+    app.add_message(message(&chat, "newest-2", 40));
+    assert_eq!(app.message_list_state.selected, Some(2));
+    assert_eq!(
+        app.message_list_state.get_selected_message(),
+        Some("middle".into())
+    );
+}
+
+#[test]
+fn new_message_in_other_chat_leaves_selection_untouched() {
+    let (mut app, _dir) = app();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+    let other = wr::JID::from("other@example.test".to_owned());
+    app.open_chat = Some(chat.clone());
+    for item in [("oldest", 10), ("middle", 20), ("newest", 30)] {
+        app.add_message(message(&chat, item.0, item.1));
+    }
+    app.message_list_state.select(Some(1));
+    app.message_list_state.set_selected_message("middle".into());
+    app.message_list_state.selected = Some(1);
+    app.add_message(message(&other, "other-msg", 40));
+    assert_eq!(app.message_list_state.selected, Some(1));
+    assert_eq!(
+        app.message_list_state.get_selected_message(),
+        Some("middle".into())
+    );
+}

--- a/src/app/message_ingestion/tests.rs
+++ b/src/app/message_ingestion/tests.rs
@@ -1,40 +1,7 @@
 use std::sync::{Arc, Mutex};
 
-use super::super::{App, STATUS_BROADCAST_CHAT};
+use super::super::{STATUS_BROADCAST_CHAT, test_support::TestApp};
 use whatsrust as wr;
-
-struct TestApp {
-    app: App<'static>,
-    _dir: tempfile::TempDir,
-}
-
-impl TestApp {
-    fn new() -> Self {
-        let dir = tempfile::tempdir().unwrap();
-        let app = App::with_data_dir(dir.path(), dir.path());
-        app.db_handler.init();
-        Self { app, _dir: dir }
-    }
-}
-
-impl Drop for TestApp {
-    fn drop(&mut self) {
-        self.app.db_handler.stop();
-    }
-}
-
-impl std::ops::Deref for TestApp {
-    type Target = App<'static>;
-    fn deref(&self) -> &Self::Target {
-        &self.app
-    }
-}
-
-impl std::ops::DerefMut for TestApp {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.app
-    }
-}
 
 fn message(chat: &wr::JID, id: &str, timestamp: i64) -> wr::Message {
     wr::Message {

--- a/src/app/test_support.rs
+++ b/src/app/test_support.rs
@@ -1,0 +1,35 @@
+use super::App;
+
+pub(crate) struct TestApp {
+    pub(crate) app: App<'static>,
+    _dir: tempfile::TempDir,
+}
+
+impl TestApp {
+    pub(crate) fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let app = App::with_data_dir(dir.path(), dir.path());
+        app.db_handler.init();
+        Self { app, _dir: dir }
+    }
+}
+
+impl Drop for TestApp {
+    fn drop(&mut self) {
+        self.app.db_handler.stop();
+    }
+}
+
+impl std::ops::Deref for TestApp {
+    type Target = App<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.app
+    }
+}
+
+impl std::ops::DerefMut for TestApp {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.app
+    }
+}


### PR DESCRIPTION
## Summary

- Extract deterministic chat/message ordering and selected-message anchoring from `App`.
- Colocate ordering and selection-preservation unit tests with the responsibility.
- Leave storage and indexing behavior for the next bounded slice.

## Changes

| File | Change |
|---|---|
| `src/app/chat_ordering.rs` | Owns chat sorting, message sorting, and selection anchoring |
| `src/app/chat_ordering/tests.rs` | Covers out-of-order history, tie-breaking, and selection stability |
| `src/app.rs` | Retains message storage/indexing orchestration |

## Testing

- [x] `cargo test --lib app::chat_ordering` (4 passed)
- [x] Relevant status ordering tests passed
- [x] `cargo test --test author_message_grouping` (15 passed)
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Sixth responsibility in the chained `App` modularization refactor.

Depends on #49.