### PR TITLE
refactor(bridge): extract group info

### DIFF
--- a/whatsrust/lib/group_info.go
+++ b/whatsrust/lib/group_info.go
@@ -1,0 +1,84 @@
+package main
+
+/*
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+	uint8_t status;
+	bool is_announce;
+	bool is_admin;
+} GroupInfoResult;
+*/
+import "C"
+
+import (
+	"context"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+const (
+	groupInfoStatusOK uint8 = iota
+	groupInfoStatusNotGroup
+	groupInfoStatusClientUnavailable
+	groupInfoStatusRequestFailed
+)
+
+const groupInfoTimeout = 5 * time.Second
+
+var groupInfoClientUnavailable = groupInfoResult{status: groupInfoStatusClientUnavailable}
+
+type groupInfoLookup func(context.Context, types.JID) (*types.GroupInfo, error)
+type groupInfoSelfMatcher func(types.GroupParticipant) bool
+
+type groupInfoResult struct {
+	status   uint8
+	announce bool
+	admin    bool
+}
+
+func fetchGroupInfo(client *whatsmeow.Client, jid types.JID, matchesSelf groupInfoSelfMatcher) groupInfoResult {
+	if client == nil {
+		return groupInfoClientUnavailable
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), groupInfoTimeout)
+	defer cancel()
+	return fetchGroupInfoWith(ctx, jid, client.GetGroupInfo, matchesSelf)
+}
+
+func fetchGroupInfoWith(ctx context.Context, jid types.JID, lookup groupInfoLookup, matchesSelf groupInfoSelfMatcher) groupInfoResult {
+	if jid.Server != types.GroupServer {
+		return groupInfoResult{status: groupInfoStatusNotGroup}
+	}
+	if lookup == nil {
+		return groupInfoClientUnavailable
+	}
+
+	info, err := lookup(ctx, jid)
+	if err != nil || info == nil {
+		LOG_WARN("failed to get group info for %s: %v", jid, err)
+		return groupInfoResult{status: groupInfoStatusRequestFailed}
+	}
+
+	result := groupInfoResult{
+		announce: info.IsAnnounce,
+	}
+	for _, participant := range info.Participants {
+		if matchesSelf != nil && matchesSelf(participant) {
+			result.admin = participant.IsAdmin || participant.IsSuperAdmin
+			break
+		}
+	}
+	return result
+}
+
+func groupInfoResultToC(result groupInfoResult) C.GroupInfoResult {
+	return C.GroupInfoResult{
+		status:      C.uint8_t(result.status),
+		is_announce: C.bool(result.announce),
+		is_admin:    C.bool(result.admin),
+	}
+}

--- a/whatsrust/lib/group_info_test.go
+++ b/whatsrust/lib/group_info_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestFetchGroupInfoPreservesStatusesAndGroupFields(t *testing.T) {
+	wantErr := errors.New("group request failed")
+	group := types.NewJID("123", types.GroupServer)
+	cases := []struct {
+		name       string
+		jid        types.JID
+		lookup     groupInfoLookup
+		wantStatus uint8
+		wantResult groupInfoResult
+	}{
+		{name: "not a group", jid: types.NewJID("1", types.DefaultUserServer), lookup: func(context.Context, types.JID) (*types.GroupInfo, error) {
+			t.Fatal("lookup must not run")
+			return nil, nil
+		}, wantStatus: groupInfoStatusNotGroup},
+		{name: "client unavailable", jid: group, wantStatus: groupInfoStatusClientUnavailable},
+		{name: "request failed", jid: group, lookup: func(context.Context, types.JID) (*types.GroupInfo, error) { return nil, wantErr }, wantStatus: groupInfoStatusRequestFailed},
+		{name: "successful group", jid: group, lookup: func(context.Context, types.JID) (*types.GroupInfo, error) {
+			return &types.GroupInfo{GroupAnnounce: types.GroupAnnounce{IsAnnounce: true}, Participants: []types.GroupParticipant{{IsAdmin: true}}}, nil
+		}, wantResult: groupInfoResult{announce: true, admin: true}},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := fetchGroupInfoWith(context.Background(), testCase.jid, testCase.lookup, func(types.GroupParticipant) bool { return true })
+			if result.status != testCase.wantStatus {
+				t.Fatalf("status = %d, want %d", result.status, testCase.wantStatus)
+			}
+			if testCase.wantResult != (groupInfoResult{}) && result != testCase.wantResult {
+				t.Fatalf("result = %#v, want %#v", result, testCase.wantResult)
+			}
+		})
+	}
+}
+
+func TestFetchGroupInfoRequiresIdentityMatchForAdmin(t *testing.T) {
+	group := types.NewJID("123", types.GroupServer)
+	info := &types.GroupInfo{Participants: []types.GroupParticipant{{IsAdmin: true}}}
+	result := fetchGroupInfoWith(context.Background(), group, func(context.Context, types.JID) (*types.GroupInfo, error) { return info, nil }, func(types.GroupParticipant) bool { return false })
+	if result.admin {
+		t.Fatal("unmatched administrator must not grant admin permission")
+	}
+}
+
+func TestGroupInfoResultToCPreservesABIFields(t *testing.T) {
+	result := groupInfoResultToC(groupInfoResult{status: groupInfoStatusRequestFailed, announce: true, admin: true})
+	if result.status != 3 || !bool(result.is_announce) || !bool(result.is_admin) {
+		t.Fatalf("C result = %#v, want status 3 with announce and admin", result)
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -649,29 +649,12 @@ func GetSelfId(client *whatsmeow.Client) string {
 
 //export C_GetGroupInfo
 func C_GetGroupInfo(cjid C.JID) C.GroupInfoResult {
-	if client == nil || cjid == nil {
-		return C.GroupInfoResult{status: 2}
+	if cjid == nil {
+		return groupInfoResultToC(groupInfoClientUnavailable)
 	}
-	jid := cToJid(cjid).ToNonAD()
-	if jid.Server != types.GroupServer {
-		return C.GroupInfoResult{status: 1}
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	info, err := client.GetGroupInfo(ctx, jid)
-	if err != nil {
-		LOG_WARN("failed to get group info for %s: %v", jid, err)
-		return C.GroupInfoResult{status: 3}
-	}
-
-	result := C.GroupInfoResult{is_announce: C.bool(info.IsAnnounce)}
-	for _, participant := range info.Participants {
-		if participantMatchesSelf(client, participant) {
-			result.is_admin = C.bool(participant.IsAdmin || participant.IsSuperAdmin)
-			break
-		}
-	}
-	return result
+	return groupInfoResultToC(fetchGroupInfo(client, cToJid(cjid).ToNonAD(), func(participant types.GroupParticipant) bool {
+		return participantMatchesSelf(client, participant)
+	}))
 }
 
 // GetChatId returns the normalized chat id (conversation key): LID→PN, broadcast→per-sender, status as-is.


### PR DESCRIPTION
## Summary

- Extract group-info lookup, admin detection, and result conversion from the Go bridge.
- Reuse participant identity matching for PN/LID/device normalization.
- Preserve the exported C wrapper and result layout unchanged.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`

Fourth responsibility in the Go bridge modularization chain.

Depends on #59.