### PR TITLE
refactor(bridge): extract forwarding requests

### DIFF
--- a/whatsrust/lib/forwarding_requests.go
+++ b/whatsrust/lib/forwarding_requests.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+// forwardRequest is the validated, typed input for the forwarding orchestration.
+type forwardRequest struct {
+	sourceChat, sourceSender types.JID
+	sourceID                 types.MessageID
+	destinations             []types.JID
+}
+
+func forwardableJID(jid types.JID) bool {
+	return !jid.IsEmpty() && jid.Server != types.BroadcastServer && jid.Server != types.NewsletterServer
+}
+
+// newForwardRequest owns the forwarding boundary: it parses all JIDs and
+// rejects destinations and sources that cannot participate in ordinary chats.
+func newForwardRequest(sourceChat, sourceSender, sourceID string, destinations []string) (forwardRequest, error) {
+	chat, err := parseActionJID(sourceChat)
+	if err != nil || !forwardableJID(chat) {
+		return forwardRequest{}, fmt.Errorf("forward source chat is invalid")
+	}
+	sender, err := parseActionJID(sourceSender)
+	if err != nil || sender.IsEmpty() || sourceID == "" {
+		return forwardRequest{}, fmt.Errorf("forward requires source sender and message ID")
+	}
+	if len(destinations) == 0 {
+		return forwardRequest{}, fmt.Errorf("forward requires at least one destination")
+	}
+	request := forwardRequest{sourceChat: chat, sourceSender: sender, sourceID: types.MessageID(sourceID)}
+	for _, raw := range destinations {
+		destination, err := parseActionJID(raw)
+		if err != nil || !forwardableJID(destination) {
+			return forwardRequest{}, fmt.Errorf("forward destination is invalid")
+		}
+		request.destinations = append(request.destinations, destination)
+	}
+	return request, nil
+}

--- a/whatsrust/lib/forwarding_requests_test.go
+++ b/whatsrust/lib/forwarding_requests_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestNewForwardRequestValidationAndConversion(t *testing.T) {
+	chat := types.NewJID("source", types.DefaultUserServer)
+	sender := types.NewJID("sender", types.DefaultUserServer)
+	newsletter := types.NewJID("channel", types.NewsletterServer)
+	cases := []struct {
+		name         string
+		sourceChat   string
+		sourceSender string
+		sourceID     string
+		destinations []string
+		wantError    string
+	}{
+		{name: "valid request", sourceChat: chat.String(), sourceSender: sender.String(), sourceID: "message", destinations: []string{chat.String()}},
+		{name: "broadcast source", sourceChat: types.StatusBroadcastJID.String(), sourceSender: sender.String(), sourceID: "message", destinations: []string{chat.String()}, wantError: "forward source chat is invalid"},
+		{name: "newsletter source", sourceChat: newsletter.String(), sourceSender: sender.String(), sourceID: "message", destinations: []string{chat.String()}, wantError: "forward source chat is invalid"},
+		{name: "empty source JID", sourceChat: "", sourceSender: sender.String(), sourceID: "message", destinations: []string{chat.String()}, wantError: "forward source chat is invalid"},
+		{name: "missing sender", sourceChat: chat.String(), sourceSender: "", sourceID: "message", destinations: []string{chat.String()}, wantError: "forward requires source sender and message ID"},
+		{name: "missing source ID", sourceChat: chat.String(), sourceSender: sender.String(), destinations: []string{chat.String()}, wantError: "forward requires source sender and message ID"},
+		{name: "missing destinations", sourceChat: chat.String(), sourceSender: sender.String(), sourceID: "message", wantError: "forward requires at least one destination"},
+		{name: "broadcast destination", sourceChat: chat.String(), sourceSender: sender.String(), sourceID: "message", destinations: []string{types.StatusBroadcastJID.String()}, wantError: "forward destination is invalid"},
+		{name: "newsletter destination", sourceChat: chat.String(), sourceSender: sender.String(), sourceID: "message", destinations: []string{newsletter.String()}, wantError: "forward destination is invalid"},
+		{name: "empty destination JID", sourceChat: chat.String(), sourceSender: sender.String(), sourceID: "message", destinations: []string{""}, wantError: "forward destination is invalid"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request, err := newForwardRequest(testCase.sourceChat, testCase.sourceSender, testCase.sourceID, testCase.destinations)
+			if testCase.wantError != "" {
+				if err == nil || err.Error() != testCase.wantError {
+					t.Fatalf("error = %v, want %q", err, testCase.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newForwardRequest() error = %v", err)
+			}
+			if request.sourceChat != chat || request.sourceSender != sender || request.sourceID != types.MessageID("message") || len(request.destinations) != 1 || request.destinations[0] != chat {
+				t.Fatalf("request conversion = %#v", request)
+			}
+		})
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -2163,39 +2163,6 @@ func quotedMessageFromContent(messageType C.uint8_t, messageContent unsafe.Point
 	}
 }
 
-type forwardRequest struct {
-	sourceChat, sourceSender types.JID
-	sourceID                 types.MessageID
-	destinations             []types.JID
-}
-
-func forwardableJID(jid types.JID) bool {
-	return !jid.IsEmpty() && jid.Server != types.BroadcastServer && jid.Server != types.NewsletterServer
-}
-
-func newForwardRequest(sourceChat, sourceSender, sourceID string, destinations []string) (forwardRequest, error) {
-	chat, err := parseActionJID(sourceChat)
-	if err != nil || !forwardableJID(chat) {
-		return forwardRequest{}, fmt.Errorf("forward source chat is invalid")
-	}
-	sender, err := parseActionJID(sourceSender)
-	if err != nil || sender.IsEmpty() || sourceID == "" {
-		return forwardRequest{}, fmt.Errorf("forward requires source sender and message ID")
-	}
-	if len(destinations) == 0 {
-		return forwardRequest{}, fmt.Errorf("forward requires at least one destination")
-	}
-	request := forwardRequest{sourceChat: chat, sourceSender: sender, sourceID: types.MessageID(sourceID)}
-	for _, raw := range destinations {
-		destination, err := parseActionJID(raw)
-		if err != nil || !forwardableJID(destination) {
-			return forwardRequest{}, fmt.Errorf("forward destination is invalid")
-		}
-		request.destinations = append(request.destinations, destination)
-	}
-	return request, nil
-}
-
 func forwardingContext(existing *waE2E.ContextInfo, sourceIsFromMe bool) *waE2E.ContextInfo {
 	context := &waE2E.ContextInfo{}
 	if existing != nil {

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -1392,31 +1392,6 @@ func TestSourceOwnedByCurrentUserUsesMessageMetadataAndClientIdentity(t *testing
 	}
 }
 
-func TestNewForwardRequestRejectsBroadcastAndInvalidDestinations(t *testing.T) {
-	chat := types.NewJID("source", types.DefaultUserServer)
-	sender := types.NewJID("source", types.DefaultUserServer)
-	if _, err := newForwardRequest(chat.String(), sender.String(), "message", []string{types.StatusBroadcastJID.String()}); err == nil {
-		t.Fatal("broadcast destination was accepted")
-	}
-	if _, err := newForwardRequest(types.StatusBroadcastJID.String(), sender.String(), "message", []string{chat.String()}); err == nil {
-		t.Fatal("status source was accepted")
-	}
-	newsletter := types.NewJID("channel", types.NewsletterServer)
-	if _, err := newForwardRequest(chat.String(), sender.String(), "message", []string{newsletter.String()}); err == nil {
-		t.Fatal("newsletter destination was accepted")
-	}
-	if _, err := newForwardRequest(newsletter.String(), sender.String(), "message", []string{chat.String()}); err == nil {
-		t.Fatal("newsletter source was accepted")
-	}
-	if _, err := newForwardRequest(chat.String(), sender.String(), "", []string{chat.String()}); err == nil {
-		t.Fatal("empty source ID was accepted")
-	}
-	request, err := newForwardRequest(chat.String(), sender.String(), "message", []string{chat.String()})
-	if err != nil || len(request.destinations) != 1 {
-		t.Fatalf("forward to source chat must be allowed: request=%#v err=%v", request, err)
-	}
-}
-
 func TestForwardSourceBytesSurviveCacheReset(t *testing.T) {
 	text := &waE2E.Message{Conversation: stringPointer("historical")}
 	raw, err := proto.Marshal(text)


### PR DESCRIPTION
## Summary

- Extract forwarding request validation and JID conversion from the Go bridge.
- Preserve destination, sender, ID, broadcast, and newsletter semantics.
- Keep cache, message preparation, and exported orchestration separate.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No target directory created

Twelfth responsibility in the Go bridge modularization chain.

Depends on #75.