### PR TITLE
refactor(app): extract chat opening

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use std::{
 use std::{fs, thread};
 
 pub mod actions;
+pub mod chat_opening;
 pub mod chat_ordering;
 pub mod chat_projection;
 pub mod chat_store;
@@ -1118,68 +1119,10 @@ impl App<'_> {
         state_changed.notify_all();
     }
 
-    pub fn open_chat(&self) -> Option<wr::JID> {
-        self.open_chat.clone()
-    }
-
     /// The status contact currently open in the Status section's right
     /// pane (set by pressing Enter on a contact), mirroring `open_chat`.
     pub fn open_status_contact(&self) -> Option<wr::JID> {
         self.open_status_contact.clone()
-    }
-
-    /// Opens the currently highlighted chat: it becomes the rendered
-    /// conversation, composer target, and presence subscription.
-    pub fn open_selected_chat(&mut self) {
-        if let Some(chat) = self.get_selected_chat() {
-            self.open_chat = Some(chat.clone());
-            self.refresh_group_permission(&chat);
-            self.sort_chat_messages(chat);
-            self.message_list_state.reset();
-        }
-    }
-
-    fn refresh_group_permission(&mut self, chat: &wr::JID) {
-        if Self::is_group_chat(chat) {
-            self.group_permissions.remove(chat);
-            if let Ok(info) = wr::get_group_info(chat) {
-                self.group_permissions.insert(chat.clone(), info);
-            }
-        }
-        self.composer.set_blocked(self.composer_blocked());
-    }
-
-    pub fn composer_blocked(&self) -> bool {
-        self.open_chat().is_some_and(|chat| {
-            self.group_permissions
-                .get(&chat)
-                .is_some_and(|info| info.is_announce && !info.is_admin)
-        })
-    }
-
-    pub fn is_status_chat(jid: &wr::JID) -> bool {
-        jid.0.as_ref() == STATUS_BROADCAST_CHAT
-    }
-
-    /// True for group conversations (JIDs of the form `number@g.us`).
-    pub fn is_group_chat(jid: &wr::JID) -> bool {
-        jid.0.as_ref().ends_with("@g.us")
-    }
-
-    /// Opens a direct conversation by JID, regardless of whether it already
-    /// appears in the chat list. The in-memory entry is created here so the
-    /// recipient shows up as a row; the database row is created on the first
-    /// real message, so an empty conversation is never persisted.
-    pub fn open_chat_by_jid(&mut self, jid: wr::JID) {
-        self.chats.entry(jid.clone()).or_insert_with(|| Chat {
-            jid: jid.clone(),
-            last_message_time: None,
-        });
-        self.sort_chats();
-        self.open_chat = Some(jid.clone());
-        self.composer.set_blocked(self.composer_blocked());
-        self.sort_chat_messages(jid);
-        self.message_list_state.reset();
     }
 
     /// Jumps to a private conversation with the sender of the selected
@@ -1575,29 +1518,6 @@ mod tests {
         fn deref_mut(&mut self) -> &mut Self::Target {
             &mut self.app
         }
-    }
-
-    #[test]
-    fn is_group_chat_detects_group_jids() {
-        assert!(App::is_group_chat(&wr::JID::from("123@g.us".to_owned())));
-        assert!(!App::is_group_chat(&wr::JID::from(
-            "123@s.whatsapp.net".to_owned()
-        )));
-        assert!(!App::is_group_chat(&wr::JID::from(
-            "status@broadcast".to_owned()
-        )));
-    }
-
-    #[test]
-    fn open_chat_by_jid_registers_recipient_in_chat_list() {
-        let mut app = TestApp::new();
-        let recipient = wr::JID::from("alice@s.whatsapp.net".to_owned());
-
-        app.open_chat_by_jid(recipient.clone());
-
-        assert_eq!(app.open_chat(), Some(recipient.clone()));
-        assert!(app.chats.contains_key(&recipient));
-        assert!(app.sorted_chats.contains(&recipient));
     }
 
     #[test]

--- a/src/app/chat_opening.rs
+++ b/src/app/chat_opening.rs
@@ -1,0 +1,66 @@
+use whatsrust as wr;
+
+use super::{App, Chat, STATUS_BROADCAST_CHAT};
+
+#[cfg(test)]
+mod tests;
+
+impl App<'_> {
+    pub fn open_chat(&self) -> Option<wr::JID> {
+        self.open_chat.clone()
+    }
+
+    /// Opens the currently highlighted chat: it becomes the rendered
+    /// conversation, composer target, and presence subscription.
+    pub fn open_selected_chat(&mut self) {
+        if let Some(chat) = self.get_selected_chat() {
+            self.open_chat = Some(chat.clone());
+            self.refresh_group_permission(&chat);
+            self.sort_chat_messages(chat);
+            self.message_list_state.reset();
+        }
+    }
+
+    fn refresh_group_permission(&mut self, chat: &wr::JID) {
+        if Self::is_group_chat(chat) {
+            self.group_permissions.remove(chat);
+            if let Ok(info) = wr::get_group_info(chat) {
+                self.group_permissions.insert(chat.clone(), info);
+            }
+        }
+        self.composer.set_blocked(self.composer_blocked());
+    }
+
+    pub fn composer_blocked(&self) -> bool {
+        self.open_chat().is_some_and(|chat| {
+            self.group_permissions
+                .get(&chat)
+                .is_some_and(|info| info.is_announce && !info.is_admin)
+        })
+    }
+
+    pub fn is_status_chat(jid: &wr::JID) -> bool {
+        jid.0.as_ref() == STATUS_BROADCAST_CHAT
+    }
+
+    /// True for group conversations (JIDs of the form `number@g.us`).
+    pub fn is_group_chat(jid: &wr::JID) -> bool {
+        jid.0.as_ref().ends_with("@g.us")
+    }
+
+    /// Opens a direct conversation by JID, regardless of whether it already
+    /// appears in the chat list. The in-memory entry is created here so the
+    /// recipient shows up as a row; the database row is created on the first
+    /// real message, so an empty conversation is never persisted.
+    pub fn open_chat_by_jid(&mut self, jid: wr::JID) {
+        self.chats.entry(jid.clone()).or_insert_with(|| Chat {
+            jid: jid.clone(),
+            last_message_time: None,
+        });
+        self.sort_chats();
+        self.open_chat = Some(jid.clone());
+        self.composer.set_blocked(self.composer_blocked());
+        self.sort_chat_messages(jid);
+        self.message_list_state.reset();
+    }
+}

--- a/src/app/chat_opening/tests.rs
+++ b/src/app/chat_opening/tests.rs
@@ -1,0 +1,26 @@
+use super::App;
+use crate::app::test_support::TestApp;
+use whatsrust as wr;
+
+#[test]
+fn is_group_chat_detects_group_jids() {
+    assert!(App::is_group_chat(&wr::JID::from("123@g.us".to_owned())));
+    assert!(!App::is_group_chat(&wr::JID::from(
+        "123@s.whatsapp.net".to_owned()
+    )));
+    assert!(!App::is_group_chat(&wr::JID::from(
+        "status@broadcast".to_owned()
+    )));
+}
+
+#[test]
+fn open_chat_by_jid_registers_recipient_in_chat_list() {
+    let mut app = TestApp::new();
+    let recipient = wr::JID::from("alice@s.whatsapp.net".to_owned());
+
+    app.open_chat_by_jid(recipient.clone());
+
+    assert_eq!(app.open_chat(), Some(recipient.clone()));
+    assert!(app.chats.contains_key(&recipient));
+    assert!(app.sorted_chats.contains(&recipient));
+}


### PR DESCRIPTION
## Summary

- Extract chat opening and group-permission coordination from the central `App` module.
- Keep private-reply behavior as a separate future responsibility.
- Colocate focused opening tests with the module.

## Testing

- [x] Focused `chat_opening` tests (2 passed)
- [x] Relevant keybinding, composer, and message-action tests passed
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Eleventh responsibility in the chained `App` modularization refactor.

Depends on #54.