### PR TITLE
refactor(bridge): extract forwarding cache

### DIFF
--- a/whatsrust/lib/forwarding.go
+++ b/whatsrust/lib/forwarding.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"slices"
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+const maxForwardSources = 1000
+
+type forwardSource struct {
+	info    types.MessageInfo
+	message *waE2E.Message
+}
+
+type forwardSourceCache struct {
+	mu      sync.Mutex
+	entries map[string]forwardSource
+	order   []string
+}
+
+var forwardedSources = forwardSourceCache{entries: make(map[string]forwardSource)}
+
+func resetForwardedSourcesForTest() {
+	forwardedSources.mu.Lock()
+	defer forwardedSources.mu.Unlock()
+	forwardedSources.entries = make(map[string]forwardSource)
+	forwardedSources.order = nil
+}
+
+func removeForwardSources(chat, id string) {
+	forwardedSources.mu.Lock()
+	defer forwardedSources.mu.Unlock()
+	for key, source := range forwardedSources.entries {
+		if source.info.Chat.String() == chat && string(source.info.ID) == id {
+			delete(forwardedSources.entries, key)
+		}
+	}
+	forwardedSources.order = slices.DeleteFunc(forwardedSources.order, func(key string) bool {
+		_, exists := forwardedSources.entries[key]
+		return !exists
+	})
+}
+
+func cacheForwardSource(info types.MessageInfo, message *waE2E.Message) {
+	if message == nil || info.ID == "" || containsViewOnceWrapper(message) {
+		return
+	}
+	key := forwardSourceKey(info.Chat, info.Sender, info.ID)
+	forwardedSources.mu.Lock()
+	defer forwardedSources.mu.Unlock()
+	if _, exists := forwardedSources.entries[key]; !exists {
+		forwardedSources.order = append(forwardedSources.order, key)
+		if len(forwardedSources.order) > maxForwardSources {
+			delete(forwardedSources.entries, forwardedSources.order[0])
+			forwardedSources.order = forwardedSources.order[1:]
+		}
+	}
+	forwardedSources.entries[key] = forwardSource{info: info, message: proto.Clone(message).(*waE2E.Message)}
+}

--- a/whatsrust/lib/forwarding_test.go
+++ b/whatsrust/lib/forwarding_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestViewOnceMessagesAreNotCachedForForwarding(t *testing.T) {
+	resetForwardedSourcesForTest()
+	t.Cleanup(resetForwardedSourcesForTest)
+	chat := types.NewJID("chat", types.DefaultUserServer)
+	info := types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: chat}, ID: "view-once"}
+	message := &waE2E.Message{ViewOnceMessage: &waE2E.FutureProofMessage{Message: &waE2E.Message{ImageMessage: &waE2E.ImageMessage{}}}}
+
+	cacheForwardSource(info, message)
+
+	if len(forwardedSources.entries) != 0 {
+		t.Fatal("view-once media must not be cached for forwarding")
+	}
+}
+
+func TestForwardSourceCacheEvictsAndInvalidatesDeletedSources(t *testing.T) {
+	resetForwardedSourcesForTest()
+	t.Cleanup(resetForwardedSourcesForTest)
+	chat := types.NewJID("source", types.DefaultUserServer)
+	sender := types.NewJID("sender", types.DefaultUserServer)
+	for index := 0; index <= maxForwardSources; index++ {
+		id := types.MessageID(fmt.Sprintf("message-%d", index))
+		cacheForwardSource(types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: sender}, ID: id}, &waE2E.Message{Conversation: stringPointer("payload")})
+	}
+	first := forwardSourceKey(chat, sender, "message-0")
+	last := forwardSourceKey(chat, sender, types.MessageID(fmt.Sprintf("message-%d", maxForwardSources)))
+	forwardedSources.mu.Lock()
+	_, firstExists := forwardedSources.entries[first]
+	_, lastExists := forwardedSources.entries[last]
+	entryCount := len(forwardedSources.entries)
+	forwardedSources.mu.Unlock()
+	if firstExists || !lastExists || entryCount != maxForwardSources {
+		t.Fatalf("cache eviction failed: first=%t last=%t count=%d", firstExists, lastExists, entryCount)
+	}
+	removeForwardSources(chat.String(), "message-"+fmt.Sprint(maxForwardSources))
+	forwardedSources.mu.Lock()
+	_, lastExists = forwardedSources.entries[last]
+	forwardedSources.mu.Unlock()
+	if lastExists {
+		t.Fatal("deleted source remained forwardable in cache")
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -237,8 +237,6 @@ type messageActionCensus struct {
 var eventCensus messageActionCensus
 var messageCallbackMu sync.Mutex
 
-const maxForwardSources = 1000
-
 const (
 	forwardFailureNone uint8 = iota
 	forwardFailureSourceUnavailable
@@ -246,19 +244,6 @@ const (
 	forwardFailureInvalidDestination
 	forwardFailureSendFailed
 )
-
-type forwardSource struct {
-	info    types.MessageInfo
-	message *waE2E.Message
-}
-
-type forwardSourceCache struct {
-	mu      sync.Mutex
-	entries map[string]forwardSource
-	order   []string
-}
-
-var forwardedSources = forwardSourceCache{entries: make(map[string]forwardSource)}
 
 func messageActionDiagnostic(msg string, args ...any) {
 	if os.Getenv("WPTUI_MESSAGE_ACTION_DEBUG") != "1" {
@@ -1056,44 +1041,6 @@ func isStatusProtocolContext(context *waE2E.ContextInfo) bool {
 
 func forwardSourceKey(chat, sender types.JID, id types.MessageID) string {
 	return chat.String() + "\x00" + sender.String() + "\x00" + string(id)
-}
-
-func resetForwardedSourcesForTest() {
-	forwardedSources.mu.Lock()
-	defer forwardedSources.mu.Unlock()
-	forwardedSources.entries = make(map[string]forwardSource)
-	forwardedSources.order = nil
-}
-
-func removeForwardSources(chat, id string) {
-	forwardedSources.mu.Lock()
-	defer forwardedSources.mu.Unlock()
-	for key, source := range forwardedSources.entries {
-		if source.info.Chat.String() == chat && string(source.info.ID) == id {
-			delete(forwardedSources.entries, key)
-		}
-	}
-	forwardedSources.order = slices.DeleteFunc(forwardedSources.order, func(key string) bool {
-		_, exists := forwardedSources.entries[key]
-		return !exists
-	})
-}
-
-func cacheForwardSource(info types.MessageInfo, message *waE2E.Message) {
-	if message == nil || info.ID == "" || containsViewOnceWrapper(message) {
-		return
-	}
-	key := forwardSourceKey(info.Chat, info.Sender, info.ID)
-	forwardedSources.mu.Lock()
-	defer forwardedSources.mu.Unlock()
-	if _, exists := forwardedSources.entries[key]; !exists {
-		forwardedSources.order = append(forwardedSources.order, key)
-		if len(forwardedSources.order) > maxForwardSources {
-			delete(forwardedSources.entries, forwardedSources.order[0])
-			forwardedSources.order = forwardedSources.order[1:]
-		}
-	}
-	forwardedSources.entries[key] = forwardSource{info: info, message: proto.Clone(message).(*waE2E.Message)}
 }
 
 func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -102,20 +102,6 @@ func TestViewOnceWrappersBecomeUnavailablePlaceholders(t *testing.T) {
 	}
 }
 
-func TestViewOnceMessagesAreNotCachedForForwarding(t *testing.T) {
-	resetForwardedSourcesForTest()
-	t.Cleanup(resetForwardedSourcesForTest)
-	chat := types.NewJID("chat", types.DefaultUserServer)
-	info := types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: chat}, ID: "view-once"}
-	message := &waE2E.Message{ViewOnceMessage: &waE2E.FutureProofMessage{Message: &waE2E.Message{ImageMessage: &waE2E.ImageMessage{}}}}
-
-	cacheForwardSource(info, message)
-
-	if len(forwardedSources.entries) != 0 {
-		t.Fatal("view-once media must not be cached for forwarding")
-	}
-}
-
 func TestOrdinaryAndEphemeralMessagesRemainAvailable(t *testing.T) {
 	ordinary := &waE2E.Message{Conversation: stringPointer("ordinary")}
 	if got, unavailable := unavailableViewOnceMessage(ordinary); unavailable || got != ordinary {
@@ -1428,34 +1414,6 @@ func TestNewForwardRequestRejectsBroadcastAndInvalidDestinations(t *testing.T) {
 	request, err := newForwardRequest(chat.String(), sender.String(), "message", []string{chat.String()})
 	if err != nil || len(request.destinations) != 1 {
 		t.Fatalf("forward to source chat must be allowed: request=%#v err=%v", request, err)
-	}
-}
-
-func TestForwardSourceCacheEvictsAndInvalidatesDeletedSources(t *testing.T) {
-	resetForwardedSourcesForTest()
-	t.Cleanup(resetForwardedSourcesForTest)
-	chat := types.NewJID("source", types.DefaultUserServer)
-	sender := types.NewJID("sender", types.DefaultUserServer)
-	for index := 0; index <= maxForwardSources; index++ {
-		id := types.MessageID(fmt.Sprintf("message-%d", index))
-		cacheForwardSource(types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: sender}, ID: id}, &waE2E.Message{Conversation: stringPointer("payload")})
-	}
-	first := forwardSourceKey(chat, sender, "message-0")
-	last := forwardSourceKey(chat, sender, types.MessageID(fmt.Sprintf("message-%d", maxForwardSources)))
-	forwardedSources.mu.Lock()
-	_, firstExists := forwardedSources.entries[first]
-	_, lastExists := forwardedSources.entries[last]
-	entryCount := len(forwardedSources.entries)
-	forwardedSources.mu.Unlock()
-	if firstExists || !lastExists || entryCount != maxForwardSources {
-		t.Fatalf("cache eviction failed: first=%t last=%t count=%d", firstExists, lastExists, entryCount)
-	}
-	removeForwardSources(chat.String(), "message-"+fmt.Sprint(maxForwardSources))
-	forwardedSources.mu.Lock()
-	_, lastExists = forwardedSources.entries[last]
-	forwardedSources.mu.Unlock()
-	if lastExists {
-		t.Fatal("deleted source remained forwardable in cache")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract the bounded forwarding source cache from the Go bridge.
- Preserve FIFO capacity, protobuf cloning, view-once exclusion, and deletion invalidation.
- Leave request validation and exported forwarding orchestration as separate responsibilities.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No worktree-local target directory

Eleventh responsibility in the Go bridge modularization chain.

Depends on #73.