### PR TITLE
refactor(app): extract media cache

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -20,6 +20,7 @@ pub mod composer;
 pub mod contact_avatars;
 pub mod events;
 pub mod inputs;
+pub mod media_cache;
 pub mod media_support;
 pub mod message_action_diagnostics;
 pub mod message_actions;
@@ -48,7 +49,6 @@ use crate::app::contact_avatars::ContactAvatars;
 use crate::app::events::{AppEvent, AppInput, AttachmentViewerState, ViewerPreviewState};
 use crate::app::media_support::{
     apply_video_play_marker, generate_video_thumbnail, has_decent_video_thumbnail,
-    probe_audio_duration,
 };
 pub use crate::app::media_support::{remove_owned_media_files, remove_status_media_files};
 use crate::app::message_action_diagnostics::{MessageActionDiagnostics, identifier_for_log};
@@ -432,62 +432,6 @@ impl App<'_> {
         self.presence_diagnostics = PresenceDiagnostics::new(enabled);
     }
 
-    pub fn touch_image_cache(&mut self, path: &Arc<str>) {
-        if self.image_cache.contains_key(path) {
-            self.image_cache_order.retain(|cached| cached != path);
-            self.image_cache_order.push_back(path.clone());
-        }
-    }
-
-    fn mark_evicted_preview_reloadable(&mut self, path: &Arc<str>) {
-        for (id, message) in &self.messages {
-            if matches!(&message.message, wr::MessageContent::File(file) if file.path == *path)
-                && matches!(
-                    self.metadata.get(id),
-                    Some(Metadata::File(FileMeta::Loaded))
-                )
-            {
-                self.metadata
-                    .insert(id.clone(), Metadata::File(FileMeta::Downloaded));
-                self.message_height_cache.invalidate(id);
-            }
-        }
-    }
-
-    /// Spawns a background probe for the audio duration of `message_id` once
-    /// its file is on disk. No-op for non-audio messages and for paths that
-    /// already have a cached duration.
-    fn spawn_audio_duration_probe_if_missing(&self, message_id: &wr::MessageId) {
-        let Some(file) = (match self
-            .messages
-            .get(message_id)
-            .map(|message| &message.message)
-        {
-            Some(wr::MessageContent::File(file)) => Some(file.clone()),
-            _ => None,
-        }) else {
-            return;
-        };
-        if !matches!(file.kind, wr::FileKind::Audio)
-            || self.audio_durations.contains_key(file.path.as_ref())
-        {
-            return;
-        }
-        let tx = self.tx.clone();
-        let media_path = self.media_path.to_owned();
-        let message_id = message_id.clone();
-        thread::spawn(move || {
-            let absolute = media_path.join(file.path.as_ref());
-            let duration = probe_audio_duration(&absolute);
-            tx.send(AppInput::App(AppEvent::SetAudioDuration(
-                message_id.clone(),
-                file.path,
-                duration,
-            )))
-            .unwrap();
-        });
-    }
-
     pub fn handle_whatsapp_event(&mut self, event: wr::Event) -> bool {
         match event {
             wr::Event::AppStateSyncComplete => {
@@ -772,20 +716,7 @@ impl App<'_> {
             let should_draw = match msg {
                 Ok(AppInput::App(event)) => match event {
                     AppEvent::SetFilePreview(message_id, file_path, img) => {
-                        const IMAGE_CACHE_CAPACITY: usize = 50;
-                        if !self.image_cache.contains_key(&file_path)
-                            && self.image_cache.len() >= IMAGE_CACHE_CAPACITY
-                            && let Some(oldest) = self.image_cache_order.pop_front()
-                        {
-                            self.image_cache.remove(&oldest);
-                            self.mark_evicted_preview_reloadable(&oldest);
-                        }
-                        self.image_cache.insert(file_path.clone(), img);
-                        self.image_cache_order.retain(|path| path != &file_path);
-                        self.image_cache_order.push_back(file_path.clone());
-                        self.metadata
-                            .insert(message_id.clone(), Metadata::File(FileMeta::Loaded));
-                        self.message_height_cache.invalidate(&message_id);
+                        self.cache_file_preview(message_id.clone(), file_path, img);
                         if let Some(viewer) = self.attachment_viewer.as_mut()
                             && viewer.message_id == message_id
                         {
@@ -1320,28 +1251,6 @@ mod tests {
         fn deref_mut(&mut self) -> &mut Self::Target {
             &mut self.app
         }
-    }
-
-    #[test]
-    fn evicted_loaded_preview_becomes_reloadable() {
-        let mut app = TestApp::new();
-        let chat = wr::JID::from("chat@example.test".to_owned());
-        let mut preview = message(&chat, "preview", 1);
-        preview.message = wr::MessageContent::File(wr::FileContent {
-            kind: wr::FileKind::Image,
-            path: "old.png".into(),
-            ..Default::default()
-        });
-        app.messages.insert("preview".into(), preview);
-        app.metadata
-            .insert("preview".into(), Metadata::File(FileMeta::Loaded));
-
-        app.mark_evicted_preview_reloadable(&Arc::from("old.png"));
-
-        assert!(matches!(
-            app.metadata.get(&wr::MessageId::from("preview")),
-            Some(Metadata::File(FileMeta::Downloaded))
-        ));
     }
 
     #[test]

--- a/src/app/media_cache.rs
+++ b/src/app/media_cache.rs
@@ -1,0 +1,96 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::thread;
+
+use ratatui_image::protocol::StatefulProtocol;
+use whatsrust as wr;
+
+use super::media_support::probe_audio_duration;
+use super::{App, AppEvent, AppInput, FileMeta, Metadata};
+
+const IMAGE_CACHE_CAPACITY: usize = 50;
+
+fn touch_order(order: &mut VecDeque<Arc<str>>, path: &Arc<str>) {
+    order.retain(|cached| cached != path);
+    order.push_back(path.clone());
+}
+
+impl App<'_> {
+    pub fn touch_image_cache(&mut self, path: &Arc<str>) {
+        if self.image_cache.contains_key(path) {
+            touch_order(&mut self.image_cache_order, path);
+        }
+    }
+
+    pub(crate) fn cache_file_preview(
+        &mut self,
+        message_id: wr::MessageId,
+        file_path: Arc<str>,
+        preview: StatefulProtocol,
+    ) {
+        if !self.image_cache.contains_key(&file_path)
+            && self.image_cache.len() >= IMAGE_CACHE_CAPACITY
+            && let Some(oldest) = self.image_cache_order.pop_front()
+        {
+            self.image_cache.remove(&oldest);
+            self.mark_evicted_preview_reloadable(&oldest);
+        }
+        self.image_cache.insert(file_path.clone(), preview);
+        self.touch_image_cache(&file_path);
+        self.metadata
+            .insert(message_id.clone(), Metadata::File(FileMeta::Loaded));
+        self.message_height_cache.invalidate(&message_id);
+    }
+
+    fn mark_evicted_preview_reloadable(&mut self, path: &Arc<str>) {
+        for (id, message) in &self.messages {
+            if matches!(&message.message, wr::MessageContent::File(file) if file.path == *path)
+                && matches!(
+                    self.metadata.get(id),
+                    Some(Metadata::File(FileMeta::Loaded))
+                )
+            {
+                self.metadata
+                    .insert(id.clone(), Metadata::File(FileMeta::Downloaded));
+                self.message_height_cache.invalidate(id);
+            }
+        }
+    }
+
+    /// Spawns a background probe for the audio duration of `message_id` once
+    /// its file is on disk. No-op for non-audio messages and for paths that
+    /// already have a cached duration.
+    pub(crate) fn spawn_audio_duration_probe_if_missing(&self, message_id: &wr::MessageId) {
+        let Some(file) = (match self
+            .messages
+            .get(message_id)
+            .map(|message| &message.message)
+        {
+            Some(wr::MessageContent::File(file)) => Some(file.clone()),
+            _ => None,
+        }) else {
+            return;
+        };
+        if !matches!(file.kind, wr::FileKind::Audio)
+            || self.audio_durations.contains_key(file.path.as_ref())
+        {
+            return;
+        }
+        let tx = self.tx.clone();
+        let media_path = self.media_path.to_owned();
+        let message_id = message_id.clone();
+        thread::spawn(move || {
+            let absolute = media_path.join(file.path.as_ref());
+            let duration = probe_audio_duration(&absolute);
+            tx.send(AppInput::App(AppEvent::SetAudioDuration(
+                message_id.clone(),
+                file.path,
+                duration,
+            )))
+            .unwrap();
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/media_cache/tests.rs
+++ b/src/app/media_cache/tests.rs
@@ -1,0 +1,57 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use super::super::test_support::TestApp;
+use super::super::{FileMeta, Metadata};
+use whatsrust as wr;
+
+fn file_message(id: &str, path: &str) -> wr::Message {
+    wr::Message {
+        info: wr::MessageInfo {
+            id: id.into(),
+            chat: wr::JID::from("chat@example.test".to_owned()),
+            sender: wr::JID::from("sender@example.test".to_owned()),
+            timestamp: 1,
+            forwarding: Default::default(),
+            is_from_me: false,
+            quote_id: None,
+            read_by: 0,
+        },
+        message: wr::MessageContent::File(wr::FileContent {
+            kind: wr::FileKind::Image,
+            path: path.into(),
+            ..Default::default()
+        }),
+    }
+}
+
+#[test]
+fn evicted_loaded_preview_becomes_reloadable() {
+    let mut app = TestApp::new();
+    let message = file_message("preview", "old.png");
+    app.messages.insert(message.info.id.clone(), message);
+    app.metadata
+        .insert("preview".into(), Metadata::File(FileMeta::Loaded));
+    app.mark_evicted_preview_reloadable(&Arc::from("old.png"));
+
+    assert!(matches!(
+        app.metadata.get(&wr::MessageId::from("preview")),
+        Some(Metadata::File(FileMeta::Downloaded))
+    ));
+    assert!(
+        !app.message_height_cache
+            .contains(&wr::MessageId::from("preview"))
+    );
+}
+
+#[test]
+fn touching_preview_moves_it_to_the_lru_tail() {
+    let mut app = TestApp::new();
+    let first = Arc::<str>::from("first.png");
+    let second = Arc::<str>::from("second.png");
+    app.image_cache_order.push_back(first.clone());
+    app.image_cache_order.push_back(second.clone());
+    super::touch_order(&mut app.image_cache_order, &first);
+
+    assert_eq!(app.image_cache_order, VecDeque::from([second, first]));
+}


### PR DESCRIPTION
## Summary

- Extract App media-cache and asynchronous preparation coordination.
- Keep pure media utilities and runtime dispatch in their existing responsibilities.
- Colocate cache lifecycle tests with the module.

## Testing

- [x] Media-cache tests (2 passed)
- [x] Media lifecycle and height-cache tests (35 passed)
- [x] `cargo check --all-targets`
- [x] Formatting and diff checks

Fifteenth responsibility in the App modularization chain.

Depends on #62.