### PR TITLE
refactor(bridge): extract presence diagnostics

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -224,38 +224,6 @@ var messageHandler C.MessageHandler
 var eventHandler C.EventHandler
 var presenceHandler C.PresenceHandler
 
-const maxRawPresenceDiagnosticEntries = 50
-
-type rawPresenceDiagnosticEntry struct {
-	sequence        uint64
-	server          string
-	unavailable     bool
-	lastSeenPresent bool
-	normalized      string
-	normalization   string
-	dispatch        string
-}
-
-type rawPresenceDiagnostics struct {
-	mu      sync.Mutex
-	enabled atomic.Bool
-	total   uint64
-	entries []rawPresenceDiagnosticEntry
-}
-
-var rawPresenceProbe rawPresenceDiagnostics
-
-func classifyPresenceServer(server string) string {
-	switch server {
-	case types.DefaultUserServer:
-		return "s.whatsapp.net"
-	case types.HiddenUserServer:
-		return "lid"
-	default:
-		return "other"
-	}
-}
-
 var messageActionArrivalOrder uint64
 
 const messageActionCensusLimit = 100
@@ -363,73 +331,6 @@ func receiptCensusSubtype(receiptType types.ReceiptType) string {
 	default:
 		return "other"
 	}
-}
-
-func (diagnostics *rawPresenceDiagnostics) reset(enabled bool) {
-	diagnostics.mu.Lock()
-	defer diagnostics.mu.Unlock()
-	diagnostics.total = 0
-	diagnostics.entries = nil
-	diagnostics.enabled.Store(enabled)
-}
-
-func (diagnostics *rawPresenceDiagnostics) record(event *events.Presence) uint64 {
-	if !diagnostics.enabled.Load() {
-		return 0
-	}
-	diagnostics.mu.Lock()
-	defer diagnostics.mu.Unlock()
-	if !diagnostics.enabled.Load() {
-		return 0
-	}
-	diagnostics.total++
-	if len(diagnostics.entries) == maxRawPresenceDiagnosticEntries {
-		copy(diagnostics.entries, diagnostics.entries[1:])
-		diagnostics.entries = diagnostics.entries[:maxRawPresenceDiagnosticEntries-1]
-	}
-	diagnostics.entries = append(diagnostics.entries, rawPresenceDiagnosticEntry{
-		sequence:        diagnostics.total,
-		server:          classifyPresenceServer(event.From.Server),
-		unavailable:     event.Unavailable,
-		lastSeenPresent: !event.LastSeen.IsZero(),
-	})
-	return diagnostics.total
-}
-
-func (diagnostics *rawPresenceDiagnostics) update(sequence uint64, normalized, normalization, dispatch string) {
-	if !diagnostics.enabled.Load() {
-		return
-	}
-	diagnostics.mu.Lock()
-	defer diagnostics.mu.Unlock()
-	for index := range diagnostics.entries {
-		if diagnostics.entries[index].sequence == sequence {
-			diagnostics.entries[index].normalized = normalized
-			diagnostics.entries[index].normalization = normalization
-			diagnostics.entries[index].dispatch = dispatch
-			return
-		}
-	}
-}
-
-func (diagnostics *rawPresenceDiagnostics) drain() string {
-	if !diagnostics.enabled.Load() {
-		return ""
-	}
-	diagnostics.mu.Lock()
-	defer diagnostics.mu.Unlock()
-	if !diagnostics.enabled.Load() {
-		return ""
-	}
-	var report strings.Builder
-	fmt.Fprintf(&report, "raw presence events received: %d\n", diagnostics.total)
-	firstSequence := diagnostics.total - uint64(len(diagnostics.entries)) + 1
-	for index, entry := range diagnostics.entries {
-		fmt.Fprintf(&report, "%d. server=%s, unavailable=%t, last_seen_present=%t, normalized=%s, normalization=%s, dispatch=%s\n", firstSequence+uint64(index), entry.server, entry.unavailable, entry.lastSeenPresent, entry.normalized, entry.normalization, entry.dispatch)
-	}
-	diagnostics.total = 0
-	diagnostics.entries = nil
-	return report.String()
 }
 
 func messageActionMessageCensusLine(eventType string, evt *events.Message) string {
@@ -2772,20 +2673,6 @@ func emitLogoutResult(status uint8) {
 		data: unsafe.Pointer(payload),
 	})
 	C.free(unsafe.Pointer(payload))
-}
-
-//export C_DrainRawPresenceDiagnostics
-func C_DrainRawPresenceDiagnostics() *C.char {
-	report := rawPresenceProbe.drain()
-	if report == "" {
-		return nil
-	}
-	return C.CString(report)
-}
-
-//export C_FreeRawPresenceDiagnostics
-func C_FreeRawPresenceDiagnostics(report *C.char) {
-	C.free(unsafe.Pointer(report))
 }
 
 func main() {} // Required for CGO

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -24,68 +24,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestRawPresenceDiagnosticsDisabledIsNoOp(t *testing.T) {
-	var diagnostics rawPresenceDiagnostics
-	diagnostics.reset(false)
-	diagnostics.record(&events.Presence{From: types.NewJID("private-user", types.DefaultUserServer)})
-	if report := diagnostics.drain(); report != "" {
-		t.Fatalf("disabled diagnostics returned %q", report)
-	}
-}
-
-func TestRawPresenceDiagnosticsAreBoundedOrderedAndRedacted(t *testing.T) {
-	var diagnostics rawPresenceDiagnostics
-	diagnostics.reset(true)
-	for index := 0; index <= maxRawPresenceDiagnosticEntries; index++ {
-		diagnostics.record(&events.Presence{
-			From:        types.NewJID(fmt.Sprintf("private-user-%d", index), types.DefaultUserServer),
-			Unavailable: index%2 == 0,
-			LastSeen:    time.Unix(int64(index+1), 0),
-		})
-	}
-
-	report := diagnostics.drain()
-	if strings.Contains(report, "private-user") {
-		t.Fatal("raw presence report exposed JID user data")
-	}
-	if !strings.Contains(report, "raw presence events received: 51\n") || strings.Contains(report, "\n1. server=") {
-		t.Fatalf("unexpected bounded report header/order:\n%s", report)
-	}
-	if !strings.Contains(report, "2. server=s.whatsapp.net, unavailable=false, last_seen_present=true") ||
-		!strings.Contains(report, "51. server=s.whatsapp.net, unavailable=true, last_seen_present=true") {
-		t.Fatalf("unexpected retained event order:\n%s", report)
-	}
-}
-
-func TestRawPresenceDiagnosticsClassifyServersAndResetOnDrain(t *testing.T) {
-	var diagnostics rawPresenceDiagnostics
-	diagnostics.reset(true)
-	for _, event := range []*events.Presence{
-		{From: types.NewJID("secret-a", types.DefaultUserServer)},
-		{From: types.NewJID("secret-b", types.HiddenUserServer), Unavailable: true},
-		{From: types.NewJID("secret-c", types.GroupServer)},
-	} {
-		diagnostics.record(event)
-	}
-
-	report := diagnostics.drain()
-	for _, expected := range []string{"server=s.whatsapp.net", "server=lid", "server=other"} {
-		if !strings.Contains(report, expected) {
-			t.Fatalf("report missing %q:\n%s", expected, report)
-		}
-	}
-	if strings.Contains(report, "secret-") || !strings.Contains(report, "last_seen_present=false") {
-		t.Fatalf("report leaked identity or omitted safe metadata:\n%s", report)
-	}
-	if report := diagnostics.drain(); report != "raw presence events received: 0\n" {
-		t.Fatalf("drain did not reset run data: %q", report)
-	}
-	diagnostics.reset(true)
-	if report := diagnostics.drain(); report != "raw presence events received: 0\n" {
-		t.Fatalf("run reset retained data: %q", report)
-	}
-}
-
 func profilePicturePNG(t *testing.T) []byte {
 	t.Helper()
 	var data bytes.Buffer

--- a/whatsrust/lib/presence_diagnostics.go
+++ b/whatsrust/lib/presence_diagnostics.go
@@ -1,0 +1,130 @@
+package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+const maxRawPresenceDiagnosticEntries = 50
+
+type rawPresenceDiagnosticEntry struct {
+	sequence        uint64
+	server          string
+	unavailable     bool
+	lastSeenPresent bool
+	normalized      string
+	normalization   string
+	dispatch        string
+}
+
+type rawPresenceDiagnostics struct {
+	mu      sync.Mutex
+	enabled atomic.Bool
+	total   uint64
+	entries []rawPresenceDiagnosticEntry
+}
+
+var rawPresenceProbe rawPresenceDiagnostics
+
+func classifyPresenceServer(server string) string {
+	switch server {
+	case types.DefaultUserServer:
+		return "s.whatsapp.net"
+	case types.HiddenUserServer:
+		return "lid"
+	default:
+		return "other"
+	}
+}
+
+func (diagnostics *rawPresenceDiagnostics) reset(enabled bool) {
+	diagnostics.mu.Lock()
+	defer diagnostics.mu.Unlock()
+	diagnostics.total = 0
+	diagnostics.entries = nil
+	diagnostics.enabled.Store(enabled)
+}
+
+func (diagnostics *rawPresenceDiagnostics) record(event *events.Presence) uint64 {
+	if !diagnostics.enabled.Load() {
+		return 0
+	}
+	diagnostics.mu.Lock()
+	defer diagnostics.mu.Unlock()
+	if !diagnostics.enabled.Load() {
+		return 0
+	}
+	diagnostics.total++
+	if len(diagnostics.entries) == maxRawPresenceDiagnosticEntries {
+		copy(diagnostics.entries, diagnostics.entries[1:])
+		diagnostics.entries = diagnostics.entries[:maxRawPresenceDiagnosticEntries-1]
+	}
+	diagnostics.entries = append(diagnostics.entries, rawPresenceDiagnosticEntry{
+		sequence:        diagnostics.total,
+		server:          classifyPresenceServer(event.From.Server),
+		unavailable:     event.Unavailable,
+		lastSeenPresent: !event.LastSeen.IsZero(),
+	})
+	return diagnostics.total
+}
+
+func (diagnostics *rawPresenceDiagnostics) update(sequence uint64, normalized, normalization, dispatch string) {
+	if !diagnostics.enabled.Load() {
+		return
+	}
+	diagnostics.mu.Lock()
+	defer diagnostics.mu.Unlock()
+	for index := range diagnostics.entries {
+		if diagnostics.entries[index].sequence == sequence {
+			diagnostics.entries[index].normalized = normalized
+			diagnostics.entries[index].normalization = normalization
+			diagnostics.entries[index].dispatch = dispatch
+			return
+		}
+	}
+}
+
+func (diagnostics *rawPresenceDiagnostics) drain() string {
+	if !diagnostics.enabled.Load() {
+		return ""
+	}
+	diagnostics.mu.Lock()
+	defer diagnostics.mu.Unlock()
+	if !diagnostics.enabled.Load() {
+		return ""
+	}
+	var report strings.Builder
+	fmt.Fprintf(&report, "raw presence events received: %d\n", diagnostics.total)
+	firstSequence := diagnostics.total - uint64(len(diagnostics.entries)) + 1
+	for index, entry := range diagnostics.entries {
+		fmt.Fprintf(&report, "%d. server=%s, unavailable=%t, last_seen_present=%t, normalized=%s, normalization=%s, dispatch=%s\n", firstSequence+uint64(index), entry.server, entry.unavailable, entry.lastSeenPresent, entry.normalized, entry.normalization, entry.dispatch)
+	}
+	diagnostics.total = 0
+	diagnostics.entries = nil
+	return report.String()
+}
+
+//export C_DrainRawPresenceDiagnostics
+func C_DrainRawPresenceDiagnostics() *C.char {
+	report := rawPresenceProbe.drain()
+	if report == "" {
+		return nil
+	}
+	return C.CString(report)
+}
+
+//export C_FreeRawPresenceDiagnostics
+func C_FreeRawPresenceDiagnostics(report *C.char) {
+	C.free(unsafe.Pointer(report))
+}

--- a/whatsrust/lib/presence_diagnostics_test.go
+++ b/whatsrust/lib/presence_diagnostics_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func TestRawPresenceDiagnosticsDisabledIsNoOp(t *testing.T) {
+	var diagnostics rawPresenceDiagnostics
+	diagnostics.reset(false)
+	diagnostics.record(&events.Presence{From: types.NewJID("private-user", types.DefaultUserServer)})
+	if report := diagnostics.drain(); report != "" {
+		t.Fatalf("disabled diagnostics returned %q", report)
+	}
+}
+
+func TestRawPresenceDiagnosticsAreBoundedOrderedAndRedacted(t *testing.T) {
+	var diagnostics rawPresenceDiagnostics
+	diagnostics.reset(true)
+	for index := 0; index <= maxRawPresenceDiagnosticEntries; index++ {
+		diagnostics.record(&events.Presence{
+			From:        types.NewJID(fmt.Sprintf("private-user-%d", index), types.DefaultUserServer),
+			Unavailable: index%2 == 0,
+			LastSeen:    time.Unix(int64(index+1), 0),
+		})
+	}
+
+	report := diagnostics.drain()
+	if strings.Contains(report, "private-user") {
+		t.Fatal("raw presence report exposed JID user data")
+	}
+	if !strings.Contains(report, "raw presence events received: 51\n") || strings.Contains(report, "\n1. server=") {
+		t.Fatalf("unexpected bounded report header/order:\n%s", report)
+	}
+	if !strings.Contains(report, "2. server=s.whatsapp.net, unavailable=false, last_seen_present=true") ||
+		!strings.Contains(report, "51. server=s.whatsapp.net, unavailable=true, last_seen_present=true") {
+		t.Fatalf("unexpected retained event order:\n%s", report)
+	}
+}
+
+func TestRawPresenceDiagnosticsClassifyServersAndResetOnDrain(t *testing.T) {
+	var diagnostics rawPresenceDiagnostics
+	diagnostics.reset(true)
+	for _, event := range []*events.Presence{
+		{From: types.NewJID("secret-a", types.DefaultUserServer)},
+		{From: types.NewJID("secret-b", types.HiddenUserServer), Unavailable: true},
+		{From: types.NewJID("secret-c", types.GroupServer)},
+	} {
+		diagnostics.record(event)
+	}
+
+	report := diagnostics.drain()
+	for _, expected := range []string{"server=s.whatsapp.net", "server=lid", "server=other"} {
+		if !strings.Contains(report, expected) {
+			t.Fatalf("report missing %q:\n%s", expected, report)
+		}
+	}
+	if strings.Contains(report, "secret-") || !strings.Contains(report, "last_seen_present=false") {
+		t.Fatalf("report leaked identity or omitted safe metadata:\n%s", report)
+	}
+	if report := diagnostics.drain(); report != "raw presence events received: 0\n" {
+		t.Fatalf("drain did not reset run data: %q", report)
+	}
+	diagnostics.reset(true)
+	if report := diagnostics.drain(); report != "raw presence events received: 0\n" {
+		t.Fatalf("run reset retained data: %q", report)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract bounded presence diagnostics, redaction, and reports from the Go bridge.
- Keep presence subscription and event conversion in their existing modules.
- Preserve C exports and callback/log semantics unchanged.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No worktree-local target directory

Tenth responsibility in the Go bridge modularization chain.

Depends on #71.