### PR TITLE
refactor(bridge): extract forwarding orchestration

### DIFF
--- a/whatsrust/lib/forwarding_orchestration.go
+++ b/whatsrust/lib/forwarding_orchestration.go
@@ -1,0 +1,72 @@
+package main
+
+/*
+#include <stdint.h>
+
+typedef struct {
+	uint32_t succeeded;
+	uint32_t failed;
+	uint8_t failure;
+} ForwardResult;
+*/
+import "C"
+
+import (
+	"context"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+type forwardingReport struct {
+	succeeded uint32
+	failed    uint32
+	failure   uint8
+}
+
+func (report forwardingReport) cResult() C.ForwardResult {
+	return C.ForwardResult{
+		succeeded: C.uint32_t(report.succeeded),
+		failed:    C.uint32_t(report.failed),
+		failure:   C.uint8_t(report.failure),
+	}
+}
+
+func forwardMessages(sourceID, sourceChat, sourceSender string, sourceIsFromMe bool, destinations []string, rawSource []byte) forwardingReport {
+	request, err := newForwardRequest(sourceChat, sourceSender, sourceID, destinations)
+	if err != nil {
+		return forwardingReport{failed: uint32(len(destinations)), failure: forwardFailureInvalidSource}
+	}
+	if client == nil || client.Store == nil || client.Store.ID == nil {
+		return forwardingReport{failed: uint32(len(request.destinations)), failure: forwardFailureSendFailed}
+	}
+	sourceMessage, failure := forwardSourceFromBytes(rawSource)
+	if failure != forwardFailureNone {
+		return forwardingReport{failed: uint32(len(request.destinations)), failure: failure}
+	}
+	sourceOwned := sourceOwnedByCurrentUser(sourceIsFromMe, request.sourceSender, *client.Store.ID)
+	report := forwardingReport{}
+	for _, destination := range request.destinations {
+		message, err := prepareForwardMessage(sourceMessage, sourceOwned)
+		if err != nil {
+			report.failed++
+			continue
+		}
+		response, err := client.SendMessage(context.Background(), destination, message)
+		if err != nil {
+			LOG_WARN("forward send failed: %v", err)
+			report.failed++
+			continue
+		}
+		report.succeeded++
+		HandleMessage(types.MessageInfo{MessageSource: types.MessageSource{Chat: destination, Sender: *client.Store.ID, IsFromMe: true}, ID: response.ID, Timestamp: response.Timestamp}, message, false)
+	}
+	return report
+}
+
+func forwardingSourceBytes(pointer *C.uint8_t, length C.size_t) []byte {
+	if pointer == nil || length == 0 {
+		return nil
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(pointer)), int(length))
+}

--- a/whatsrust/lib/forwarding_orchestration_test.go
+++ b/whatsrust/lib/forwarding_orchestration_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestForwardMessagesReportsBoundaryFailures(t *testing.T) {
+	chat := types.NewJID("chat", types.DefaultUserServer).String()
+	sender := types.NewJID("sender", types.DefaultUserServer).String()
+	destinations := []string{
+		types.NewJID("first", types.DefaultUserServer).String(),
+		types.NewJID("second", types.DefaultUserServer).String(),
+	}
+
+	tests := []struct {
+		name          string
+		sourceChat    string
+		sourceSender  string
+		sourceID      string
+		destinations  []string
+		wantSucceeded uint32
+		wantFailed    uint32
+		wantFailure   uint8
+	}{
+		{
+			name:         "invalid source request",
+			sourceChat:   types.StatusBroadcastJID.String(),
+			sourceSender: sender,
+			sourceID:     "message",
+			destinations: destinations,
+			wantFailed:   2,
+			wantFailure:  forwardFailureInvalidSource,
+		},
+		{
+			name:         "unavailable client",
+			sourceChat:   chat,
+			sourceSender: sender,
+			sourceID:     "message",
+			destinations: destinations,
+			wantFailed:   2,
+			wantFailure:  forwardFailureSendFailed,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := forwardMessages(testCase.sourceID, testCase.sourceChat, testCase.sourceSender, false, testCase.destinations, nil)
+			if got.succeeded != testCase.wantSucceeded || got.failed != testCase.wantFailed || got.failure != testCase.wantFailure {
+				t.Fatalf("forwardMessages() = %#v, want succeeded=%d failed=%d failure=%d", got, testCase.wantSucceeded, testCase.wantFailed, testCase.wantFailure)
+			}
+		})
+	}
+}
+
+func TestForwardingSourceBytesPreservesCBufferBoundaries(t *testing.T) {
+	if got := forwardingSourceBytes(nil, 0); got != nil {
+		t.Fatalf("empty source = %#v, want nil", got)
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -2165,9 +2165,8 @@ func quotedMessageFromContent(messageType C.uint8_t, messageContent unsafe.Point
 
 //export C_ForwardMessage
 func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, sourceIsFromMe C.bool, destinations **C.char, destinationCount C.size_t, forwardSource *C.uint8_t, forwardSourceLen C.size_t) C.ForwardResult {
-	result := C.ForwardResult{}
 	if sourceID == nil || sourceChat == nil || sourceSender == nil || destinations == nil || destinationCount == 0 {
-		return result
+		return C.ForwardResult{}
 	}
 	rawDestinations := unsafe.Slice(destinations, int(destinationCount))
 	destinationStrings := make([]string, 0, len(rawDestinations))
@@ -2177,37 +2176,14 @@ func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, so
 		}
 		destinationStrings = append(destinationStrings, C.GoString(destination))
 	}
-	request, err := newForwardRequest(C.GoString(sourceChat), C.GoString(sourceSender), C.GoString(sourceID), destinationStrings)
-	if err != nil {
-		return C.ForwardResult{failed: C.uint32_t(destinationCount), failure: C.uint8_t(forwardFailureInvalidSource)}
-	}
-	if client == nil || client.Store == nil || client.Store.ID == nil {
-		return C.ForwardResult{failed: C.uint32_t(destinationCount), failure: C.uint8_t(forwardFailureSendFailed)}
-	}
-	if forwardSource == nil || forwardSourceLen == 0 {
-		return C.ForwardResult{failed: C.uint32_t(destinationCount), failure: C.uint8_t(forwardFailureSourceUnavailable)}
-	}
-	sourceMessage, failure := forwardSourceFromBytes(unsafe.Slice((*byte)(unsafe.Pointer(forwardSource)), int(forwardSourceLen)))
-	if failure != forwardFailureNone {
-		return C.ForwardResult{failed: C.uint32_t(destinationCount), failure: C.uint8_t(failure)}
-	}
-	sourceOwned := sourceOwnedByCurrentUser(bool(sourceIsFromMe), request.sourceSender, *client.Store.ID)
-	for _, destination := range request.destinations {
-		message, err := prepareForwardMessage(sourceMessage, sourceOwned)
-		if err != nil {
-			result.failed++
-			continue
-		}
-		response, err := client.SendMessage(context.Background(), destination, message)
-		if err != nil {
-			LOG_WARN("forward send failed: %v", err)
-			result.failed++
-			continue
-		}
-		result.succeeded++
-		HandleMessage(types.MessageInfo{MessageSource: types.MessageSource{Chat: destination, Sender: *client.Store.ID, IsFromMe: true}, ID: response.ID, Timestamp: response.Timestamp}, message, false)
-	}
-	return result
+	return forwardMessages(
+		C.GoString(sourceID),
+		C.GoString(sourceChat),
+		C.GoString(sourceSender),
+		bool(sourceIsFromMe),
+		destinationStrings,
+		forwardingSourceBytes(forwardSource, forwardSourceLen),
+	).cResult()
 }
 
 //export C_SendMessage


### PR DESCRIPTION
## Summary

- Extract forwarding destination orchestration and report conversion from the Go bridge.
- Delegate cache, validation, and message preparation to their existing modules.
- Preserve the exported C wrapper and ForwardResult ABI unchanged.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No target directory created

Fourteenth responsibility in the Go bridge modularization chain.

Depends on #78.