### PR TITLE
refactor(bridge): extract contacts

### DIFF
--- a/whatsrust/lib/contacts.go
+++ b/whatsrust/lib/contacts.go
@@ -1,0 +1,98 @@
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef const char* JID;
+typedef struct {
+	JID jid;
+	const char* name;
+} ContactEntry;
+typedef struct {
+	ContactEntry* entries;
+	uint32_t size;
+} GetContactsResult;
+*/
+import "C"
+
+import (
+	"context"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type contactEntry struct {
+	jid  types.JID
+	name string
+}
+
+// contactDisplayName follows the same fallback order as Rust get_contact_name.
+func contactDisplayName(c types.ContactInfo) string {
+	switch {
+	case c.FullName != "":
+		return c.FullName
+	case c.FirstName != "":
+		return c.FirstName
+	case c.PushName != "":
+		return "~ " + c.PushName
+	case c.BusinessName != "":
+		return "+ " + c.BusinessName
+	default:
+		return ""
+	}
+}
+
+func lookupContactEntries(ctx context.Context, bridgeClient *whatsmeow.Client) []contactEntry {
+	if bridgeClient == nil || bridgeClient.Store == nil || bridgeClient.Store.Contacts == nil {
+		return nil
+	}
+	contacts, err := bridgeClient.Store.Contacts.GetAllContacts(ctx)
+	if err != nil {
+		panic(err)
+	}
+	entries := make([]contactEntry, 0, len(contacts))
+	for jid, contact := range contacts {
+		name := contactDisplayName(contact)
+		if name == "" {
+			continue
+		}
+		entries = append(entries, contactEntry{jid: jid, name: name})
+		if jid.Server != types.HiddenUserServer {
+			if lid, _ := bridgeClient.Store.LIDs.GetLIDForPN(ctx, jid); !lid.IsEmpty() {
+				entries = append(entries, contactEntry{jid: lid, name: name})
+			}
+		}
+	}
+	return entries
+}
+
+func contactEntriesToC(entries []contactEntry) C.GetContactsResult {
+	if len(entries) == 0 {
+		return C.GetContactsResult{}
+	}
+	cEntries := C.malloc(C.size_t(len(entries)) * C.size_t(unsafe.Sizeof(C.ContactEntry{})))
+	entryList := unsafe.Slice((*C.ContactEntry)(cEntries), len(entries))
+	for i, entry := range entries {
+		entryList[i] = C.ContactEntry{jid: jidToC(entry.jid), name: C.CString(entry.name)}
+	}
+	return C.GetContactsResult{entries: (*C.ContactEntry)(cEntries), size: C.uint32_t(len(entries))}
+}
+
+func freeContactResult(result C.GetContactsResult) {
+	if result.entries == nil {
+		return
+	}
+	entries := unsafe.Slice(result.entries, int(result.size))
+	for _, entry := range entries {
+		C.free(unsafe.Pointer(entry.jid))
+		C.free(unsafe.Pointer(entry.name))
+	}
+	C.free(unsafe.Pointer(result.entries))
+}
+
+func contactEntryStrings(entry C.ContactEntry) (string, string) {
+	return C.GoString(entry.jid), C.GoString(entry.name)
+}

--- a/whatsrust/lib/contacts_test.go
+++ b/whatsrust/lib/contacts_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestContactDisplayNameFallbackOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		info types.ContactInfo
+		want string
+	}{
+		{name: "full name", info: types.ContactInfo{FullName: "Full", FirstName: "First"}, want: "Full"},
+		{name: "first name", info: types.ContactInfo{FirstName: "First"}, want: "First"},
+		{name: "push name", info: types.ContactInfo{PushName: "Push"}, want: "~ Push"},
+		{name: "business name", info: types.ContactInfo{BusinessName: "Business"}, want: "+ Business"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := contactDisplayName(tt.info); got != tt.want {
+				t.Fatalf("contactDisplayName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContactEntriesToCPreservesOrderAndEmptyOwnership(t *testing.T) {
+	entries := []contactEntry{
+		{jid: types.JID{User: "111", Server: types.DefaultUserServer}, name: "First"},
+		{jid: types.JID{User: "111", Server: types.HiddenUserServer}, name: "First"},
+		{jid: types.JID{User: "222", Server: types.GroupServer}, name: "Group"},
+	}
+	result := contactEntriesToC(entries)
+	if result.size != 3 || result.entries == nil {
+		t.Fatalf("result = (%p, %d), want three allocated entries", result.entries, result.size)
+	}
+	cEntries := unsafe.Slice(result.entries, 3)
+	for i, want := range []struct{ jid, name string }{{"111@s.whatsapp.net", "First"}, {"111@lid", "First"}, {"222@g.us", "Group"}} {
+		jid, name := contactEntryStrings(cEntries[i])
+		if jid != want.jid {
+			t.Errorf("entry %d jid = %q, want %q", i, jid, want.jid)
+		}
+		if name != want.name {
+			t.Errorf("entry %d name = %q, want %q", i, name, want.name)
+		}
+	}
+	freeContactResult(result)
+	if empty := contactEntriesToC(nil); empty.entries != nil || empty.size != 0 {
+		t.Fatalf("empty result = (%p, %d), want nil and zero", empty.entries, empty.size)
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -726,23 +726,6 @@ func parseActionJID(raw string) (types.JID, error) {
 	return jid, nil
 }
 
-// contactDisplayName returns the display name for a contact (same order as Rust get_contact_name).
-func contactDisplayName(c types.ContactInfo) string {
-	if c.FullName != "" {
-		return c.FullName
-	}
-	if c.FirstName != "" {
-		return c.FirstName
-	}
-	if c.PushName != "" {
-		return "~ " + c.PushName
-	}
-	if c.BusinessName != "" {
-		return "+ " + c.BusinessName
-	}
-	return ""
-}
-
 //export C_SetLogHandler
 func C_SetLogHandler(callback C.LogHandlerCallback, data unsafe.Pointer) {
 	logHandler = C.LogHandler{
@@ -2713,55 +2696,23 @@ func C_RevokeMessage(chatJID C.JID, senderJID C.JID, messageID *C.char) C.uint8_
 	return 0
 }
 
-// TODO: Free the memory allocated for C.JID and C.Contact
-
 //export C_GetContacts
 func C_GetContacts() C.GetContactsResult {
+	if client == nil || client.Store == nil {
+		return contactEntriesToC(nil)
+	}
 	ctx := context.Background()
-	var entries []C.ContactEntry
+	entries := lookupContactEntries(ctx, client)
 
-	// Contacts (with LID aliases so group senders keyed by LID resolve to a name).
-	contacts, err := client.Store.Contacts.GetAllContacts(ctx)
-	if err != nil {
-		panic(err)
-	}
-	for jid, contact := range contacts {
-		name := contactDisplayName(contact)
-		if name == "" {
-			continue
-		}
-		cName := C.CString(name)
-		entries = append(entries, C.ContactEntry{jid: jidToC(jid), name: cName})
-		if jid.Server != types.HiddenUserServer {
-			if lid, _ := client.Store.LIDs.GetLIDForPN(ctx, jid); !lid.IsEmpty() {
-				entries = append(entries, C.ContactEntry{jid: jidToC(lid), name: cName})
-			}
-		}
-	}
-
-	// Groups.
+	// Groups remain in this bridge wrapper; contacts.go owns only contact lookup.
 	groups, err := client.GetJoinedGroups(ctx)
 	if err != nil {
 		panic(err)
 	}
 	for _, group := range groups {
-		entries = append(entries, C.ContactEntry{
-			jid:  jidToC(group.JID),
-			name: C.CString(group.GroupName.Name),
-		})
+		entries = append(entries, contactEntry{jid: group.JID, name: group.GroupName.Name})
 	}
-
-	n := len(entries)
-	c_entries := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.ContactEntry{})))
-	entryList := unsafe.Slice((*C.ContactEntry)(c_entries), n)
-	for i := range n {
-		entryList[i] = entries[i]
-	}
-
-	return C.GetContactsResult{
-		entries: (*C.ContactEntry)(c_entries),
-		size:    C.uint32_t(n),
-	}
+	return contactEntriesToC(entries)
 }
 
 // C_GetCommunities transfers ownership of entries and every pointed-to string


### PR DESCRIPTION
## Summary

- Extract contact lookup, fallback, and C-result ownership from the Go bridge.
- Preserve exported signatures and struct layout unchanged.
- Colocate fallback, ordering, normalization, and cleanup tests.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`

Sixth responsibility in the Go bridge modularization chain.

Depends on #63.