### PR TITLE
refactor(bridge): extract communities

### DIFF
--- a/whatsrust/lib/communities.go
+++ b/whatsrust/lib/communities.go
@@ -1,0 +1,114 @@
+package main
+
+/*
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef const char* JID;
+typedef struct {
+	JID jid;
+	const char* name;
+	JID parent_jid;
+	bool is_parent;
+} CommunityEntry;
+typedef struct {
+	CommunityEntry* entries;
+	uint32_t size;
+	uint8_t status;
+} GetCommunitiesResult;
+*/
+import "C"
+
+import (
+	"context"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type communityEntry struct {
+	jid      types.JID
+	name     string
+	parent   types.JID
+	isParent bool
+}
+
+func lookupCommunityEntries(ctx context.Context, bridgeClient *whatsmeow.Client) ([]communityEntry, error) {
+	groups, err := bridgeClient.GetJoinedGroups(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]communityEntry, 0, len(groups))
+	for _, group := range groups {
+		parent := group.LinkedParentJID
+		if !communityEntryIncluded(group.IsParent, group.LinkedParentJID.IsEmpty()) {
+			continue
+		}
+		entries = append(entries, communityEntry{
+			jid:      group.JID,
+			name:     group.GroupName.Name,
+			parent:   parent,
+			isParent: group.IsParent,
+		})
+	}
+	return entries, nil
+}
+
+//export C_GetCommunities
+func C_GetCommunities() C.GetCommunitiesResult {
+	entries, err := lookupCommunityEntries(context.Background(), client)
+	if err != nil {
+		LOG_WARN("Could not load communities: %v", err)
+		return C.GetCommunitiesResult{status: 1}
+	}
+	return communityEntriesToC(entries)
+}
+
+// C_GetCommunities transfers ownership of entries and every pointed-to string
+// to the caller. The caller must invoke C_FreeCommunities exactly once for
+// every returned result, including empty and error results. C_FreeCommunities
+// is nil-safe, but repeating it for the same non-nil result is not supported.
+//
+//export C_FreeCommunities
+func C_FreeCommunities(result C.GetCommunitiesResult) {
+	if result.entries == nil {
+		return
+	}
+	freeCommunityEntries(unsafe.Slice(result.entries, int(result.size)))
+	C.free(unsafe.Pointer(result.entries))
+}
+
+func communityEntriesToC(entries []communityEntry) C.GetCommunitiesResult {
+	if len(entries) == 0 {
+		return C.GetCommunitiesResult{}
+	}
+	cEntries := C.malloc(C.size_t(len(entries)) * C.size_t(unsafe.Sizeof(C.CommunityEntry{})))
+	entryList := unsafe.Slice((*C.CommunityEntry)(cEntries), len(entries))
+	for i, entry := range entries {
+		entryList[i] = C.CommunityEntry{
+			jid:        jidToC(entry.jid),
+			name:       C.CString(entry.name),
+			parent_jid: jidToC(entry.parent),
+			is_parent:  C.bool(entry.isParent),
+		}
+	}
+	return C.GetCommunitiesResult{entries: (*C.CommunityEntry)(cEntries), size: C.uint32_t(len(entries))}
+}
+
+func communityEntryStrings(entry C.CommunityEntry) (string, string, string, bool) {
+	return C.GoString(entry.jid), C.GoString(entry.name), C.GoString(entry.parent_jid), bool(entry.is_parent)
+}
+
+func freeCommunityEntries(entries []C.CommunityEntry) {
+	for _, entry := range entries {
+		C.free(unsafe.Pointer(entry.jid))
+		C.free(unsafe.Pointer(entry.name))
+		C.free(unsafe.Pointer(entry.parent_jid))
+	}
+}
+
+func communityEntryIncluded(isParent, parentEmpty bool) bool {
+	return isParent || !parentEmpty
+}

--- a/whatsrust/lib/communities_test.go
+++ b/whatsrust/lib/communities_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestCommunityEntryIncludedDistinguishesRootsAndLinkedGroups(t *testing.T) {
+	tests := []struct {
+		name        string
+		isParent    bool
+		parentEmpty bool
+		want        bool
+	}{
+		{name: "community root", isParent: true, parentEmpty: true, want: true},
+		{name: "linked group", parentEmpty: false, want: true},
+		{name: "ordinary group", parentEmpty: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := communityEntryIncluded(tt.isParent, tt.parentEmpty); got != tt.want {
+				t.Fatalf("communityEntryIncluded(%t, %t) = %t, want %t", tt.isParent, tt.parentEmpty, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommunityEntriesToCPreservesOrderAndHierarchy(t *testing.T) {
+	entries := []communityEntry{
+		{jid: types.NewJID("root", types.GroupServer), name: "Root", isParent: true},
+		{jid: types.NewJID("child", types.GroupServer), name: "Child", parent: types.NewJID("root", types.GroupServer)},
+	}
+	result := communityEntriesToC(entries)
+	if result.entries == nil || result.size != 2 {
+		t.Fatalf("result = (%p, %d), want two allocated entries", result.entries, result.size)
+	}
+	cEntries := unsafe.Slice(result.entries, 2)
+	jid, name, parent, isParent := communityEntryStrings(cEntries[0])
+	if jid != "root@g.us" || name != "Root" || parent != "" || !isParent {
+		t.Fatalf("root = (%q, %q, %q, %t), want root and parent", jid, name, parent, isParent)
+	}
+	jid, name, parent, isParent = communityEntryStrings(cEntries[1])
+	if jid != "child@g.us" || name != "Child" || parent != "root@g.us" || isParent {
+		t.Fatalf("child = (%q, %q, %q, %t)", jid, name, parent, isParent)
+	}
+	C_FreeCommunities(result)
+	if empty := communityEntriesToC(nil); empty.entries != nil || empty.size != 0 || empty.status != 0 {
+		t.Fatalf("empty result = (%p, %d, %d), want nil, zero, zero", empty.entries, empty.size, empty.status)
+	}
+}
+
+func TestFreeCommunitiesNilResultIsSafe(t *testing.T) {
+	freeCommunityEntries(nil)
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -23,13 +23,6 @@ typedef struct {
 } ContactEntry;
 
 typedef struct {
-	JID jid;
-	const char* name;
-	JID parent_jid;
-	bool is_parent;
-} CommunityEntry;
-
-typedef struct {
 	bool found;
 	int64_t muted_until;
 	bool pinned;
@@ -46,12 +39,6 @@ typedef struct {
 	ContactEntry* entries;
 	uint32_t size;
 } GetContactsResult;
-
-typedef struct {
-	CommunityEntry* entries;
-	uint32_t size;
-	uint8_t status;
-} GetCommunitiesResult;
 
 typedef struct {
 	uint8_t status;
@@ -2713,65 +2700,6 @@ func C_GetContacts() C.GetContactsResult {
 		entries = append(entries, contactEntry{jid: group.JID, name: group.GroupName.Name})
 	}
 	return contactEntriesToC(entries)
-}
-
-// C_GetCommunities transfers ownership of entries and every pointed-to string
-// to the caller. The caller must invoke C_FreeCommunities exactly once for
-// every returned result, including empty and error results. C_FreeCommunities
-// is nil-safe, but repeating it for the same non-nil result is not supported.
-//
-//export C_GetCommunities
-func C_GetCommunities() C.GetCommunitiesResult {
-	ctx := context.Background()
-	groups, err := client.GetJoinedGroups(ctx)
-	if err != nil {
-		LOG_WARN("Could not load communities: %v", err)
-		return C.GetCommunitiesResult{status: 1}
-	}
-	entries := make([]C.CommunityEntry, 0)
-	for _, group := range groups {
-		parent := group.LinkedParentJID
-		if !communityEntryIncluded(group.IsParent, parent.IsEmpty()) {
-			continue
-		}
-		entries = append(entries, C.CommunityEntry{
-			jid:        jidToC(group.JID),
-			name:       C.CString(group.GroupName.Name),
-			parent_jid: jidToC(parent),
-			is_parent:  C.bool(group.IsParent),
-		})
-	}
-	n := len(entries)
-	if n == 0 {
-		return C.GetCommunitiesResult{status: 0}
-	}
-	cEntries := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.CommunityEntry{})))
-	entryList := unsafe.Slice((*C.CommunityEntry)(cEntries), n)
-	for i := range n {
-		entryList[i] = entries[i]
-	}
-	return C.GetCommunitiesResult{entries: (*C.CommunityEntry)(cEntries), size: C.uint32_t(n), status: 0}
-}
-
-//export C_FreeCommunities
-func C_FreeCommunities(result C.GetCommunitiesResult) {
-	if result.entries == nil {
-		return
-	}
-	freeCommunityEntries(unsafe.Slice(result.entries, int(result.size)))
-	C.free(unsafe.Pointer(result.entries))
-}
-
-func freeCommunityEntries(entries []C.CommunityEntry) {
-	for _, entry := range entries {
-		C.free(unsafe.Pointer(entry.jid))
-		C.free(unsafe.Pointer(entry.name))
-		C.free(unsafe.Pointer(entry.parent_jid))
-	}
-}
-
-func communityEntryIncluded(isParent, parentEmpty bool) bool {
-	return isParent || !parentEmpty
 }
 
 //export C_GetProfilePicture

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -51,30 +51,6 @@ func TestPinnedPresenceContractAndNarrowSubscription(t *testing.T) {
 	}
 }
 
-func TestCommunityEntryIncludedDistinguishesRootsAndLinkedGroups(t *testing.T) {
-	tests := []struct {
-		name        string
-		isParent    bool
-		parentEmpty bool
-		want        bool
-	}{
-		{name: "community root", isParent: true, parentEmpty: true, want: true},
-		{name: "linked group", parentEmpty: false, want: true},
-		{name: "ordinary group", parentEmpty: true, want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := communityEntryIncluded(tt.isParent, tt.parentEmpty); got != tt.want {
-				t.Fatalf("communityEntryIncluded(%t, %t) = %t, want %t", tt.isParent, tt.parentEmpty, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestFreeCommunitiesNilResultIsSafe(t *testing.T) {
-	freeCommunityEntries(nil)
-}
-
 func TestRawPresenceDiagnosticsDisabledIsNoOp(t *testing.T) {
 	var diagnostics rawPresenceDiagnostics
 	diagnostics.reset(false)


### PR DESCRIPTION
## Summary

- Extract community hierarchy lookup, conversion, and ownership from the Go bridge.
- Preserve exported C signatures, layouts, statuses, ordering, and free semantics.
- Colocate deterministic hierarchy and allocation tests.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`

Seventh responsibility in the Go bridge modularization chain.

Depends on #65.