### PR TITLE
refactor(bridge): extract message send

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -2115,54 +2115,6 @@ func C_PairPhone(phone *C.char) *C.char {
 	return cCode
 }
 
-func quotedContextInfo(id, sender, chat string) *waE2E.ContextInfo {
-	return &waE2E.ContextInfo{StanzaID: &id, Participant: &sender, RemoteJID: &chat}
-}
-
-func quotedTextMessage(text string) *waE2E.Message {
-	return &waE2E.Message{Conversation: &text}
-}
-
-func quotedFileMessage(kind uint8, caption string) *waE2E.Message {
-	var captionPtr *string
-	if caption != "" {
-		captionPtr = &caption
-	}
-	switch kind {
-	case FileTypeImage:
-		return &waE2E.Message{ImageMessage: &waE2E.ImageMessage{Caption: captionPtr}}
-	case FileTypeVideo:
-		return &waE2E.Message{VideoMessage: &waE2E.VideoMessage{Caption: captionPtr}}
-	case FileTypeAudio:
-		return &waE2E.Message{AudioMessage: &waE2E.AudioMessage{}}
-	case FileTypeDocument:
-		return &waE2E.Message{DocumentMessage: &waE2E.DocumentMessage{Caption: captionPtr}}
-	case FileTypeSticker:
-		return &waE2E.Message{StickerMessage: &waE2E.StickerMessage{}}
-	default:
-		return nil
-	}
-}
-
-func quotedMessageFromContent(messageType C.uint8_t, messageContent unsafe.Pointer) *waE2E.Message {
-	if messageContent == nil {
-		return nil
-	}
-	switch messageType {
-	case C.uint8_t(MessageTypeText):
-		return quotedTextMessage(C.GoString((*C.TextMessage)(messageContent).text))
-	case C.uint8_t(MessageTypeFile):
-		file := (*C.FileMessage)(messageContent)
-		caption := ""
-		if file.caption != nil {
-			caption = C.GoString(file.caption)
-		}
-		return quotedFileMessage(uint8(file.kind), caption)
-	default:
-		return nil
-	}
-}
-
 //export C_ForwardMessage
 func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, sourceIsFromMe C.bool, destinations **C.char, destinationCount C.size_t, forwardSource *C.uint8_t, forwardSourceLen C.size_t) C.ForwardResult {
 	if sourceID == nil || sourceChat == nil || sourceSender == nil || destinations == nil || destinationCount == 0 {
@@ -2184,40 +2136,6 @@ func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, so
 		destinationStrings,
 		forwardingSourceBytes(forwardSource, forwardSourceLen),
 	).cResult()
-}
-
-//export C_SendMessage
-func C_SendMessage(cjid C.JID, messageType C.uint8_t, messageContent unsafe.Pointer, quoteId *C.char, quoteSender C.JID, quoteChat C.JID, quoteMessageType C.uint8_t, quoteMessageContent unsafe.Pointer) {
-	if cjid == nil || messageContent == nil || client == nil || client.Store == nil || client.Store.ID == nil {
-		LOG_WARN("message send rejected: client or message is unavailable")
-		return
-	}
-	jid := cToJid(cjid)
-
-	contextInfo := &waE2E.ContextInfo{}
-	if quoteId != nil {
-		contextInfo = quotedContextInfo(C.GoString(quoteId), C.GoString(quoteSender), C.GoString(quoteChat))
-		contextInfo.QuotedMessage = quotedMessageFromContent(quoteMessageType, quoteMessageContent)
-	}
-
-	message := ContentToWaE2EMessage(messageType, messageContent, contextInfo)
-
-	sendResponse, err := client.SendMessage(context.Background(), jid, message)
-	if err != nil {
-		LOG_WARN("message send failed: %v", err)
-		return
-	} else {
-		var messageInfo types.MessageInfo
-		messageInfo.Chat = jid
-		messageInfo.IsFromMe = true
-		messageInfo.Sender = *client.Store.ID
-
-		messageInfo.ID = sendResponse.ID
-		messageInfo.Timestamp = sendResponse.Timestamp
-
-		LOG_INFO("Message sent: %s %s", messageInfo.ID, messageInfo.Chat)
-		HandleMessage(messageInfo, message, false)
-	}
 }
 
 //export C_ReactToMessage

--- a/whatsrust/lib/message_send.go
+++ b/whatsrust/lib/message_send.go
@@ -1,0 +1,106 @@
+package main
+
+/*
+#include <stdint.h>
+
+typedef const char* JID;
+
+typedef struct {
+	char* text;
+} SendTextMessage;
+
+typedef struct {
+	uint8_t kind;
+	char* path;
+	char* fileID;
+	char* caption;
+} SendFileMessage;
+*/
+import "C"
+
+import (
+	"context"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func quotedContextInfo(id, sender, chat string) *waE2E.ContextInfo {
+	return &waE2E.ContextInfo{StanzaID: &id, Participant: &sender, RemoteJID: &chat}
+}
+
+func quotedTextMessage(text string) *waE2E.Message {
+	return &waE2E.Message{Conversation: &text}
+}
+
+func quotedFileMessage(kind uint8, caption string) *waE2E.Message {
+	var captionPtr *string
+	if caption != "" {
+		captionPtr = &caption
+	}
+	switch kind {
+	case FileTypeImage:
+		return &waE2E.Message{ImageMessage: &waE2E.ImageMessage{Caption: captionPtr}}
+	case FileTypeVideo:
+		return &waE2E.Message{VideoMessage: &waE2E.VideoMessage{Caption: captionPtr}}
+	case FileTypeAudio:
+		return &waE2E.Message{AudioMessage: &waE2E.AudioMessage{}}
+	case FileTypeDocument:
+		return &waE2E.Message{DocumentMessage: &waE2E.DocumentMessage{Caption: captionPtr}}
+	case FileTypeSticker:
+		return &waE2E.Message{StickerMessage: &waE2E.StickerMessage{}}
+	default:
+		return nil
+	}
+}
+
+func quotedMessageFromContent(messageType C.uint8_t, messageContent unsafe.Pointer) *waE2E.Message {
+	if messageContent == nil {
+		return nil
+	}
+	switch messageType {
+	case C.uint8_t(MessageTypeText):
+		return quotedTextMessage(C.GoString((*C.SendTextMessage)(messageContent).text))
+	case C.uint8_t(MessageTypeFile):
+		file := (*C.SendFileMessage)(messageContent)
+		caption := ""
+		if file.caption != nil {
+			caption = C.GoString(file.caption)
+		}
+		return quotedFileMessage(uint8(file.kind), caption)
+	default:
+		return nil
+	}
+}
+
+//export C_SendMessage
+func C_SendMessage(cjid C.JID, messageType C.uint8_t, messageContent unsafe.Pointer, quoteId *C.char, quoteSender C.JID, quoteChat C.JID, quoteMessageType C.uint8_t, quoteMessageContent unsafe.Pointer) {
+	if cjid == nil || messageContent == nil || client == nil || client.Store == nil || client.Store.ID == nil {
+		LOG_WARN("message send rejected: client or message is unavailable")
+		return
+	}
+	jid := cToJid(cjid)
+
+	contextInfo := &waE2E.ContextInfo{}
+	if quoteId != nil {
+		contextInfo = quotedContextInfo(C.GoString(quoteId), C.GoString(quoteSender), C.GoString(quoteChat))
+		contextInfo.QuotedMessage = quotedMessageFromContent(quoteMessageType, quoteMessageContent)
+	}
+
+	message := ContentToWaE2EMessage(messageType, messageContent, contextInfo)
+
+	sendResponse, err := client.SendMessage(context.Background(), jid, message)
+	if err != nil {
+		LOG_WARN("message send failed: %v", err)
+		return
+	}
+
+	messageInfo := types.MessageInfo{
+		MessageSource: types.MessageSource{Chat: jid, Sender: *client.Store.ID, IsFromMe: true},
+		ID:            sendResponse.ID,
+		Timestamp:     sendResponse.Timestamp,
+	}
+	LOG_INFO("Message sent: %s %s", messageInfo.ID, messageInfo.Chat)
+	HandleMessage(messageInfo, message, false)
+}

--- a/whatsrust/lib/message_send_test.go
+++ b/whatsrust/lib/message_send_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestQuotedMessageBuildersPreserveTextAndFileKinds(t *testing.T) {
+	if quotedTextMessage("quoted text").GetConversation() != "quoted text" {
+		t.Fatal("quoted text was not preserved")
+	}
+	if quotedFileMessage(FileTypeImage, "caption").GetImageMessage().GetCaption() != "caption" {
+		t.Fatal("image quote caption was not preserved")
+	}
+	if quotedFileMessage(FileTypeAudio, "ignored").GetAudioMessage() == nil {
+		t.Fatal("audio quote was not built")
+	}
+	if quotedFileMessage(99, "caption") != nil {
+		t.Fatal("unknown quoted file kind should be omitted")
+	}
+}
+
+func TestQuotedContextInfoPreservesOriginalAttribution(t *testing.T) {
+	context := quotedContextInfo("message-id", "sender@s.whatsapp.net", "chat@s.whatsapp.net")
+	if context.GetStanzaID() != "message-id" || context.GetParticipant() != "sender@s.whatsapp.net" || context.GetRemoteJID() != "chat@s.whatsapp.net" {
+		t.Fatalf("quote context = %+v, want original attribution", context)
+	}
+}
+
+func TestMessageSendKeepsExportedBridgeContractInDedicatedOrchestration(t *testing.T) {
+	source, err := os.ReadFile("message_send.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fragment := range []string{
+		"//export C_SendMessage",
+		"func C_SendMessage(cjid C.JID",
+		"HandleMessage(messageInfo, message, false)",
+	} {
+		if !strings.Contains(string(source), fragment) {
+			t.Fatalf("message send orchestration missing %q", fragment)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Extract message-send conversion and orchestration from the Go bridge.
- Preserve text/file, quote/reply, sent-ID, callback ownership, and ordinary/newsletter semantics.
- Keep forwarding and message-action orchestration separate.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No target directory created

Fifteenth responsibility in the Go bridge modularization chain.

Depends on #79.