### PR TITLE
refactor(bridge): extract forwarding messages

### DIFF
--- a/whatsrust/lib/forwarding_messages.go
+++ b/whatsrust/lib/forwarding_messages.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func forwardingContext(existing *waE2E.ContextInfo, sourceIsFromMe bool) *waE2E.ContextInfo {
+	context := &waE2E.ContextInfo{}
+	if existing != nil {
+		context = proto.Clone(existing).(*waE2E.ContextInfo)
+	}
+	if sourceIsFromMe {
+		context.IsForwarded = proto.Bool(false)
+		context.ForwardingScore = nil
+		return context
+	}
+	forwarded := true
+	score := context.GetForwardingScore() + 1
+	if score > 5 {
+		score = 5
+	}
+	context.ForwardingScore = &score
+	context.IsForwarded = &forwarded
+	return context
+}
+
+func sourceOwnedByCurrentUser(sourceIsFromMe bool, sourceSender, self types.JID) bool {
+	return sourceIsFromMe || sourceSender.ToNonAD() == self.ToNonAD()
+}
+
+func marshalForwardSource(message *waE2E.Message) ([]byte, error) {
+	if message == nil || containsViewOnceWrapper(message) {
+		return nil, nil
+	}
+	return proto.Marshal(message)
+}
+
+func forwardSourceFromBytes(raw []byte) (*waE2E.Message, uint8) {
+	if len(raw) == 0 {
+		return nil, forwardFailureSourceUnavailable
+	}
+	message := &waE2E.Message{}
+	if err := proto.Unmarshal(raw, message); err != nil {
+		return nil, forwardFailureSourceUnavailable
+	}
+	return message, forwardFailureNone
+}
+
+func prepareForwardMessage(source *waE2E.Message, sourceIsFromMe bool) (*waE2E.Message, error) {
+	if source == nil {
+		return nil, fmt.Errorf("forward source is unavailable")
+	}
+	forwarded, ok := proto.Clone(source).(*waE2E.Message)
+	if !ok {
+		return nil, fmt.Errorf("forward source cannot be cloned")
+	}
+	switch {
+	case forwarded.Conversation != nil:
+		forwarded.ExtendedTextMessage = &waE2E.ExtendedTextMessage{Text: forwarded.Conversation, ContextInfo: forwardingContext(nil, sourceIsFromMe)}
+		forwarded.Conversation = nil
+	case forwarded.ExtendedTextMessage != nil:
+		forwarded.ExtendedTextMessage.ContextInfo = forwardingContext(forwarded.ExtendedTextMessage.ContextInfo, sourceIsFromMe)
+	case forwarded.ImageMessage != nil:
+		forwarded.ImageMessage.ContextInfo = forwardingContext(forwarded.ImageMessage.ContextInfo, sourceIsFromMe)
+	case forwarded.VideoMessage != nil:
+		forwarded.VideoMessage.ContextInfo = forwardingContext(forwarded.VideoMessage.ContextInfo, sourceIsFromMe)
+	case forwarded.AudioMessage != nil:
+		forwarded.AudioMessage.ContextInfo = forwardingContext(forwarded.AudioMessage.ContextInfo, sourceIsFromMe)
+	case forwarded.DocumentMessage != nil:
+		forwarded.DocumentMessage.ContextInfo = forwardingContext(forwarded.DocumentMessage.ContextInfo, sourceIsFromMe)
+	case forwarded.StickerMessage != nil:
+		forwarded.StickerMessage.ContextInfo = forwardingContext(forwarded.StickerMessage.ContextInfo, sourceIsFromMe)
+	default:
+		return nil, fmt.Errorf("message content is not forwardable")
+	}
+	return forwarded, nil
+}

--- a/whatsrust/lib/forwarding_messages_test.go
+++ b/whatsrust/lib/forwarding_messages_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestPrepareForwardMessagePreservesTextAndFilePayloads(t *testing.T) {
+	text := &waE2E.Message{Conversation: stringPointer("hello")}
+	forwarded, err := prepareForwardMessage(text, false)
+	if err != nil || forwarded.GetExtendedTextMessage().GetText() != "hello" || !forwarded.GetExtendedTextMessage().GetContextInfo().GetIsForwarded() {
+		t.Fatalf("text forwarding envelope = %#v, error = %v", forwarded, err)
+	}
+	if text.GetConversation() != "hello" || text.GetExtendedTextMessage() != nil {
+		t.Fatalf("source message was mutated: %#v", text)
+	}
+	media := &waE2E.Message{ImageMessage: &waE2E.ImageMessage{URL: stringPointer("https://media.example"), DirectPath: stringPointer("/media")}}
+	forwarded, err = prepareForwardMessage(media, false)
+	if err != nil || forwarded.GetImageMessage().GetDirectPath() != "/media" || !forwarded.GetImageMessage().GetContextInfo().GetIsForwarded() {
+		t.Fatalf("file forwarding envelope = %#v, error = %v", forwarded, err)
+	}
+}
+
+func TestPrepareForwardMessageAppliesMobileForwardingContextSemantics(t *testing.T) {
+	stanzaID := "quoted-message"
+	score := uint32(4)
+	other := &waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{Text: stringPointer("other person's message"), ContextInfo: &waE2E.ContextInfo{StanzaID: &stanzaID, ForwardingScore: &score, IsForwarded: proto.Bool(true)}}}
+	forwarded, err := prepareForwardMessage(other, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	context := forwarded.GetExtendedTextMessage().GetContextInfo()
+	if !context.GetIsForwarded() || context.GetForwardingScore() != 5 || context.GetStanzaID() != stanzaID {
+		t.Fatalf("other sender context = %#v", context)
+	}
+	repeated, err := prepareForwardMessage(forwarded, false)
+	if err != nil || !repeated.GetExtendedTextMessage().GetContextInfo().GetIsForwarded() || repeated.GetExtendedTextMessage().GetContextInfo().GetForwardingScore() != 5 || repeated.GetExtendedTextMessage().GetContextInfo().GetStanzaID() != stanzaID {
+		t.Fatalf("capped forwarding context = %#v, error = %v", repeated, err)
+	}
+	own := &waE2E.Message{ImageMessage: &waE2E.ImageMessage{DirectPath: stringPointer("/media"), ContextInfo: &waE2E.ContextInfo{StanzaID: &stanzaID, ForwardingScore: &score, IsForwarded: proto.Bool(true)}}}
+	forwarded, err = prepareForwardMessage(own, true)
+	context = forwarded.GetImageMessage().GetContextInfo()
+	if err != nil || context.GetIsForwarded() || context.GetForwardingScore() != 0 || context.GetStanzaID() != stanzaID || forwarded.GetImageMessage().GetDirectPath() != "/media" {
+		t.Fatalf("own sender context = %#v, message = %#v, error = %v", context, forwarded, err)
+	}
+}
+
+func TestSourceOwnedByCurrentUserUsesMessageMetadataAndClientIdentity(t *testing.T) {
+	self := types.NewJID("self", types.DefaultUserServer)
+	other := types.NewJID("other", types.DefaultUserServer)
+	if !sourceOwnedByCurrentUser(true, other, self) || !sourceOwnedByCurrentUser(false, self, self) || sourceOwnedByCurrentUser(false, other, self) {
+		t.Fatal("source ownership did not preserve metadata and client identity")
+	}
+}
+
+func TestForwardSourceBytesSurviveCacheReset(t *testing.T) {
+	for _, message := range []*waE2E.Message{{Conversation: stringPointer("historical")}, {ImageMessage: &waE2E.ImageMessage{DirectPath: stringPointer("/media")}}} {
+		raw, err := proto.Marshal(message)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resetForwardedSourcesForTest()
+		restored, reason := forwardSourceFromBytes(raw)
+		if reason != forwardFailureNone || !proto.Equal(restored, message) {
+			t.Fatalf("source recovery = %#v, %v", restored, reason)
+		}
+	}
+}
+
+func TestMarshalForwardSourceExcludesViewOnce(t *testing.T) {
+	message := &waE2E.Message{ViewOnceMessage: &waE2E.FutureProofMessage{Message: &waE2E.Message{Conversation: stringPointer("private")}}}
+	raw, err := marshalForwardSource(message)
+	if err != nil || len(raw) != 0 {
+		t.Fatalf("view-once source bytes = %v, error = %v", raw, err)
+	}
+}
+
+func TestForwardMessagePreparationAndDecodingReportFailures(t *testing.T) {
+	if _, err := prepareForwardMessage(nil, false); err == nil {
+		t.Fatal("nil source should fail")
+	}
+	if _, err := prepareForwardMessage(&waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{}}, false); err == nil {
+		t.Fatal("unsupported content should fail")
+	}
+	for _, raw := range [][]byte{nil, []byte("invalid protobuf")} {
+		if message, reason := forwardSourceFromBytes(raw); message != nil || reason != forwardFailureSourceUnavailable {
+			t.Fatalf("source failure = %#v, %v", message, reason)
+		}
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -1085,7 +1085,7 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	var rawSource []byte
 	if !viewOnceUnavailable {
 		var err error
-		rawSource, err = proto.Marshal(msg)
+		rawSource, err = marshalForwardSource(msg)
 		if err != nil {
 			LOG_WARN("forward source serialization failed: %v", err)
 			rawSource = nil
@@ -2161,71 +2161,6 @@ func quotedMessageFromContent(messageType C.uint8_t, messageContent unsafe.Point
 	default:
 		return nil
 	}
-}
-
-func forwardingContext(existing *waE2E.ContextInfo, sourceIsFromMe bool) *waE2E.ContextInfo {
-	context := &waE2E.ContextInfo{}
-	if existing != nil {
-		context = proto.Clone(existing).(*waE2E.ContextInfo)
-	}
-	if sourceIsFromMe {
-		context.IsForwarded = proto.Bool(false)
-		context.ForwardingScore = nil
-		return context
-	}
-	forwarded := true
-	score := context.GetForwardingScore() + 1
-	if score > 5 {
-		score = 5
-	}
-	context.ForwardingScore = &score
-	context.IsForwarded = &forwarded
-	return context
-}
-
-func sourceOwnedByCurrentUser(sourceIsFromMe bool, sourceSender, self types.JID) bool {
-	return sourceIsFromMe || sourceSender.ToNonAD() == self.ToNonAD()
-}
-
-func forwardSourceFromBytes(raw []byte) (*waE2E.Message, uint8) {
-	if len(raw) == 0 {
-		return nil, forwardFailureSourceUnavailable
-	}
-	message := &waE2E.Message{}
-	if err := proto.Unmarshal(raw, message); err != nil {
-		return nil, forwardFailureSourceUnavailable
-	}
-	return message, forwardFailureNone
-}
-
-func prepareForwardMessage(source *waE2E.Message, sourceIsFromMe bool) (*waE2E.Message, error) {
-	if source == nil {
-		return nil, fmt.Errorf("forward source is unavailable")
-	}
-	forwarded, ok := proto.Clone(source).(*waE2E.Message)
-	if !ok {
-		return nil, fmt.Errorf("forward source cannot be cloned")
-	}
-	switch {
-	case forwarded.Conversation != nil:
-		forwarded.ExtendedTextMessage = &waE2E.ExtendedTextMessage{Text: forwarded.Conversation, ContextInfo: forwardingContext(nil, sourceIsFromMe)}
-		forwarded.Conversation = nil
-	case forwarded.ExtendedTextMessage != nil:
-		forwarded.ExtendedTextMessage.ContextInfo = forwardingContext(forwarded.ExtendedTextMessage.ContextInfo, sourceIsFromMe)
-	case forwarded.ImageMessage != nil:
-		forwarded.ImageMessage.ContextInfo = forwardingContext(forwarded.ImageMessage.ContextInfo, sourceIsFromMe)
-	case forwarded.VideoMessage != nil:
-		forwarded.VideoMessage.ContextInfo = forwardingContext(forwarded.VideoMessage.ContextInfo, sourceIsFromMe)
-	case forwarded.AudioMessage != nil:
-		forwarded.AudioMessage.ContextInfo = forwardingContext(forwarded.AudioMessage.ContextInfo, sourceIsFromMe)
-	case forwarded.DocumentMessage != nil:
-		forwarded.DocumentMessage.ContextInfo = forwardingContext(forwarded.DocumentMessage.ContextInfo, sourceIsFromMe)
-	case forwarded.StickerMessage != nil:
-		forwarded.StickerMessage.ContextInfo = forwardingContext(forwarded.StickerMessage.ContextInfo, sourceIsFromMe)
-	default:
-		return nil, fmt.Errorf("message content is not forwardable")
-	}
-	return forwarded, nil
 }
 
 //export C_ForwardMessage

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -1315,135 +1315,23 @@ func TestMessageActionEventFromMessage(t *testing.T) {
 	}
 }
 
-func TestPrepareForwardMessagePreservesTextAndFilePayloads(t *testing.T) {
-	text := &waE2E.Message{Conversation: stringPointer("hello")}
-	forwarded, err := prepareForwardMessage(text, false)
-	if err != nil {
-		t.Fatalf("prepare text forward: %v", err)
-	}
-	if forwarded.GetExtendedTextMessage().GetText() != "hello" || !forwarded.GetExtendedTextMessage().GetContextInfo().GetIsForwarded() {
-		t.Fatalf("text forwarding envelope = %#v", forwarded)
-	}
-
-	media := &waE2E.Message{ImageMessage: &waE2E.ImageMessage{URL: stringPointer("https://media.example"), DirectPath: stringPointer("/media")}}
-	forwarded, err = prepareForwardMessage(media, false)
-	if err != nil {
-		t.Fatalf("prepare file forward: %v", err)
-	}
-	if forwarded.GetImageMessage().GetDirectPath() != "/media" || !forwarded.GetImageMessage().GetContextInfo().GetIsForwarded() {
-		t.Fatalf("file forwarding envelope lost media payload: %#v", forwarded)
-	}
-}
-
-func TestPrepareForwardMessageAppliesMobileForwardingContextSemantics(t *testing.T) {
-	stanzaID := "quoted-message"
-	score := uint32(4)
-	other := &waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{
-		Text: stringPointer("other person's message"),
-		ContextInfo: &waE2E.ContextInfo{
-			StanzaID:        &stanzaID,
-			ForwardingScore: &score,
-			IsForwarded:     proto.Bool(true),
-		},
-	}}
-
-	forwarded, err := prepareForwardMessage(other, false)
-	if err != nil {
-		t.Fatalf("prepare other sender forward: %v", err)
-	}
-	context := forwarded.GetExtendedTextMessage().GetContextInfo()
-	if !context.GetIsForwarded() || context.GetForwardingScore() != 5 || context.GetStanzaID() != stanzaID {
-		t.Fatalf("other sender context = %#v", context)
-	}
-
-	repeated, err := prepareForwardMessage(forwarded, false)
-	if err != nil {
-		t.Fatalf("prepare repeatedly forwarded message: %v", err)
-	}
-	if context := repeated.GetExtendedTextMessage().GetContextInfo(); !context.GetIsForwarded() || context.GetForwardingScore() != 5 || context.GetStanzaID() != stanzaID {
-		t.Fatalf("capped frequently-forwarded context = %#v", context)
-	}
-
-	own := &waE2E.Message{ImageMessage: &waE2E.ImageMessage{
-		DirectPath:  stringPointer("/media"),
-		ContextInfo: &waE2E.ContextInfo{StanzaID: &stanzaID, ForwardingScore: &score, IsForwarded: proto.Bool(true)},
-	}}
-	forwarded, err = prepareForwardMessage(own, true)
-	if err != nil {
-		t.Fatalf("prepare own forward: %v", err)
-	}
-	context = forwarded.GetImageMessage().GetContextInfo()
-	if context.GetIsForwarded() || context.GetForwardingScore() != 0 || context.GetStanzaID() != stanzaID || forwarded.GetImageMessage().GetDirectPath() != "/media" {
-		t.Fatalf("own sender context = %#v, message = %#v", context, forwarded)
-	}
-}
-
-func TestSourceOwnedByCurrentUserUsesMessageMetadataAndClientIdentity(t *testing.T) {
-	self := types.NewJID("self", types.DefaultUserServer)
-	other := types.NewJID("other", types.DefaultUserServer)
-	if !sourceOwnedByCurrentUser(true, other, self) {
-		t.Fatal("source metadata marking the message as own was ignored")
-	}
-	if !sourceOwnedByCurrentUser(false, self, self) {
-		t.Fatal("source sender matching the current client identity was ignored")
-	}
-	if sourceOwnedByCurrentUser(false, other, self) {
-		t.Fatal("other sender was incorrectly treated as current user")
-	}
-}
-
-func TestForwardSourceBytesSurviveCacheReset(t *testing.T) {
-	text := &waE2E.Message{Conversation: stringPointer("historical")}
-	raw, err := proto.Marshal(text)
-	if err != nil {
-		t.Fatalf("marshal source: %v", err)
-	}
-	resetForwardedSourcesForTest()
-	restored, reason := forwardSourceFromBytes(raw)
-	if reason != forwardFailureNone || restored.GetConversation() != "historical" {
-		t.Fatalf("historical source recovery = %#v, %v", restored, reason)
-	}
-	file := &waE2E.Message{ImageMessage: &waE2E.ImageMessage{DirectPath: stringPointer("/media")}}
-	raw, err = proto.Marshal(file)
-	if err != nil {
-		t.Fatalf("marshal file source: %v", err)
-	}
-	restored, reason = forwardSourceFromBytes(raw)
-	if reason != forwardFailureNone || restored.GetImageMessage().GetDirectPath() != "/media" {
-		t.Fatalf("historical file recovery = %#v, %v", restored, reason)
-	}
-}
-
 func TestForwardingStateExtractsEverySupportedMessageContext(t *testing.T) {
-	forwarded := proto.Bool(true)
-	score := uint32(5)
+	forwarded, score := proto.Bool(true), uint32(5)
 	context := &waE2E.ContextInfo{IsForwarded: forwarded, ForwardingScore: &score}
-	cases := []struct {
-		name    string
-		message *waE2E.Message
-	}{
-		{"extended text", &waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{ContextInfo: context}}},
-		{"image", &waE2E.Message{ImageMessage: &waE2E.ImageMessage{ContextInfo: context}}},
-		{"video", &waE2E.Message{VideoMessage: &waE2E.VideoMessage{ContextInfo: context}}},
-		{"audio", &waE2E.Message{AudioMessage: &waE2E.AudioMessage{ContextInfo: context}}},
-		{"document", &waE2E.Message{DocumentMessage: &waE2E.DocumentMessage{ContextInfo: context}}},
-		{"sticker", &waE2E.Message{StickerMessage: &waE2E.StickerMessage{ContextInfo: context}}},
-	}
-	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
-			state := forwardingStateFromMessage(testCase.message)
-			if !state.isForwarded || state.score != 5 {
-				t.Fatalf("forwarding state = %#v", state)
-			}
-		})
-	}
-
-	t.Run("conversation has no forwarding context", func(t *testing.T) {
-		state := forwardingStateFromMessage(&waE2E.Message{Conversation: stringPointer("text")})
-		if state != (forwardingState{}) {
-			t.Fatalf("conversation forwarding state = %#v", state)
+	for _, message := range []*waE2E.Message{
+		{ExtendedTextMessage: &waE2E.ExtendedTextMessage{ContextInfo: context}},
+		{ImageMessage: &waE2E.ImageMessage{ContextInfo: context}}, {VideoMessage: &waE2E.VideoMessage{ContextInfo: context}},
+		{AudioMessage: &waE2E.AudioMessage{ContextInfo: context}}, {DocumentMessage: &waE2E.DocumentMessage{ContextInfo: context}},
+		{StickerMessage: &waE2E.StickerMessage{ContextInfo: context}},
+	} {
+		state := forwardingStateFromMessage(message)
+		if !state.isForwarded || state.score != 5 {
+			t.Fatalf("forwarding state = %#v", state)
 		}
-	})
+	}
+	if state := forwardingStateFromMessage(&waE2E.Message{Conversation: stringPointer("text")}); state != (forwardingState{}) {
+		t.Fatalf("conversation forwarding state = %#v", state)
+	}
 }
 
 func int64Pointer(value int64) *int64 { return &value }


### PR DESCRIPTION
## Summary

- Extract forwarding source decoding and message preparation from the Go bridge.
- Preserve text/file semantics, metadata, clone safety, and view-once exclusions.
- Keep cache, request validation, and exported orchestration separate.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No target directory created

Thirteenth responsibility in the Go bridge modularization chain.

Depends on #77.