### PR TITLE
refactor(bridge): extract presence lifecycle

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -761,10 +761,6 @@ func C_NewClient(dbPath *C.char) {
 	configurePresenceSubscriptions(client)
 }
 
-func configurePresenceSubscriptions(client *whatsmeow.Client) {
-	client.ErrorOnSubscribePresenceWithoutToken = true
-}
-
 func requestFullHistorySync() {
 	// Ask WhatsApp to send the complete conversation + history list instead of
 	// only a recent-activity subset. WhatsApp gates history sync requests on an
@@ -2210,10 +2206,6 @@ func countSyncMessages(conversations []*waHistorySync.Conversation) int {
 	return total
 }
 
-type sendPresenceFunc func(context.Context, types.Presence) error
-type connectedReadyFunc func()
-type presenceWarningFunc func(string, ...any)
-
 type lidToPNFunc func(context.Context, types.JID) (types.JID, error)
 
 func normalizePresenceJID(ctx context.Context, jid types.JID, getPNForLID lidToPNFunc) (types.JID, string) {
@@ -2268,15 +2260,6 @@ func C_TestEmitPresenceEventsConcurrently(from *C.char, count C.uint32_t) {
 	wait.Wait()
 }
 
-func handleConnected(sendPresence sendPresenceFunc, connected connectedReadyFunc, warn presenceWarningFunc) bool {
-	if err := sendPresence(context.Background(), types.PresenceAvailable); err != nil {
-		warn("Failed to announce presence after connection; presence subscriptions will wait for the next connection: %v", err)
-		return false
-	}
-	connected()
-	return true
-}
-
 //export C_Connect
 func C_Connect(handler C.QrCallback, data unsafe.Pointer) {
 	AddEventHandlers()
@@ -2308,42 +2291,6 @@ func C_Connect(handler C.QrCallback, data unsafe.Pointer) {
 		}
 	}
 
-}
-
-const (
-	subscribePresenceAccepted uint8 = iota
-	subscribePresenceNoPrivacyToken
-	subscribePresenceRejected
-)
-
-//export C_SubscribePresence
-func C_SubscribePresence(cjid C.JID) C.uint8_t {
-	jid := cToJid(cjid)
-	if client == nil {
-		return C.uint8_t(subscribePresenceRejected)
-	}
-	result := subscribePresence(jid, client.SubscribePresence)
-	if result == subscribePresenceNoPrivacyToken {
-		LOG_WARN("Failed to subscribe to presence: no privacy token")
-	} else if result == subscribePresenceRejected {
-		LOG_WARN("Failed to subscribe to presence")
-	}
-	return C.uint8_t(result)
-}
-
-type subscribePresenceFunc func(context.Context, types.JID) error
-
-func subscribePresence(jid types.JID, subscribe subscribePresenceFunc) uint8 {
-	if jid.Server != types.DefaultUserServer {
-		return subscribePresenceRejected
-	}
-	if err := subscribe(context.Background(), jid); err != nil {
-		if errors.Is(err, whatsmeow.ErrNoPrivacyToken) {
-			return subscribePresenceNoPrivacyToken
-		}
-		return subscribePresenceRejected
-	}
-	return subscribePresenceAccepted
 }
 
 //export C_PairPhone

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -24,33 +24,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestPinnedPresenceContractAndNarrowSubscription(t *testing.T) {
-	lastSeen := time.Unix(42, 0)
-	event := &events.Presence{
-		From:        types.NewJID("12345", types.DefaultUserServer),
-		Unavailable: true,
-		LastSeen:    lastSeen,
-	}
-	if event.From.User != "12345" || !event.Unavailable || event.LastSeen.Unix() != 42 {
-		t.Fatalf("unexpected pinned presence contract: %#v", event)
-	}
-
-	calls := 0
-	subscribe := func(_ context.Context, jid types.JID) error {
-		calls++
-		if jid != event.From {
-			t.Fatalf("subscribed to %s, want %s", jid, event.From)
-		}
-		return nil
-	}
-	if got := subscribePresence(event.From, subscribe); got != subscribePresenceAccepted || calls != 1 {
-		t.Fatalf("individual subscription result=%d calls=%d", got, calls)
-	}
-	if got := subscribePresence(types.NewJID("group", types.GroupServer), subscribe); got != subscribePresenceRejected || calls != 1 {
-		t.Fatalf("group subscription must be rejected before whatsmeow, calls=%d", calls)
-	}
-}
-
 func TestRawPresenceDiagnosticsDisabledIsNoOp(t *testing.T) {
 	var diagnostics rawPresenceDiagnostics
 	diagnostics.reset(false)
@@ -110,36 +83,6 @@ func TestRawPresenceDiagnosticsClassifyServersAndResetOnDrain(t *testing.T) {
 	diagnostics.reset(true)
 	if report := diagnostics.drain(); report != "raw presence events received: 0\n" {
 		t.Fatalf("run reset retained data: %q", report)
-	}
-}
-
-func TestSubscribePresenceResultIdentifiesNoPrivacyToken(t *testing.T) {
-	jid := types.NewJID("12345", types.DefaultUserServer)
-	tests := []struct {
-		name string
-		err  error
-		want uint8
-	}{
-		{name: "valid token accepted", want: subscribePresenceAccepted},
-		{name: "missing token identifiable", err: fmt.Errorf("wrapped: %w", whatsmeow.ErrNoPrivacyToken), want: subscribePresenceNoPrivacyToken},
-		{name: "transport error rejected", err: errors.New("transport failed"), want: subscribePresenceRejected},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := subscribePresence(jid, func(context.Context, types.JID) error { return tt.err })
-			if got != tt.want {
-				t.Fatalf("subscribePresence() = %d, want %d", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestPresenceSubscriptionsRequirePrivacyToken(t *testing.T) {
-	client := &whatsmeow.Client{}
-	configurePresenceSubscriptions(client)
-	if !client.ErrorOnSubscribePresenceWithoutToken {
-		t.Fatal("presence subscriptions must reject missing privacy tokens")
 	}
 }
 
@@ -235,79 +178,6 @@ func TestDispatchPresenceEventFallsBackAndDispatchesAfterNormalizationTimeout(t 
 	report := diagnostics.drain()
 	if !strings.Contains(report, "normalized=fallback-lid, normalization=timeout, dispatch=called") {
 		t.Fatalf("timeout outcome missing from diagnostics:\n%s", report)
-	}
-}
-
-func TestConnectedAnnouncesPresenceBeforeReportingReady(t *testing.T) {
-	var calls []string
-
-	ready := handleConnected(
-		func(_ context.Context, presence types.Presence) error {
-			if presence != types.PresenceAvailable {
-				t.Fatalf("presence = %q, want available", presence)
-			}
-			calls = append(calls, "announce")
-			return nil
-		},
-		func() { calls = append(calls, "connected") },
-		func(string, ...any) { t.Fatal("unexpected warning") },
-	)
-
-	if !ready {
-		t.Fatal("successful announcement must report readiness")
-	}
-	if got, want := strings.Join(calls, ","), "announce,connected"; got != want {
-		t.Fatalf("call order = %q, want %q", got, want)
-	}
-}
-
-func TestConnectedRepeatsPresenceAnnouncementAfterReconnect(t *testing.T) {
-	var calls []string
-	announce := func(_ context.Context, _ types.Presence) error {
-		calls = append(calls, "announce")
-		return nil
-	}
-	connected := func() { calls = append(calls, "connected") }
-	warn := func(string, ...any) { t.Fatal("unexpected warning") }
-
-	handleConnected(announce, connected, warn)
-	handleConnected(announce, connected, warn)
-
-	if got, want := strings.Join(calls, ","), "announce,connected,announce,connected"; got != want {
-		t.Fatalf("reconnect call order = %q, want %q", got, want)
-	}
-}
-
-func TestConnectedAnnouncementFailureDefersReadinessUntilNextConnection(t *testing.T) {
-	announcementError := errors.New("send failed")
-	announcements := 0
-	connected := 0
-	var warning string
-	announce := func(_ context.Context, _ types.Presence) error {
-		announcements++
-		if announcements == 1 {
-			return announcementError
-		}
-		return nil
-	}
-	warn := func(format string, args ...any) { warning = fmt.Sprintf(format, args...) }
-
-	if handleConnected(announce, func() { connected++ }, warn) {
-		t.Fatal("failed announcement must not report readiness")
-	}
-	if connected != 0 {
-		t.Fatalf("connected callbacks after failure = %d, want 0", connected)
-	}
-	if !strings.Contains(warning, "presence subscriptions will wait for the next connection") ||
-		!strings.Contains(warning, announcementError.Error()) {
-		t.Fatalf("warning = %q, want retry context and error", warning)
-	}
-
-	if !handleConnected(announce, func() { connected++ }, warn) {
-		t.Fatal("next successful connection must report readiness")
-	}
-	if announcements != 2 || connected != 1 {
-		t.Fatalf("announcements = %d, connected callbacks = %d, want 2 and 1", announcements, connected)
 	}
 }
 

--- a/whatsrust/lib/presence.go
+++ b/whatsrust/lib/presence.go
@@ -1,0 +1,68 @@
+package main
+
+/*
+#include <stdint.h>
+typedef const char* JID;
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type sendPresenceFunc func(context.Context, types.Presence) error
+type connectedReadyFunc func()
+type presenceWarningFunc func(string, ...any)
+
+func handleConnected(sendPresence sendPresenceFunc, connected connectedReadyFunc, warn presenceWarningFunc) bool {
+	if err := sendPresence(context.Background(), types.PresenceAvailable); err != nil {
+		warn("Failed to announce presence after connection; presence subscriptions will wait for the next connection: %v", err)
+		return false
+	}
+	connected()
+	return true
+}
+
+func configurePresenceSubscriptions(client *whatsmeow.Client) {
+	client.ErrorOnSubscribePresenceWithoutToken = true
+}
+
+const (
+	subscribePresenceAccepted uint8 = iota
+	subscribePresenceNoPrivacyToken
+	subscribePresenceRejected
+)
+
+//export C_SubscribePresence
+func C_SubscribePresence(cjid C.JID) C.uint8_t {
+	jid := cToJid(cjid)
+	if client == nil {
+		return C.uint8_t(subscribePresenceRejected)
+	}
+	result := subscribePresence(jid, client.SubscribePresence)
+	if result == subscribePresenceNoPrivacyToken {
+		LOG_WARN("Failed to subscribe to presence: no privacy token")
+	} else if result == subscribePresenceRejected {
+		LOG_WARN("Failed to subscribe to presence")
+	}
+	return C.uint8_t(result)
+}
+
+type subscribePresenceFunc func(context.Context, types.JID) error
+
+func subscribePresence(jid types.JID, subscribe subscribePresenceFunc) uint8 {
+	if jid.Server != types.DefaultUserServer {
+		return subscribePresenceRejected
+	}
+	if err := subscribe(context.Background(), jid); err != nil {
+		if errors.Is(err, whatsmeow.ErrNoPrivacyToken) {
+			return subscribePresenceNoPrivacyToken
+		}
+		return subscribePresenceRejected
+	}
+	return subscribePresenceAccepted
+}

--- a/whatsrust/lib/presence_test.go
+++ b/whatsrust/lib/presence_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestPinnedPresenceContractAndNarrowSubscription(t *testing.T) {
+	jid := types.NewJID("12345", types.DefaultUserServer)
+	calls := 0
+	subscribe := func(_ context.Context, got types.JID) error {
+		calls++
+		if got != jid {
+			t.Fatalf("subscribed to %s, want %s", got, jid)
+		}
+		return nil
+	}
+	if got := subscribePresence(jid, subscribe); got != subscribePresenceAccepted || calls != 1 {
+		t.Fatalf("individual subscription result=%d calls=%d", got, calls)
+	}
+	if got := subscribePresence(types.NewJID("group", types.GroupServer), subscribe); got != subscribePresenceRejected || calls != 1 {
+		t.Fatalf("group subscription must be rejected before whatsmeow, calls=%d", calls)
+	}
+}
+
+func TestSubscribePresenceResultIdentifiesNoPrivacyToken(t *testing.T) {
+	jid := types.NewJID("12345", types.DefaultUserServer)
+	tests := []struct {
+		name string
+		err  error
+		want uint8
+	}{
+		{name: "valid token accepted", want: subscribePresenceAccepted},
+		{name: "missing token identifiable", err: fmt.Errorf("wrapped: %w", whatsmeow.ErrNoPrivacyToken), want: subscribePresenceNoPrivacyToken},
+		{name: "transport error rejected", err: errors.New("transport failed"), want: subscribePresenceRejected},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := subscribePresence(jid, func(context.Context, types.JID) error { return tt.err })
+			if got != tt.want {
+				t.Fatalf("subscribePresence() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPresenceSubscriptionsRequirePrivacyToken(t *testing.T) {
+	client := &whatsmeow.Client{}
+	configurePresenceSubscriptions(client)
+	if !client.ErrorOnSubscribePresenceWithoutToken {
+		t.Fatal("presence subscriptions must reject missing privacy tokens")
+	}
+}
+
+func TestConnectedAnnouncesPresenceBeforeReportingReady(t *testing.T) {
+	var calls []string
+
+	ready := handleConnected(
+		func(_ context.Context, presence types.Presence) error {
+			if presence != types.PresenceAvailable {
+				t.Fatalf("presence = %q, want available", presence)
+			}
+			calls = append(calls, "announce")
+			return nil
+		},
+		func() { calls = append(calls, "connected") },
+		func(string, ...any) { t.Fatal("unexpected warning") },
+	)
+
+	if !ready {
+		t.Fatal("successful announcement must report readiness")
+	}
+	if got, want := strings.Join(calls, ","), "announce,connected"; got != want {
+		t.Fatalf("call order = %q, want %q", got, want)
+	}
+}
+
+func TestConnectedRepeatsPresenceAnnouncementAfterReconnect(t *testing.T) {
+	var calls []string
+	announce := func(_ context.Context, _ types.Presence) error {
+		calls = append(calls, "announce")
+		return nil
+	}
+	connected := func() { calls = append(calls, "connected") }
+	warn := func(string, ...any) { t.Fatal("unexpected warning") }
+
+	handleConnected(announce, connected, warn)
+	handleConnected(announce, connected, warn)
+
+	if got, want := strings.Join(calls, ","), "announce,connected,announce,connected"; got != want {
+		t.Fatalf("reconnect call order = %q, want %q", got, want)
+	}
+}
+
+func TestConnectedAnnouncementFailureDefersReadinessUntilNextConnection(t *testing.T) {
+	announcementError := errors.New("send failed")
+	announcements := 0
+	connected := 0
+	var warning string
+	announce := func(_ context.Context, _ types.Presence) error {
+		announcements++
+		if announcements == 1 {
+			return announcementError
+		}
+		return nil
+	}
+	warn := func(format string, args ...any) { warning = fmt.Sprintf(format, args...) }
+
+	if handleConnected(announce, func() { connected++ }, warn) {
+		t.Fatal("failed announcement must not report readiness")
+	}
+	if connected != 0 {
+		t.Fatalf("connected callbacks after failure = %d, want 0", connected)
+	}
+	if !strings.Contains(warning, "presence subscriptions will wait for the next connection") || !strings.Contains(warning, announcementError.Error()) {
+		t.Fatalf("warning = %q, want retry context and error", warning)
+	}
+
+	if !handleConnected(announce, func() { connected++ }, warn) {
+		t.Fatal("next successful connection must report readiness")
+	}
+	if announcements != 2 || connected != 1 {
+		t.Fatalf("announcements = %d, connected callbacks = %d, want 2 and 1", announcements, connected)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract presence subscription lifecycle and privacy-token semantics from the Go bridge.
- Preserve the exported C wrapper, status values, and ownership unchanged.
- Leave event conversion and diagnostics as separate follow-up responsibilities.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No worktree-local target directory

Eighth responsibility in the Go bridge modularization chain.

Depends on #67.