### PR TITLE
refactor(app): extract private replies

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ pub mod message_actions;
 pub mod message_ingestion;
 pub mod notifications;
 pub mod presence;
+pub mod private_reply;
 pub mod share_picker;
 #[cfg(test)]
 pub(crate) mod test_support;
@@ -1125,39 +1126,6 @@ impl App<'_> {
         self.open_status_contact.clone()
     }
 
-    /// Jumps to a private conversation with the sender of the selected
-    /// message. Only meaningful inside a group, on a message sent by
-    /// someone else (the sender JID is the group participant).
-    pub fn reply_privately(&mut self) {
-        let Some(message) = self.selected_message().cloned() else {
-            return self.unavailable("Reply in private is not available");
-        };
-        if message.info.is_from_me {
-            return self.unavailable("Reply in private is not available for your own messages");
-        }
-        let Some(chat) = self.open_chat() else {
-            return self.unavailable("Reply in private is not available");
-        };
-        if !Self::is_group_chat(&chat) {
-            return self.unavailable("Reply in private is only available in groups");
-        }
-        // Group participants can be a LID while the real direct chat lives
-        // under its phone number; resolve so we open/send to the stored chat
-        // instead of an empty LID-keyed thread.
-        let target = wr::resolve_dm_chat(&message.info.sender)
-            .unwrap_or_else(|| message.info.sender.clone());
-        let name = self.contact_name(&target).to_string();
-        self.open_chat_by_jid(target);
-        // Mirror the status "reply to DM" flow: switch to the Chats view,
-        // focus the conversation, quote the original message and drop the
-        // user straight into the composer for the private reply.
-        self.selected_section = Section::Chats;
-        self.composer.quote = Some(message);
-        self.conversation_mode = ConversationMode::ComposerEditing;
-        self.focus_pane = FocusPane::Conversation;
-        self.action_notice = Some(ActionNotice::ReplyPrivatelyNamed(name));
-    }
-
     /// Re-derives `status_contacts` from the `status@broadcast` chat and
     /// keeps the list selection valid. Runs on every message arrival.
     fn refresh_status_contacts(&mut self) {
@@ -1518,106 +1486,6 @@ mod tests {
         fn deref_mut(&mut self) -> &mut Self::Target {
             &mut self.app
         }
-    }
-
-    #[test]
-    fn reply_privately_from_group_jumps_to_sender_direct_chat() {
-        let mut app = TestApp::new();
-        let group = wr::JID::from("123@g.us".to_owned());
-        let alice = wr::JID::from("alice@s.whatsapp.net".to_owned());
-        let group_msg = wr::Message {
-            info: wr::MessageInfo {
-                id: "g1".into(),
-                chat: group.clone(),
-                sender: alice.clone(),
-                timestamp: 100,
-                forwarding: Default::default(),
-                is_from_me: false,
-                quote_id: None,
-                read_by: 0,
-            },
-            message: wr::MessageContent::Text("hello group".into()),
-        };
-        app.open_chat = Some(group.clone());
-        app.add_message(group_msg);
-        app.message_list_state.set_selected_message("g1".into());
-
-        app.reply_privately();
-
-        assert_eq!(app.open_chat(), Some(alice.clone()));
-        assert!(app.chats.contains_key(&alice));
-        assert_eq!(app.selected_section, Section::Chats);
-        assert_eq!(app.focus_pane, FocusPane::Conversation);
-        assert_eq!(app.conversation_mode, ConversationMode::ComposerEditing);
-        assert_eq!(
-            app.composer.quote.as_ref().map(|m| m.info.id.as_ref()),
-            Some("g1")
-        );
-        assert!(matches!(
-            app.action_notice,
-            Some(ActionNotice::ReplyPrivatelyNamed(_))
-        ));
-    }
-
-    #[test]
-    fn reply_privately_is_refused_outside_groups() {
-        let mut app = TestApp::new();
-        let dm = wr::JID::from("alice@s.whatsapp.net".to_owned());
-        let msg = wr::Message {
-            info: wr::MessageInfo {
-                id: "m1".into(),
-                chat: dm.clone(),
-                sender: dm.clone(),
-                timestamp: 100,
-                forwarding: Default::default(),
-                is_from_me: false,
-                quote_id: None,
-                read_by: 0,
-            },
-            message: wr::MessageContent::Text("hi".into()),
-        };
-        app.open_chat = Some(dm.clone());
-        app.add_message(msg);
-        app.message_list_state.set_selected_message("m1".into());
-
-        app.reply_privately();
-
-        assert_eq!(app.open_chat(), Some(dm.clone()));
-        assert!(matches!(
-            app.action_notice,
-            Some(ActionNotice::Unavailable(_))
-        ));
-    }
-
-    #[test]
-    fn reply_privately_is_refused_for_own_group_message() {
-        let mut app = TestApp::new();
-        let group = wr::JID::from("123@g.us".to_owned());
-        let me = wr::JID::from("me@s.whatsapp.net".to_owned());
-        let own_msg = wr::Message {
-            info: wr::MessageInfo {
-                id: "g1".into(),
-                chat: group.clone(),
-                sender: me.clone(),
-                timestamp: 100,
-                forwarding: Default::default(),
-                is_from_me: true,
-                quote_id: None,
-                read_by: 0,
-            },
-            message: wr::MessageContent::Text("my message".into()),
-        };
-        app.open_chat = Some(group.clone());
-        app.add_message(own_msg);
-        app.message_list_state.set_selected_message("g1".into());
-
-        app.reply_privately();
-
-        assert_eq!(app.open_chat(), Some(group.clone()));
-        assert!(matches!(
-            app.action_notice,
-            Some(ActionNotice::Unavailable(_))
-        ));
     }
 
     #[test]

--- a/src/app/private_reply.rs
+++ b/src/app/private_reply.rs
@@ -1,0 +1,44 @@
+use super::{App, ConversationMode, FocusPane, Section, actions::ActionNotice};
+use whatsrust as wr;
+
+#[cfg(test)]
+mod tests;
+
+impl App<'_> {
+    /// Jumps to a private conversation with the sender of the selected
+    /// incoming message. The chat-opening mechanics remain owned by
+    /// `chat_opening`.
+    pub fn reply_privately(&mut self) {
+        let Some(message) = self.selected_message().cloned() else {
+            return self.unavailable("Reply in private is not available");
+        };
+        if self.message_status(&message.info.id).deleted {
+            return self.unavailable("This message was deleted.");
+        }
+        if message.info.is_from_me {
+            return self.unavailable("Reply in private is not available for your own messages");
+        }
+        let Some(chat) = self.open_chat() else {
+            return self.unavailable("Reply in private is not available");
+        };
+        if self.selected_section == Section::Status || !Self::is_group_chat(&chat) {
+            return self.unavailable("Reply in private is only available in groups");
+        }
+        if message.info.chat != chat {
+            return self.unavailable("Reply in private is not available");
+        }
+
+        // Group participants can be a LID while the real direct chat lives
+        // under its phone number; resolve so we open/send to the stored chat
+        // instead of an empty LID-keyed thread.
+        let target = wr::resolve_dm_chat(&message.info.sender)
+            .unwrap_or_else(|| message.info.sender.clone());
+        let name = self.contact_name(&target).to_string();
+        self.open_chat_by_jid(target);
+        self.selected_section = Section::Chats;
+        self.composer.quote = Some(message);
+        self.conversation_mode = ConversationMode::ComposerEditing;
+        self.focus_pane = FocusPane::Conversation;
+        self.action_notice = Some(ActionNotice::ReplyPrivatelyNamed(name));
+    }
+}

--- a/src/app/private_reply/tests.rs
+++ b/src/app/private_reply/tests.rs
@@ -1,0 +1,133 @@
+use crate::app::actions::{ActionNotice, ConversationMode, FocusPane, Section};
+use crate::app::test_support::TestApp;
+use crate::app::{MessageAction, MessageActionKind};
+use whatsrust as wr;
+
+fn message(chat: &wr::JID, sender: &wr::JID, id: &str, is_from_me: bool) -> wr::Message {
+    wr::Message {
+        info: wr::MessageInfo {
+            id: id.into(),
+            chat: chat.clone(),
+            sender: sender.clone(),
+            timestamp: 100,
+            forwarding: Default::default(),
+            is_from_me,
+            quote_id: None,
+            read_by: 0,
+        },
+        message: wr::MessageContent::Text("hello group".into()),
+    }
+}
+
+fn select(app: &mut TestApp, message: wr::Message) {
+    let id = message.info.id.clone();
+    app.add_message(message);
+    app.message_list_state.set_selected_message(id);
+}
+
+#[test]
+fn reply_privately_from_group_registers_direct_chat_and_preserves_quote_and_composer() {
+    let mut app = TestApp::new();
+    let group = wr::JID::from("123@g.us".to_owned());
+    let alice = wr::JID::from("alice@s.whatsapp.net".to_owned());
+    select(&mut app, message(&group, &alice, "g1", false));
+    app.open_chat = Some(group);
+
+    app.reply_privately();
+
+    assert_eq!(app.open_chat(), Some(alice.clone()));
+    assert!(app.chats.contains_key(&alice));
+    assert_eq!(app.selected_section, Section::Chats);
+    assert_eq!(app.focus_pane, FocusPane::Conversation);
+    assert_eq!(app.conversation_mode, ConversationMode::ComposerEditing);
+    assert_eq!(
+        app.composer.quote.as_ref().map(|m| m.info.id.as_ref()),
+        Some("g1")
+    );
+    assert!(matches!(
+        app.action_notice,
+        Some(ActionNotice::ReplyPrivatelyNamed(_))
+    ));
+}
+
+#[test]
+fn reply_privately_refuses_invalid_selection_and_preserves_chat() {
+    let mut app = TestApp::new();
+    let group = wr::JID::from("123@g.us".to_owned());
+    app.open_chat = Some(group.clone());
+
+    app.reply_privately();
+
+    assert_eq!(app.open_chat(), Some(group));
+    assert!(matches!(
+        app.action_notice,
+        Some(ActionNotice::Unavailable(_))
+    ));
+}
+
+#[test]
+fn reply_privately_refuses_own_outside_group_status_and_deleted_messages() {
+    let mut app = TestApp::new();
+    let group = wr::JID::from("123@g.us".to_owned());
+    let alice = wr::JID::from("alice@s.whatsapp.net".to_owned());
+    let dm = alice.clone();
+
+    select(&mut app, message(&group, &alice, "own", true));
+    app.open_chat = Some(group.clone());
+    app.reply_privately();
+    assert!(matches!(
+        app.action_notice,
+        Some(ActionNotice::Unavailable(_))
+    ));
+
+    select(&mut app, message(&dm, &dm, "dm", false));
+    app.open_chat = Some(dm.clone());
+    app.reply_privately();
+    assert!(matches!(
+        app.action_notice,
+        Some(ActionNotice::Unavailable(_))
+    ));
+
+    select(&mut app, message(&group, &alice, "status", false));
+    app.open_chat = Some(group.clone());
+    app.selected_section = Section::Status;
+    app.reply_privately();
+    assert!(matches!(
+        app.action_notice,
+        Some(ActionNotice::Unavailable(_))
+    ));
+
+    select(&mut app, message(&group, &alice, "deleted", false));
+    app.selected_section = Section::Chats;
+    app.apply_message_action(MessageAction {
+        action_id: "delete".into(),
+        target_message_id: "deleted".into(),
+        chat: group.clone(),
+        sender: alice,
+        kind: MessageActionKind::Delete,
+        occurred_at: 101,
+        arrival_order: 1,
+    });
+    app.reply_privately();
+    assert!(matches!(
+        app.action_notice,
+        Some(ActionNotice::Unavailable(_))
+    ));
+}
+
+#[test]
+fn reply_privately_refuses_message_from_another_chat() {
+    let mut app = TestApp::new();
+    let open_group = wr::JID::from("123@g.us".to_owned());
+    let other_group = wr::JID::from("456@g.us".to_owned());
+    let alice = wr::JID::from("alice@s.whatsapp.net".to_owned());
+    select(&mut app, message(&other_group, &alice, "other", false));
+    app.open_chat = Some(open_group);
+
+    app.reply_privately();
+
+    assert!(matches!(
+        app.action_notice,
+        Some(ActionNotice::Unavailable(_))
+    ));
+}


### PR DESCRIPTION
## Summary

- Extract private-reply policy and orchestration from the central `App` module.
- Delegate direct-chat opening to the existing chat-opening responsibility.
- Colocate policy and transition tests with the module.

## Testing

- [x] Private-reply tests (4 passed)
- [x] Relevant message-action tests (3 passed)
- [x] Input/status tests (2 passed)
- [x] `cargo check --all-targets`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Twelfth responsibility in the chained `App` modularization refactor.

Depends on #56.