### PR TITLE
refactor(bridge): extract chat settings

### DIFF
--- a/whatsrust/lib/chat_settings.go
+++ b/whatsrust/lib/chat_settings.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+type chatSettingsLookup func(context.Context, types.JID) (types.LocalChatSettings, error)
+type chatSettingsJIDMapping func(context.Context, types.JID) (types.JID, error)
+
+type chatSettingsPayload struct {
+	found      bool
+	mutedUntil int64
+	pinned     bool
+	archived   bool
+}
+
+func lookupChatSettings(
+	ctx context.Context,
+	jid types.JID,
+	lookup chatSettingsLookup,
+	lidForPN chatSettingsJIDMapping,
+	pnForLID chatSettingsJIDMapping,
+) (types.LocalChatSettings, error) {
+	settings, err := lookup(ctx, jid)
+	if err != nil || settings.Found {
+		return settings, err
+	}
+
+	var alternate types.JID
+	switch jid.Server {
+	case types.DefaultUserServer:
+		alternate, _ = lidForPN(ctx, jid)
+	case types.HiddenUserServer:
+		alternate, _ = pnForLID(ctx, jid)
+	}
+	if alternate.IsEmpty() {
+		return settings, nil
+	}
+
+	if alternateSettings, alternateErr := lookup(ctx, alternate.ToNonAD()); alternateErr == nil && alternateSettings.Found {
+		return alternateSettings, nil
+	}
+	return settings, nil
+}
+
+func chatSettingsPayloadFrom(settings types.LocalChatSettings) chatSettingsPayload {
+	mutedUntil := int64(0)
+	if !settings.MutedUntil.IsZero() {
+		mutedUntil = settings.MutedUntil.Unix()
+	}
+	return chatSettingsPayload{
+		found:      settings.Found,
+		mutedUntil: mutedUntil,
+		pinned:     settings.Pinned,
+		archived:   settings.Archived,
+	}
+}

--- a/whatsrust/lib/chat_settings_test.go
+++ b/whatsrust/lib/chat_settings_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestLookupChatSettingsUsesEquivalentJIDWhenPrimaryIsMissing(t *testing.T) {
+	ctx := context.Background()
+	lid := types.NewJID("alice", types.HiddenUserServer)
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	want := types.LocalChatSettings{Found: true, Pinned: true}
+
+	got, err := lookupChatSettings(ctx, pn, func(_ context.Context, jid types.JID) (types.LocalChatSettings, error) {
+		if jid == pn {
+			return types.LocalChatSettings{}, nil
+		}
+		if jid == lid {
+			return want, nil
+		}
+		t.Fatalf("unexpected lookup JID: %s", jid)
+		return types.LocalChatSettings{}, nil
+	}, func(_ context.Context, jid types.JID) (types.JID, error) {
+		if jid != pn {
+			t.Fatalf("mapping JID = %s, want %s", jid, pn)
+		}
+		return lid, nil
+	}, nil)
+
+	if err != nil || got != want {
+		t.Fatalf("settings = %#v, err = %v; want %#v, nil", got, err, want)
+	}
+}
+
+func TestLookupChatSettingsPreservesPrimaryError(t *testing.T) {
+	wantErr := errors.New("settings unavailable")
+	got, err := lookupChatSettings(context.Background(), types.NewJID("1", types.DefaultUserServer), func(context.Context, types.JID) (types.LocalChatSettings, error) {
+		return types.LocalChatSettings{}, wantErr
+	}, nil, nil)
+
+	if !errors.Is(err, wantErr) || got.Found {
+		t.Fatalf("settings = %#v, err = %v; want empty settings and original error", got, err)
+	}
+}
+
+func TestChatSettingsPayloadFromUsesUnixSecondsAndZeroForUnsetTime(t *testing.T) {
+	settings := types.LocalChatSettings{
+		Found:      true,
+		MutedUntil: time.Unix(123, 456).In(time.FixedZone("offset", 3600)),
+		Pinned:     true,
+		Archived:   true,
+	}
+
+	got := chatSettingsPayloadFrom(settings)
+	want := chatSettingsPayload{found: true, mutedUntil: 123, pinned: true, archived: true}
+	if got != want {
+		t.Fatalf("payload = %#v, want %#v", got, want)
+	}
+	if zero := chatSettingsPayloadFrom(types.LocalChatSettings{}); zero.mutedUntil != 0 {
+		t.Fatalf("unset muted time = %d, want 0", zero.mutedUntil)
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -2914,40 +2914,23 @@ func C_FreeProfilePicture(result C.ProfilePictureResult) {
 func C_GetChatSettings(cjid C.JID) C.ChatSettings {
 	ctx := context.Background()
 	jid := cToJid(cjid).ToNonAD()
-
-	settings, err := client.Store.ChatSettings.GetChatSettings(ctx, jid)
+	settings, err := lookupChatSettings(
+		ctx,
+		jid,
+		client.Store.ChatSettings.GetChatSettings,
+		client.Store.LIDs.GetLIDForPN,
+		client.Store.LIDs.GetPNForLID,
+	)
 	if err != nil {
 		LOG_WARN("failed to get chat settings for %s: %v", jid, err)
 		return C.ChatSettings{}
 	}
-
-	if !settings.Found {
-		if jid.Server == types.DefaultUserServer {
-			// App state often stores settings under LID JID, try that if PN lookup missed.
-			if lidJID, mapErr := client.Store.LIDs.GetLIDForPN(ctx, jid); mapErr == nil && !lidJID.IsEmpty() {
-				if altSettings, altErr := client.Store.ChatSettings.GetChatSettings(ctx, lidJID.ToNonAD()); altErr == nil && altSettings.Found {
-					settings = altSettings
-				}
-			}
-		} else if jid.Server == types.HiddenUserServer {
-			if pnJID, mapErr := client.Store.LIDs.GetPNForLID(ctx, jid); mapErr == nil && !pnJID.IsEmpty() {
-				if altSettings, altErr := client.Store.ChatSettings.GetChatSettings(ctx, pnJID.ToNonAD()); altErr == nil && altSettings.Found {
-					settings = altSettings
-				}
-			}
-		}
-	}
-
-	mutedUntil := int64(0)
-	if !settings.MutedUntil.IsZero() {
-		mutedUntil = settings.MutedUntil.Unix()
-	}
-
+	payload := chatSettingsPayloadFrom(settings)
 	return C.ChatSettings{
-		found:       C.bool(settings.Found),
-		muted_until: C.int64_t(mutedUntil),
-		pinned:      C.bool(settings.Pinned),
-		archived:    C.bool(settings.Archived),
+		found:       C.bool(payload.found),
+		muted_until: C.int64_t(payload.mutedUntil),
+		pinned:      C.bool(payload.pinned),
+		archived:    C.bool(payload.archived),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract chat-settings lookup and result conversion from the monolithic Go bridge.
- Keep the exported C wrapper and struct contract unchanged.
- Add focused fallback and timestamp tests beside the responsibility.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`

Third responsibility in the Go bridge modularization chain.

Depends on #57.