### PR TITLE
refactor(bridge): extract profile pictures

### DIFF
--- a/whatsrust/build.rs
+++ b/whatsrust/build.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf, process::Command};
+use std::{env, fs, path::PathBuf, process::Command};
 
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
@@ -32,8 +32,22 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=lib");
     // Directory-level rerun-if-changed is unreliable for edits inside files,
-    // so also track the Go sources that feed the archive explicitly.
-    println!("cargo:rerun-if-changed=lib/main.go");
+    // so track every production Go source that feeds the archive explicitly.
+    let mut go_sources = fs::read_dir("lib")
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension().is_some_and(|extension| extension == "go")
+                && !path
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().ends_with("_test.go"))
+        })
+        .collect::<Vec<_>>();
+    go_sources.sort();
+    for source in go_sources {
+        println!("cargo:rerun-if-changed={}", source.display());
+    }
     println!("cargo:rerun-if-changed=lib/go.mod");
     println!("cargo:rerun-if-changed=lib/go.sum");
     println!(

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -198,15 +198,9 @@ static void callLogInfo(LogHandler hdl, const char* msg, uint8_t level) {
 */
 import "C"
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"image"
-	_ "image/gif"
-	_ "image/jpeg"
-	_ "image/png"
-	"io"
 	"math"
 	"mime"
 	"os"
@@ -2894,118 +2888,6 @@ func freeCommunityEntries(entries []C.CommunityEntry) {
 
 func communityEntryIncluded(isParent, parentEmpty bool) bool {
 	return isParent || !parentEmpty
-}
-
-const (
-	profilePictureStatusAvailable uint8 = iota
-	profilePictureStatusUnavailable
-	profilePictureStatusInvalidJID
-	profilePictureStatusClientUnavailable
-	profilePictureStatusCancelled
-	profilePictureStatusMetadataFailed
-	profilePictureStatusEmptyURL
-	profilePictureStatusDownloadFailed
-	profilePictureStatusOversized
-	profilePictureStatusInvalidImage
-)
-
-const (
-	profilePictureMaxSize int64 = 512 * 1024
-	profilePictureTimeout       = 8 * time.Second
-)
-
-var errProfilePictureOversized = errors.New("profile picture exceeds size limit")
-
-type profilePictureLookup func(
-	context.Context,
-	types.JID,
-	*whatsmeow.GetProfilePictureParams,
-) (*types.ProfilePictureInfo, error)
-
-type profilePictureDownload func(context.Context, string, int64) ([]byte, error)
-
-type profilePictureOutcome struct {
-	status      uint8
-	pictureID   string
-	pictureType string
-	data        []byte
-}
-
-func fetchProfilePicture(ctx context.Context, jidText string, lookup profilePictureLookup, download profilePictureDownload) profilePictureOutcome {
-	jidText = strings.TrimSpace(jidText)
-	jid, err := types.ParseJID(jidText)
-	if err != nil || strings.Count(jidText, "@") != 1 || jid.User == "" || (jid.Server != types.DefaultUserServer && jid.Server != types.HiddenUserServer && jid.Server != types.GroupServer) {
-		return profilePictureOutcome{status: profilePictureStatusInvalidJID}
-	}
-	if lookup == nil || download == nil {
-		return profilePictureOutcome{status: profilePictureStatusClientUnavailable}
-	}
-
-	info, err := lookup(ctx, jid.ToNonAD(), &whatsmeow.GetProfilePictureParams{Preview: true})
-	if errors.Is(err, whatsmeow.ErrProfilePictureUnauthorized) || errors.Is(err, whatsmeow.ErrProfilePictureNotSet) {
-		return profilePictureOutcome{status: profilePictureStatusUnavailable}
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
-		return profilePictureOutcome{status: profilePictureStatusCancelled}
-	}
-	if err != nil || info == nil {
-		return profilePictureOutcome{status: profilePictureStatusMetadataFailed}
-	}
-	if info.URL == "" {
-		return profilePictureOutcome{status: profilePictureStatusEmptyURL, pictureID: info.ID, pictureType: info.Type}
-	}
-
-	data, err := download(ctx, info.URL, profilePictureMaxSize)
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
-		return profilePictureOutcome{status: profilePictureStatusCancelled, pictureID: info.ID, pictureType: info.Type}
-	}
-	if errors.Is(err, errProfilePictureOversized) {
-		return profilePictureOutcome{status: profilePictureStatusOversized, pictureID: info.ID, pictureType: info.Type}
-	}
-	if err != nil {
-		return profilePictureOutcome{status: profilePictureStatusDownloadFailed, pictureID: info.ID, pictureType: info.Type}
-	}
-	if int64(len(data)) > profilePictureMaxSize {
-		return profilePictureOutcome{status: profilePictureStatusOversized, pictureID: info.ID, pictureType: info.Type}
-	}
-	if len(data) == 0 {
-		return profilePictureOutcome{status: profilePictureStatusInvalidImage, pictureID: info.ID, pictureType: info.Type}
-	}
-	if _, _, err := image.DecodeConfig(bytes.NewReader(data)); err != nil {
-		return profilePictureOutcome{status: profilePictureStatusInvalidImage, pictureID: info.ID, pictureType: info.Type}
-	}
-	return profilePictureOutcome{status: profilePictureStatusAvailable, pictureID: info.ID, pictureType: info.Type, data: data}
-}
-
-func downloadProfilePicture(ctx context.Context, url string, limit int64) ([]byte, error) {
-	response, err := client.DangerousInternals().DoMediaDownloadRequest(ctx, url)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > limit {
-		return nil, errProfilePictureOversized
-	}
-	return data, nil
-}
-
-func profilePictureToC(outcome profilePictureOutcome) C.ProfilePictureResult {
-	result := C.ProfilePictureResult{status: C.uint8_t(outcome.status)}
-	if outcome.pictureID != "" {
-		result.picture_id = C.CString(outcome.pictureID)
-	}
-	if outcome.pictureType != "" {
-		result.picture_type = C.CString(outcome.pictureType)
-	}
-	if len(outcome.data) > 0 {
-		result.data = (*C.uint8_t)(C.CBytes(outcome.data))
-		result.size = C.uint32_t(len(outcome.data))
-	}
-	return result
 }
 
 //export C_GetProfilePicture

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -379,57 +379,6 @@ func TestFetchProfilePictureAvailablePreview(t *testing.T) {
 	}
 }
 
-func TestFetchProfilePictureRecoverableOutcomes(t *testing.T) {
-	validImage := profilePicturePNG(t)
-	metadataError := errors.New("metadata failed")
-	downloadError := errors.New("download failed")
-	cases := []struct {
-		name        string
-		jid         string
-		info        *types.ProfilePictureInfo
-		lookupErr   error
-		data        []byte
-		downloadErr error
-		lookupNil   bool
-		want        uint8
-	}{
-		{name: "empty JID", jid: "", want: profilePictureStatusInvalidJID},
-		{name: "malformed JID", jid: "a@b@c", want: profilePictureStatusInvalidJID},
-		{name: "unsupported JID", jid: "status@broadcast", want: profilePictureStatusInvalidJID},
-		{name: "client unavailable", jid: "1@s.whatsapp.net", lookupNil: true, want: profilePictureStatusClientUnavailable},
-		{name: "privacy unauthorized", jid: "1@s.whatsapp.net", lookupErr: whatsmeow.ErrProfilePictureUnauthorized, want: profilePictureStatusUnavailable},
-		{name: "picture not set", jid: "1@s.whatsapp.net", lookupErr: whatsmeow.ErrProfilePictureNotSet, want: profilePictureStatusUnavailable},
-		{name: "cancelled metadata", jid: "1@s.whatsapp.net", lookupErr: context.Canceled, want: profilePictureStatusCancelled},
-		{name: "metadata failure", jid: "1@s.whatsapp.net", lookupErr: metadataError, want: profilePictureStatusMetadataFailed},
-		{name: "nil metadata", jid: "1@s.whatsapp.net", want: profilePictureStatusMetadataFailed},
-		{name: "empty URL", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{ID: "id", Type: "preview"}, want: profilePictureStatusEmptyURL},
-		{name: "network failure", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, downloadErr: downloadError, want: profilePictureStatusDownloadFailed},
-		{name: "cancelled download", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, downloadErr: context.DeadlineExceeded, want: profilePictureStatusCancelled},
-		{name: "oversized download", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, downloadErr: errProfilePictureOversized, want: profilePictureStatusOversized},
-		{name: "oversized returned payload", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, data: make([]byte, profilePictureMaxSize+1), want: profilePictureStatusOversized},
-		{name: "empty image", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, want: profilePictureStatusInvalidImage},
-		{name: "invalid image", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, data: []byte("not an image"), want: profilePictureStatusInvalidImage},
-		{name: "valid contact preview", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, data: validImage, want: profilePictureStatusAvailable},
-	}
-
-	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
-			var lookup profilePictureLookup
-			if !testCase.lookupNil {
-				lookup = func(context.Context, types.JID, *whatsmeow.GetProfilePictureParams) (*types.ProfilePictureInfo, error) {
-					return testCase.info, testCase.lookupErr
-				}
-			}
-			outcome := fetchProfilePicture(context.Background(), testCase.jid, lookup, func(context.Context, string, int64) ([]byte, error) {
-				return testCase.data, testCase.downloadErr
-			})
-			if outcome.status != testCase.want {
-				t.Fatalf("status = %d, want %d", outcome.status, testCase.want)
-			}
-		})
-	}
-}
-
 func TestViewOnceWrappersBecomeUnavailablePlaceholders(t *testing.T) {
 	for _, testCase := range []struct {
 		name string

--- a/whatsrust/lib/profile_picture.go
+++ b/whatsrust/lib/profile_picture.go
@@ -1,0 +1,138 @@
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+	uint8_t status;
+	char* picture_id;
+	char* picture_type;
+	uint8_t* data;
+	uint32_t size;
+} ProfilePictureResult;
+*/
+import "C"
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"strings"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+const (
+	profilePictureStatusAvailable uint8 = iota
+	profilePictureStatusUnavailable
+	profilePictureStatusInvalidJID
+	profilePictureStatusClientUnavailable
+	profilePictureStatusCancelled
+	profilePictureStatusMetadataFailed
+	profilePictureStatusEmptyURL
+	profilePictureStatusDownloadFailed
+	profilePictureStatusOversized
+	profilePictureStatusInvalidImage
+)
+
+const (
+	profilePictureMaxSize int64 = 512 * 1024
+	profilePictureTimeout       = 8 * time.Second
+)
+
+var errProfilePictureOversized = errors.New("profile picture exceeds size limit")
+
+type profilePictureLookup func(context.Context, types.JID, *whatsmeow.GetProfilePictureParams) (*types.ProfilePictureInfo, error)
+type profilePictureDownload func(context.Context, string, int64) ([]byte, error)
+
+type profilePictureOutcome struct {
+	status      uint8
+	pictureID   string
+	pictureType string
+	data        []byte
+}
+
+func fetchProfilePicture(ctx context.Context, jidText string, lookup profilePictureLookup, download profilePictureDownload) profilePictureOutcome {
+	jidText = strings.TrimSpace(jidText)
+	jid, err := types.ParseJID(jidText)
+	if err != nil || strings.Count(jidText, "@") != 1 || jid.User == "" || (jid.Server != types.DefaultUserServer && jid.Server != types.HiddenUserServer && jid.Server != types.GroupServer) {
+		return profilePictureOutcome{status: profilePictureStatusInvalidJID}
+	}
+	if lookup == nil || download == nil {
+		return profilePictureOutcome{status: profilePictureStatusClientUnavailable}
+	}
+
+	info, err := lookup(ctx, jid.ToNonAD(), &whatsmeow.GetProfilePictureParams{Preview: true})
+	if errors.Is(err, whatsmeow.ErrProfilePictureUnauthorized) || errors.Is(err, whatsmeow.ErrProfilePictureNotSet) {
+		return profilePictureOutcome{status: profilePictureStatusUnavailable}
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+		return profilePictureOutcome{status: profilePictureStatusCancelled}
+	}
+	if err != nil || info == nil {
+		return profilePictureOutcome{status: profilePictureStatusMetadataFailed}
+	}
+	if info.URL == "" {
+		return profilePictureOutcome{status: profilePictureStatusEmptyURL, pictureID: info.ID, pictureType: info.Type}
+	}
+
+	data, err := download(ctx, info.URL, profilePictureMaxSize)
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+		return profilePictureOutcome{status: profilePictureStatusCancelled, pictureID: info.ID, pictureType: info.Type}
+	}
+	if errors.Is(err, errProfilePictureOversized) {
+		return profilePictureOutcome{status: profilePictureStatusOversized, pictureID: info.ID, pictureType: info.Type}
+	}
+	if err != nil {
+		return profilePictureOutcome{status: profilePictureStatusDownloadFailed, pictureID: info.ID, pictureType: info.Type}
+	}
+	if int64(len(data)) > profilePictureMaxSize {
+		return profilePictureOutcome{status: profilePictureStatusOversized, pictureID: info.ID, pictureType: info.Type}
+	}
+	if len(data) == 0 {
+		return profilePictureOutcome{status: profilePictureStatusInvalidImage, pictureID: info.ID, pictureType: info.Type}
+	}
+	if _, _, err := image.DecodeConfig(bytes.NewReader(data)); err != nil {
+		return profilePictureOutcome{status: profilePictureStatusInvalidImage, pictureID: info.ID, pictureType: info.Type}
+	}
+	return profilePictureOutcome{status: profilePictureStatusAvailable, pictureID: info.ID, pictureType: info.Type, data: data}
+}
+
+func downloadProfilePicture(ctx context.Context, url string, limit int64) ([]byte, error) {
+	response, err := client.DangerousInternals().DoMediaDownloadRequest(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, errProfilePictureOversized
+	}
+	return data, nil
+}
+
+func profilePictureToC(outcome profilePictureOutcome) C.ProfilePictureResult {
+	result := C.ProfilePictureResult{status: C.uint8_t(outcome.status)}
+	if outcome.pictureID != "" {
+		result.picture_id = C.CString(outcome.pictureID)
+	}
+	if outcome.pictureType != "" {
+		result.picture_type = C.CString(outcome.pictureType)
+	}
+	if len(outcome.data) > 0 {
+		result.data = (*C.uint8_t)(C.CBytes(outcome.data))
+		result.size = C.uint32_t(len(outcome.data))
+	}
+	return result
+}

--- a/whatsrust/lib/profile_picture_test.go
+++ b/whatsrust/lib/profile_picture_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestFetchProfilePictureRecoverableOutcomes(t *testing.T) {
+	validImage := profilePicturePNG(t)
+	metadataError := errors.New("metadata failed")
+	downloadError := errors.New("download failed")
+	cases := []struct {
+		name        string
+		jid         string
+		info        *types.ProfilePictureInfo
+		lookupErr   error
+		data        []byte
+		downloadErr error
+		lookupNil   bool
+		want        uint8
+	}{
+		{name: "empty JID", jid: "", want: profilePictureStatusInvalidJID},
+		{name: "malformed JID", jid: "a@b@c", want: profilePictureStatusInvalidJID},
+		{name: "unsupported JID", jid: "status@broadcast", want: profilePictureStatusInvalidJID},
+		{name: "client unavailable", jid: "1@s.whatsapp.net", lookupNil: true, want: profilePictureStatusClientUnavailable},
+		{name: "privacy unauthorized", jid: "1@s.whatsapp.net", lookupErr: whatsmeow.ErrProfilePictureUnauthorized, want: profilePictureStatusUnavailable},
+		{name: "picture not set", jid: "1@s.whatsapp.net", lookupErr: whatsmeow.ErrProfilePictureNotSet, want: profilePictureStatusUnavailable},
+		{name: "cancelled metadata", jid: "1@s.whatsapp.net", lookupErr: context.Canceled, want: profilePictureStatusCancelled},
+		{name: "metadata failure", jid: "1@s.whatsapp.net", lookupErr: metadataError, want: profilePictureStatusMetadataFailed},
+		{name: "nil metadata", jid: "1@s.whatsapp.net", want: profilePictureStatusMetadataFailed},
+		{name: "empty URL", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{ID: "id", Type: "preview"}, want: profilePictureStatusEmptyURL},
+		{name: "network failure", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, downloadErr: downloadError, want: profilePictureStatusDownloadFailed},
+		{name: "cancelled download", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, downloadErr: context.DeadlineExceeded, want: profilePictureStatusCancelled},
+		{name: "oversized download", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, downloadErr: errProfilePictureOversized, want: profilePictureStatusOversized},
+		{name: "oversized returned payload", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, data: make([]byte, profilePictureMaxSize+1), want: profilePictureStatusOversized},
+		{name: "empty image", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, want: profilePictureStatusInvalidImage},
+		{name: "invalid image", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, data: []byte("not an image"), want: profilePictureStatusInvalidImage},
+		{name: "valid contact preview", jid: "1@s.whatsapp.net", info: &types.ProfilePictureInfo{URL: "url"}, data: validImage, want: profilePictureStatusAvailable},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var lookup profilePictureLookup
+			if !testCase.lookupNil {
+				lookup = func(context.Context, types.JID, *whatsmeow.GetProfilePictureParams) (*types.ProfilePictureInfo, error) {
+					return testCase.info, testCase.lookupErr
+				}
+			}
+			outcome := fetchProfilePicture(context.Background(), testCase.jid, lookup, func(context.Context, string, int64) ([]byte, error) {
+				return testCase.data, testCase.downloadErr
+			})
+			if outcome.status != testCase.want {
+				t.Fatalf("status = %d, want %d", outcome.status, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extract profile-picture lookup, validation, and result conversion from the monolithic Go bridge.
- Preserve the exported C wrappers and ownership contract unchanged.
- Track every production Go source explicitly from the Cargo build script.

## Changes

| File | Change |
|---|---|
| `whatsrust/lib/profile_picture.go` | Owns profile-picture lookup and conversion |
| `whatsrust/lib/profile_picture_test.go` | Covers recoverable lookup outcomes |
| `whatsrust/lib/main.go` | Retains thin exported C wrappers |
| `whatsrust/build.rs` | Tracks all production `.go` inputs for archive rebuilds |

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cargo check --manifest-path whatsrust/Cargo.toml`
- [x] Rust formatting and diff checks

Second responsibility in the Go bridge modularization chain.

Depends on #55.