### PR TITLE
refactor(app): extract chat store

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,7 @@ use std::{fs, thread};
 
 pub mod actions;
 pub mod chat_ordering;
+pub mod chat_store;
 pub mod composer;
 pub mod contact_avatars;
 pub mod events;
@@ -1116,57 +1117,6 @@ impl App<'_> {
         }
     }
 
-    pub fn load_data_from_db(&mut self) {
-        info!("Reading database");
-        for chat in self.db_handler.get_chats() {
-            self.chats.insert(chat.jid.clone(), chat);
-        }
-        for (jid, name) in self.db_handler.get_contacts() {
-            self.contacts.insert(jid, name);
-        }
-
-        for action in self.db_handler.get_message_actions() {
-            self.local_action_sequence = self.local_action_sequence.max(
-                action
-                    .action_id
-                    .rsplit_once(':')
-                    .and_then(|(_, sequence)| sequence.parse().ok())
-                    .unwrap_or_default(),
-            );
-            self.message_actions
-                .entry(action.target_message_id.clone())
-                .or_default()
-                .push(action);
-        }
-
-        for message in self.db_handler.get_messages() {
-            self.add_message_without_sort(message);
-        }
-        let chat_ids = self.chat_messages.keys().cloned().collect::<Vec<_>>();
-        for chat_id in chat_ids {
-            self.sort_chat_messages(chat_id);
-        }
-        for (message_id, participant, emoji) in self.db_handler.get_reactions() {
-            self.reactions
-                .entry(message_id)
-                .or_default()
-                .insert(participant, emoji);
-        }
-        warn!(
-            "Finished reading database with {} chats and {} messages",
-            self.chats.len(),
-            self.messages.len()
-        );
-    }
-
-    /// Display name for a JID (chat or sender). Falls back to the JID string if not in contacts.
-    pub fn contact_name(&self, jid: &wr::JID) -> Arc<str> {
-        self.contacts
-            .get(jid)
-            .cloned()
-            .unwrap_or_else(|| jid.0.clone())
-    }
-
     pub(crate) fn now(&self) -> i64 {
         now_or(0, &*self.clock)
     }
@@ -1714,66 +1664,6 @@ impl App<'_> {
             self.chat_list_state.select(Some(0));
         } else {
             self.chat_list_state.select(None);
-        }
-    }
-
-    pub fn add_message(&mut self, message: wr::Message) {
-        let chat_jid = message.info.chat.clone();
-        let is_open_chat = self.open_chat.as_ref() == Some(&chat_jid);
-        self.add_message_without_sort(message);
-        self.sort_chat_messages(chat_jid.clone());
-        if is_open_chat {
-            self.reanchor_message_selection(&chat_jid);
-        }
-    }
-
-    fn add_message_without_sort(&mut self, message: wr::Message) {
-        let chat_jid = message.info.chat.clone();
-        self.add_or_update_chat(
-            Chat {
-                jid: chat_jid.clone(),
-                last_message_time: Some(message.info.timestamp),
-            },
-            |chat| {
-                if Some(message.info.timestamp) > chat.last_message_time {
-                    chat.last_message_time = Some(message.info.timestamp);
-                }
-            },
-        );
-
-        let id = message.info.id.clone();
-        let is_new = !self.messages.contains_key(&id);
-        let should_replace = self
-            .messages
-            .get(&id)
-            .is_none_or(|existing| existing.info.timestamp < message.info.timestamp);
-        if should_replace {
-            self.messages.insert(id.clone(), message);
-        }
-        if is_new {
-            self.chat_messages
-                .entry(chat_jid.clone())
-                .or_default()
-                .push(id.clone());
-        }
-        self.refresh_message_projection(&id);
-        self.refresh_status_contacts();
-    }
-
-    fn add_or_update_chat<F: FnOnce(&mut Chat)>(&mut self, chat: Chat, callback: F) {
-        if let Some(existing_chat) = self.chats.get_mut(&chat.jid) {
-            callback(existing_chat);
-            self.db_handler.add_chat(existing_chat);
-        } else {
-            self.db_handler.add_chat(&chat);
-            self.chats.insert(chat.jid.clone(), chat);
-        }
-    }
-
-    fn get_contacts(&mut self) {
-        for (jid, name) in wr::get_contacts() {
-            self.contacts.insert(jid.clone(), name.clone());
-            self.db_handler.add_contact(&jid, name.as_ref());
         }
     }
 }

--- a/src/app/chat_store.rs
+++ b/src/app/chat_store.rs
@@ -1,0 +1,122 @@
+use std::sync::Arc;
+
+use log::{info, warn};
+use whatsrust as wr;
+
+use super::{App, Chat};
+
+impl App<'_> {
+    pub fn load_data_from_db(&mut self) {
+        info!("Reading database");
+        for chat in self.db_handler.get_chats() {
+            self.chats.insert(chat.jid.clone(), chat);
+        }
+        for (jid, name) in self.db_handler.get_contacts() {
+            self.contacts.insert(jid, name);
+        }
+
+        for action in self.db_handler.get_message_actions() {
+            self.local_action_sequence = self.local_action_sequence.max(
+                action
+                    .action_id
+                    .rsplit_once(':')
+                    .and_then(|(_, sequence)| sequence.parse().ok())
+                    .unwrap_or_default(),
+            );
+            self.message_actions
+                .entry(action.target_message_id.clone())
+                .or_default()
+                .push(action);
+        }
+
+        for message in self.db_handler.get_messages() {
+            self.add_message_without_sort(message);
+        }
+        let chat_ids = self.chat_messages.keys().cloned().collect::<Vec<_>>();
+        for chat_id in chat_ids {
+            self.sort_chat_messages(chat_id);
+        }
+        for (message_id, participant, emoji) in self.db_handler.get_reactions() {
+            self.reactions
+                .entry(message_id)
+                .or_default()
+                .insert(participant, emoji);
+        }
+        warn!(
+            "Finished reading database with {} chats and {} messages",
+            self.chats.len(),
+            self.messages.len()
+        );
+    }
+
+    /// Display name for a JID (chat or sender). Falls back to the JID string if not in contacts.
+    pub fn contact_name(&self, jid: &wr::JID) -> Arc<str> {
+        self.contacts
+            .get(jid)
+            .cloned()
+            .unwrap_or_else(|| jid.0.clone())
+    }
+
+    pub fn add_message(&mut self, message: wr::Message) {
+        let chat_jid = message.info.chat.clone();
+        let is_open_chat = self.open_chat.as_ref() == Some(&chat_jid);
+        self.add_message_without_sort(message);
+        self.sort_chat_messages(chat_jid.clone());
+        if is_open_chat {
+            self.reanchor_message_selection(&chat_jid);
+        }
+    }
+
+    fn add_message_without_sort(&mut self, message: wr::Message) {
+        let chat_jid = message.info.chat.clone();
+        self.add_or_update_chat(
+            Chat {
+                jid: chat_jid.clone(),
+                last_message_time: Some(message.info.timestamp),
+            },
+            |chat| {
+                if Some(message.info.timestamp) > chat.last_message_time {
+                    chat.last_message_time = Some(message.info.timestamp);
+                }
+            },
+        );
+
+        let id = message.info.id.clone();
+        let is_new = !self.messages.contains_key(&id);
+        let should_replace = self
+            .messages
+            .get(&id)
+            .is_none_or(|existing| existing.info.timestamp < message.info.timestamp);
+        if should_replace {
+            self.messages.insert(id.clone(), message);
+        }
+        if is_new {
+            self.chat_messages
+                .entry(chat_jid.clone())
+                .or_default()
+                .push(id.clone());
+        }
+        self.refresh_message_projection(&id);
+        self.refresh_status_contacts();
+    }
+
+    pub(crate) fn add_or_update_chat<F: FnOnce(&mut Chat)>(&mut self, chat: Chat, callback: F) {
+        if let Some(existing_chat) = self.chats.get_mut(&chat.jid) {
+            callback(existing_chat);
+            self.db_handler.add_chat(existing_chat);
+        } else {
+            self.db_handler.add_chat(&chat);
+            self.chats.insert(chat.jid.clone(), chat);
+        }
+    }
+
+    pub(crate) fn get_contacts(&mut self) {
+        for (jid, name) in wr::get_contacts() {
+            self.contacts.insert(jid.clone(), name.clone());
+            self.db_handler.add_contact(&jid, name.as_ref());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/chat_store/tests.rs
+++ b/src/app/chat_store/tests.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+fn app() -> (App<'static>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let app = App::with_data_dir(dir.path(), dir.path());
+    app.db_handler.init();
+    (app, dir)
+}
+
+fn message(chat: &wr::JID, id: &str, timestamp: i64) -> wr::Message {
+    wr::Message {
+        info: wr::MessageInfo {
+            id: id.into(),
+            chat: chat.clone(),
+            sender: chat.clone(),
+            timestamp,
+            forwarding: Default::default(),
+            is_from_me: false,
+            quote_id: None,
+            read_by: 0,
+        },
+        message: wr::MessageContent::Text(id.into()),
+    }
+}
+
+#[test]
+fn contact_name_falls_back_to_the_jid() {
+    let (app, _dir) = app();
+    let jid = wr::JID::from("alice@example.test".to_owned());
+
+    assert_eq!(app.contact_name(&jid).as_ref(), "alice@example.test");
+}
+
+#[test]
+fn adding_a_message_registers_chat_and_indexes_message() {
+    let (mut app, _dir) = app();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+
+    app.add_message(message(&chat, "message", 42));
+
+    assert_eq!(app.chats[&chat].last_message_time, Some(42));
+    assert_eq!(
+        app.chat_messages[&chat],
+        vec![wr::MessageId::from("message")]
+    );
+}
+
+#[test]
+fn newer_message_revision_replaces_existing_body_without_duplicate_index() {
+    let (mut app, _dir) = app();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+    app.add_message(message(&chat, "message", 10));
+    app.add_message(message(&chat, "message", 20));
+
+    assert_eq!(
+        app.messages[&wr::MessageId::from("message")].info.timestamp,
+        20
+    );
+    assert_eq!(app.chat_messages[&chat].len(), 1);
+}

--- a/src/app/chat_store/tests.rs
+++ b/src/app/chat_store/tests.rs
@@ -1,11 +1,5 @@
 use super::*;
-
-fn app() -> (App<'static>, tempfile::TempDir) {
-    let dir = tempfile::tempdir().unwrap();
-    let app = App::with_data_dir(dir.path(), dir.path());
-    app.db_handler.init();
-    (app, dir)
-}
+use crate::app::test_support::TestApp;
 
 fn message(chat: &wr::JID, id: &str, timestamp: i64) -> wr::Message {
     wr::Message {
@@ -25,7 +19,7 @@ fn message(chat: &wr::JID, id: &str, timestamp: i64) -> wr::Message {
 
 #[test]
 fn contact_name_falls_back_to_the_jid() {
-    let (app, _dir) = app();
+    let app = TestApp::new();
     let jid = wr::JID::from("alice@example.test".to_owned());
 
     assert_eq!(app.contact_name(&jid).as_ref(), "alice@example.test");
@@ -33,7 +27,7 @@ fn contact_name_falls_back_to_the_jid() {
 
 #[test]
 fn adding_a_message_registers_chat_and_indexes_message() {
-    let (mut app, _dir) = app();
+    let mut app = TestApp::new();
     let chat = wr::JID::from("chat@example.test".to_owned());
 
     app.add_message(message(&chat, "message", 42));
@@ -47,7 +41,7 @@ fn adding_a_message_registers_chat_and_indexes_message() {
 
 #[test]
 fn newer_message_revision_replaces_existing_body_without_duplicate_index() {
-    let (mut app, _dir) = app();
+    let mut app = TestApp::new();
     let chat = wr::JID::from("chat@example.test".to_owned());
     app.add_message(message(&chat, "message", 10));
     app.add_message(message(&chat, "message", 20));


### PR DESCRIPTION
## Summary

- Extract chat/message storage and indexing coordination from the central `App` module.
- Colocate focused indexing tests with the responsibility.
- Delegate deterministic ordering and selection preservation to the preceding module.

## Changes

| File | Change |
|---|---|
| `src/app/chat_store.rs` | Owns database hydration, message/chat registration, contact indexing, and name fallback |
| `src/app/chat_store/tests.rs` | Covers contact fallback, indexing, and replacement without duplication |
| `src/app.rs` | Retains composition and unrelated projections |

## Testing

- [x] `cargo test app::chat_store` (3 passed)
- [x] `cargo test --test author_message_grouping` (15 passed)
- [x] Relevant persistence/action/status tests (29 passed)
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Seventh responsibility in the chained `App` modularization refactor.

Depends on #50.