### PR TITLE
refactor(app): extract chat projection

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     sync::Arc,
     sync::Condvar,
     sync::Mutex,
@@ -11,6 +11,7 @@ use std::{fs, thread};
 
 pub mod actions;
 pub mod chat_ordering;
+pub mod chat_projection;
 pub mod chat_store;
 pub mod community_bridge;
 pub mod community_hierarchy;
@@ -36,6 +37,7 @@ use crate::app::actions::{
     UnavailableClipboardWriter, UrlOpener, WhatsAppMessageEditor, WhatsAppMessageForwarder,
     WhatsAppMessageReactor, WhatsAppMessageRevoker,
 };
+pub use crate::app::chat_projection::ChatRow;
 pub use crate::app::community_hierarchy::CommunityNode;
 use crate::app::composer::Composer;
 use crate::app::contact_avatars::ContactAvatars;
@@ -92,15 +94,6 @@ enum InputReaderState {
 pub struct Chat {
     pub jid: wr::JID,
     pub last_message_time: Option<i64>,
-}
-
-/// Presentation-only Chats row. `target` and `members` are always real chat
-/// JIDs; a community never becomes a persisted or addressable chat.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ChatRow {
-    pub label: String,
-    pub members: Vec<wr::JID>,
-    pub target: wr::JID,
 }
 
 #[derive(Debug)]
@@ -1123,94 +1116,6 @@ impl App<'_> {
         let mut state = state_lock.lock().unwrap();
         *state = InputReaderState::Stopped;
         state_changed.notify_all();
-    }
-
-    pub fn get_selected_chat(&self) -> Option<wr::JID> {
-        let rows = self.visible_chat_rows();
-        self.chat_list_state
-            .selected()
-            .and_then(|index| rows.get(index))
-            .map(|row| row.target.clone())
-    }
-
-    pub fn chat_rows(&self) -> Vec<ChatRow> {
-        let mut grouped = HashSet::new();
-        let community_metadata = self
-            .communities
-            .iter()
-            .map(|node| node.jid.clone())
-            .collect::<HashSet<_>>();
-        let mut rows = Vec::new();
-        for community in self.communities.iter().filter(|node| node.is_root) {
-            let members = community
-                .linked_groups
-                .iter()
-                .filter(|jid| self.chats.contains_key(*jid))
-                .cloned()
-                .collect::<Vec<_>>();
-            if members.is_empty() {
-                continue;
-            }
-            grouped.extend(members.iter().cloned());
-            let target = members
-                .iter()
-                .max_by_key(|jid| self.chat_recency(jid))
-                .expect("non-empty community members")
-                .clone();
-            rows.push(ChatRow {
-                label: community.name.clone(),
-                members,
-                target,
-            });
-        }
-        rows.extend(
-            self.sorted_chats
-                .iter()
-                .filter(|jid| !grouped.contains(*jid))
-                .filter(|jid| !community_metadata.contains(*jid))
-                .map(|jid| ChatRow {
-                    label: self.contact_name(jid).to_string(),
-                    members: vec![(*jid).clone()],
-                    target: (*jid).clone(),
-                }),
-        );
-        rows.sort_by(|left, right| {
-            self.chat_recency(&right.target)
-                .cmp(&self.chat_recency(&left.target))
-                .then_with(|| left.label.cmp(&right.label))
-                .then_with(|| left.target.0.cmp(&right.target.0))
-        });
-        rows
-    }
-
-    pub fn visible_chat_rows(&self) -> Vec<ChatRow> {
-        let query = self.contact_search.input.to_lowercase();
-        self.chat_rows()
-            .into_iter()
-            .filter(|row| {
-                query.is_empty()
-                    || row.label.to_lowercase().contains(&query)
-                    || row
-                        .members
-                        .iter()
-                        .any(|jid| self.contact_name(jid).to_lowercase().contains(&query))
-            })
-            .collect()
-    }
-
-    pub fn chat_row_item(&self, row: &ChatRow) -> crate::ui::contact_list::ContactListItem {
-        crate::ui::contact_list::ContactListItem::from_row(self, row)
-    }
-
-    fn chat_recency(&self, jid: &wr::JID) -> i64 {
-        self.chat_messages
-            .get(jid)
-            .into_iter()
-            .flatten()
-            .filter_map(|id| self.messages.get(id).map(|message| message.info.timestamp))
-            .max()
-            .or_else(|| self.chats.get(jid).and_then(|chat| chat.last_message_time))
-            .unwrap_or_default()
     }
 
     pub fn open_chat(&self) -> Option<wr::JID> {

--- a/src/app/chat_projection.rs
+++ b/src/app/chat_projection.rs
@@ -1,0 +1,106 @@
+use std::collections::HashSet;
+
+use super::App;
+use whatsrust as wr;
+
+/// Presentation-only Chats row. `target` and `members` are always real chat
+/// JIDs; a community never becomes a persisted or addressable chat.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatRow {
+    pub label: String,
+    pub members: Vec<wr::JID>,
+    pub target: wr::JID,
+}
+
+impl App<'_> {
+    pub fn get_selected_chat(&self) -> Option<wr::JID> {
+        let rows = self.visible_chat_rows();
+        self.chat_list_state
+            .selected()
+            .and_then(|index| rows.get(index))
+            .map(|row| row.target.clone())
+    }
+
+    pub fn chat_rows(&self) -> Vec<ChatRow> {
+        let mut grouped = HashSet::new();
+        let community_metadata = self
+            .communities
+            .iter()
+            .map(|node| node.jid.clone())
+            .collect::<HashSet<_>>();
+        let mut rows = Vec::new();
+        for community in self.communities.iter().filter(|node| node.is_root) {
+            let members = community
+                .linked_groups
+                .iter()
+                .filter(|jid| self.chats.contains_key(*jid))
+                .cloned()
+                .collect::<Vec<_>>();
+            if members.is_empty() {
+                continue;
+            }
+            grouped.extend(members.iter().cloned());
+            let target = members
+                .iter()
+                .max_by_key(|jid| self.chat_recency(jid))
+                .expect("non-empty community members")
+                .clone();
+            rows.push(ChatRow {
+                label: community.name.clone(),
+                members,
+                target,
+            });
+        }
+        rows.extend(
+            self.sorted_chats
+                .iter()
+                .filter(|jid| !grouped.contains(*jid))
+                .filter(|jid| !community_metadata.contains(*jid))
+                .map(|jid| ChatRow {
+                    label: self.contact_name(jid).to_string(),
+                    members: vec![(*jid).clone()],
+                    target: (*jid).clone(),
+                }),
+        );
+        rows.sort_by(|left, right| {
+            self.chat_recency(&right.target)
+                .cmp(&self.chat_recency(&left.target))
+                .then_with(|| left.label.cmp(&right.label))
+                .then_with(|| left.target.0.cmp(&right.target.0))
+        });
+        rows
+    }
+
+    pub fn visible_chat_rows(&self) -> Vec<ChatRow> {
+        let query = self.contact_search.input.to_lowercase();
+        self.chat_rows()
+            .into_iter()
+            .filter(|row| {
+                query.is_empty()
+                    || row.label.to_lowercase().contains(&query)
+                    || row
+                        .members
+                        .iter()
+                        .any(|jid| self.contact_name(jid).to_lowercase().contains(&query))
+            })
+            .collect()
+    }
+
+    pub fn chat_row_item(&self, row: &ChatRow) -> crate::ui::contact_list::ContactListItem {
+        crate::ui::contact_list::ContactListItem::from_row(self, row)
+    }
+
+    fn chat_recency(&self, jid: &wr::JID) -> i64 {
+        self.chat_messages
+            .get(jid)
+            .into_iter()
+            .flatten()
+            .filter_map(|id| self.messages.get(id).map(|message| message.info.timestamp))
+            .max()
+            .or_else(|| self.chats.get(jid).and_then(|chat| chat.last_message_time))
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/chat_projection/tests.rs
+++ b/src/app/chat_projection/tests.rs
@@ -1,0 +1,58 @@
+use super::super::{Chat, CommunityNode, test_support::TestApp};
+use whatsrust as wr;
+
+fn jid(value: &str) -> wr::JID {
+    wr::JID::from(value.to_owned())
+}
+
+#[test]
+fn community_rows_use_the_most_recent_linked_chat_as_target() {
+    let mut app = TestApp::new();
+    let first = jid("first@g.us");
+    let second = jid("second@g.us");
+
+    app.chats.insert(
+        first.clone(),
+        Chat {
+            jid: first.clone(),
+            last_message_time: Some(10),
+        },
+    );
+    app.chats.insert(
+        second.clone(),
+        Chat {
+            jid: second.clone(),
+            last_message_time: Some(20),
+        },
+    );
+    app.sorted_chats = vec![first.clone(), second.clone()];
+    app.communities = vec![CommunityNode {
+        jid: jid("community@g.us"),
+        name: "Project Team".into(),
+        is_root: true,
+        linked_groups: vec![first, second.clone()],
+    }];
+
+    let rows = app.chat_rows();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].label, "Project Team");
+    assert_eq!(rows[0].target, second);
+}
+
+#[test]
+fn selected_chat_follows_the_visible_row_target() {
+    let mut app = TestApp::new();
+    let chat = jid("alice@s.whatsapp.net");
+    app.chats.insert(
+        chat.clone(),
+        Chat {
+            jid: chat.clone(),
+            last_message_time: Some(1),
+        },
+    );
+    app.sorted_chats = vec![chat.clone()];
+    app.chat_list_state.select(Some(0));
+
+    assert_eq!(app.get_selected_chat(), Some(chat));
+}


### PR DESCRIPTION
## Summary

- Extract pure chat-row projection from the central `App` module.
- Keep chat opening, permissions, and private-reply behavior for later responsibilities.
- Colocate focused row-target and selection tests with the projection.

## Testing

- [x] `cargo test --lib app::chat_projection` (2 passed)
- [x] `cargo test --test communities` (5 passed)
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Tenth responsibility in the chained `App` modularization refactor.

Depends on #53.