### PR TITLE
refactor(bridge): extract media downloads

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -188,11 +188,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"mime"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -659,29 +657,6 @@ func ParseWebMessageInfo(selfJid types.JID, chatJid types.JID, webMsg *waWeb.Web
 		return nil
 	}
 	return &info
-}
-
-func SliceIndex(list []string, value string, defaultValue int) int {
-	index := slices.Index(list, value)
-	if index == -1 {
-		index = defaultValue
-	}
-	return index
-}
-
-func ExtensionByType(mimeType string, defaultExt string) string {
-	ext := defaultExt
-	exts, extErr := mime.ExtensionsByType(mimeType)
-	if extErr == nil && len(exts) > 0 {
-		// prefer common extensions over less common (.jpe, etc) returned by mime library
-		preferredExts := []string{".jpg", ".jpeg"}
-		sort.Slice(exts, func(i, j int) bool {
-			return SliceIndex(preferredExts, exts[i], math.MaxInt32) < SliceIndex(preferredExts, exts[j], math.MaxInt32)
-		})
-		ext = exts[0]
-	}
-
-	return ext
 }
 
 const (
@@ -1841,14 +1816,6 @@ func reactionEventFromMessage(info types.MessageInfo, msg *waE2E.Message) (react
 		return reactionEvent{}, false
 	}
 	return reactionEvent{chat: info.Chat.String(), targetMessageID: reaction.GetKey().GetID(), participant: info.Sender.String(), text: reaction.GetText(), isFromMe: info.IsFromMe}, true
-}
-
-//export C_DownloadFile
-func C_DownloadFile(fileId *C.char, basePath *C.char) C.uint8_t {
-	goFileId := C.GoString(fileId)
-	goBasePath := C.GoString(basePath)
-	status := DownloadFromFileId(client, goFileId, goBasePath)
-	return C.uint8_t(status)
 }
 
 func AddEventHandlers() {

--- a/whatsrust/lib/media_downloads.go
+++ b/whatsrust/lib/media_downloads.go
@@ -1,0 +1,45 @@
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+
+import (
+	"math"
+	"mime"
+	"sort"
+)
+
+func SliceIndex(list []string, value string, defaultValue int) int {
+	for index, item := range list {
+		if item == value {
+			return index
+		}
+	}
+	return defaultValue
+}
+
+// ExtensionByType chooses a stable, useful extension for a MIME type when
+// constructing the relative media path exposed through the C ABI.
+func ExtensionByType(mimeType string, defaultExt string) string {
+	ext := defaultExt
+	exts, extErr := mime.ExtensionsByType(mimeType)
+	if extErr == nil && len(exts) > 0 {
+		// Prefer common extensions over less common (.jpe, etc) returned by mime.
+		preferredExts := []string{".jpg", ".jpeg"}
+		sort.Slice(exts, func(i, j int) bool {
+			return SliceIndex(preferredExts, exts[i], math.MaxInt32) < SliceIndex(preferredExts, exts[j], math.MaxInt32)
+		})
+		ext = exts[0]
+	}
+	return ext
+}
+
+//export C_DownloadFile
+func C_DownloadFile(fileId *C.char, basePath *C.char) C.uint8_t {
+	goFileId := C.GoString(fileId)
+	goBasePath := C.GoString(basePath)
+	status := DownloadFromFileId(client, goFileId, goBasePath)
+	return C.uint8_t(status)
+}

--- a/whatsrust/lib/media_downloads_test.go
+++ b/whatsrust/lib/media_downloads_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMediaDownloadExportsAndPathHelpersStayOutOfMain(t *testing.T) {
+	mediaSource, err := os.ReadFile("media_downloads.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fragment := range []string{"func C_DownloadFile", "func SliceIndex", "func ExtensionByType"} {
+		if !strings.Contains(string(mediaSource), fragment) {
+			t.Fatalf("media download module must contain %q", fragment)
+		}
+		if strings.Contains(string(mainSource), fragment) {
+			t.Fatalf("main.go must not contain %q", fragment)
+		}
+	}
+	for _, fragment := range []string{"func DownloadFromFileId", "func safeDownloadTarget", "func writeDownload"} {
+		if strings.Contains(string(mainSource), fragment) {
+			t.Fatalf("main.go must not contain %q", fragment)
+		}
+	}
+}
+
+func TestExtensionByTypeUsesDefaultsAndStableCommonExtensions(t *testing.T) {
+	for _, testCase := range []struct {
+		name, mimeType, defaultExt, want string
+	}{
+		{name: "unknown MIME uses default", mimeType: "application/x-unknown", defaultExt: ".bin", want: ".bin"},
+		{name: "JPEG prefers jpg", mimeType: "image/jpeg", defaultExt: ".bin", want: ".jpg"},
+		{name: "PNG preserves MIME extension", mimeType: "image/png", defaultExt: ".bin", want: ".png"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := ExtensionByType(testCase.mimeType, testCase.defaultExt); got != testCase.want {
+				t.Fatalf("extension = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extract media download export, file-type extension, and slice helpers from the Go bridge.
- Preserve `C_DownloadFile` status and ownership semantics unchanged.
- Keep message send/conversion and profile pictures separate.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No target directory created

Seventeenth responsibility in the Go bridge modularization chain.

Depends on #83.