### PR TITLE
refactor(app): extract logout lifecycle

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -20,6 +20,7 @@ pub mod download_worker;
 pub mod events;
 pub mod input_reader;
 pub mod inputs;
+pub mod logout;
 pub mod media_cache;
 pub mod media_support;
 pub mod message_action_diagnostics;
@@ -712,110 +713,5 @@ mod tests {
                 .iter()
                 .any(|jid| jid.0.as_ref() == STATUS_BROADCAST_CHAT)
         );
-    }
-
-    #[test]
-    fn section_rail_navigates_through_sections_into_logout_and_back() {
-        use crate::app::FocusPane;
-        use crate::app::actions::{AppAction, Section};
-
-        let mut app = TestApp::new();
-        app.focus_pane = FocusPane::SectionRail;
-        app.selected_section = Section::Chats;
-        app.rail_on_logout = false;
-
-        // j: Chats -> Status -> Communities -> Logout (flag set) -> wraps to Chats.
-        app.dispatch_action(AppAction::SelectNext);
-        assert_eq!(app.selected_section, Section::Status);
-        assert!(!app.rail_on_logout);
-        app.dispatch_action(AppAction::SelectNext);
-        assert_eq!(app.selected_section, Section::Communities);
-        assert!(!app.rail_on_logout);
-        app.dispatch_action(AppAction::SelectNext);
-        assert!(app.rail_on_logout);
-        app.dispatch_action(AppAction::SelectNext);
-        assert_eq!(app.selected_section, Section::Chats);
-        assert!(!app.rail_on_logout);
-
-        // k: Chats wraps backward up to Logout.
-        app.dispatch_action(AppAction::SelectPrevious);
-        assert!(app.rail_on_logout);
-        app.dispatch_action(AppAction::SelectPrevious);
-        assert_eq!(app.selected_section, Section::Communities);
-        assert!(!app.rail_on_logout);
-
-        // G (jump_bottom) lands on Logout; gg (jump_top) returns to Chats.
-        app.dispatch_action(AppAction::JumpBottom);
-        assert!(app.rail_on_logout);
-        app.dispatch_action(AppAction::JumpTop);
-        assert_eq!(app.selected_section, Section::Chats);
-        assert!(!app.rail_on_logout);
-    }
-
-    #[test]
-    fn pressing_enter_on_the_rail_logout_slot_begins_confirmation() {
-        use crate::app::FocusPane;
-        use crate::app::actions::{AppAction, Section};
-        use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-
-        let mut app = TestApp::new();
-        app.focus_pane = FocusPane::SectionRail;
-        app.selected_section = Section::Chats;
-        app.rail_on_logout = false;
-
-        // Enter on a normal section does not start logout confirmation.
-        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        app.on_terminal_event(Event::Key(enter));
-        assert!(!app.pending_logout);
-
-        // Move the rail to the Logout slot and press Enter: confirmation starts.
-        app.dispatch_action(AppAction::JumpBottom);
-        assert!(app.rail_on_logout);
-        app.on_terminal_event(Event::Key(KeyEvent::new(
-            KeyCode::Enter,
-            KeyModifiers::NONE,
-        )));
-        assert!(app.pending_logout);
-        assert_eq!(app.focus_pane, FocusPane::SectionRail);
-        assert_eq!(app.selected_section, Section::Communities);
-    }
-
-    #[test]
-    fn logout_confirmation_menu_navigates_and_cancels() {
-        use crate::app::FocusPane;
-        use crate::app::actions::AppAction;
-        use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-
-        let mut app = TestApp::new();
-        app.focus_pane = FocusPane::SectionRail;
-        app.selected_section = crate::app::actions::Section::Chats;
-        app.dispatch_action(AppAction::JumpBottom);
-        assert!(app.rail_on_logout);
-
-        // Enter on the rail Logout slot opens the confirmation menu.
-        app.on_terminal_event(Event::Key(KeyEvent::new(
-            KeyCode::Enter,
-            KeyModifiers::NONE,
-        )));
-        assert!(app.pending_logout);
-        assert_eq!(app.logout_menu_index, 0);
-
-        // j / k move the selection between Confirm and Cancel (2 items).
-        app.on_terminal_event(Event::Key(KeyEvent::new(
-            KeyCode::Char('j'),
-            KeyModifiers::NONE,
-        )));
-        assert_eq!(app.logout_menu_index, 1);
-        app.on_terminal_event(Event::Key(KeyEvent::new(
-            KeyCode::Char('k'),
-            KeyModifiers::NONE,
-        )));
-        assert_eq!(app.logout_menu_index, 0);
-
-        // Esc cancels without starting logout (no bridge call).
-        app.on_terminal_event(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
-        assert!(!app.pending_logout);
-        assert!(!app.logout_in_progress);
-        assert_eq!(app.logout_menu_index, 0);
     }
 }

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -29,7 +29,7 @@ impl App<'_> {
                     // further input until Event::LogoutResult resolves.
                     return;
                 }
-                self.resolve_logout_confirmation(key);
+                self.handle_logout_input(key);
                 return;
             }
 
@@ -380,69 +380,6 @@ impl App<'_> {
         self.action_notice = Some(crate::app::actions::ActionNotice::Unavailable(
             action.into(),
         ));
-    }
-
-    fn begin_logout_confirmation(&mut self) {
-        self.pending_logout = true;
-        self.logout_menu_index = 0;
-    }
-
-    /// Resolve the logout confirmation as a top-right menu, matching the
-    /// message-menu interaction: j/k (or Up/Down) move the selection, Enter
-    /// confirms it, Esc/n cancel. y is kept as a fast "confirm" and N as a
-    /// fast "cancel".
-    fn resolve_logout_confirmation(&mut self, key: Key) {
-        match key.code {
-            KeyCode::Char('y') | KeyCode::Char('Y') => {
-                self.pending_logout = false;
-                self.confirm_logout();
-            }
-            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-                self.pending_logout = false;
-                self.logout_menu_index = 0;
-                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
-            }
-            KeyCode::Enter => {
-                if self.logout_menu_index == 0 {
-                    self.pending_logout = false;
-                    self.confirm_logout();
-                } else {
-                    self.pending_logout = false;
-                    self.logout_menu_index = 0;
-                    self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
-                }
-            }
-            KeyCode::Char('j') | KeyCode::Down => {
-                self.logout_menu_index = (self.logout_menu_index + 1) % 2;
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.logout_menu_index = (self.logout_menu_index + 1) % 2;
-            }
-            _ => {}
-        }
-    }
-
-    fn confirm_logout(&mut self) {
-        // The bridge runs the remove-companion-device IQ asynchronously so
-        // the event loop stays responsive. Keep intercepting input and let
-        // Event::LogoutResult drive the local cleanup / quit / error path.
-        self.pending_logout = true;
-        self.logout_in_progress = true;
-        wr::logout();
-    }
-
-    pub fn finish_logout(&mut self) {
-        self.pending_logout = false;
-        self.logout_in_progress = false;
-        self.logout_menu_index = 0;
-        // Stop the history writer so the sqlite files are released, then wipe
-        // BOTH databases plus media: a logout is a full account sign-out, and
-        // pairing a different account must never see the previous one's data.
-        self.db_handler.stop();
-        wipe_sqlite_file(&self.whatsmeow_db);
-        wipe_sqlite_file(&self.whatsmeow_db.with_file_name("whatsapp.db"));
-        clear_media_dir(&self.media_path);
-        self.should_quit = true;
     }
 
     fn selected_message_is_deleted(&self) -> bool {
@@ -1162,12 +1099,7 @@ impl App<'_> {
     fn select_next(&mut self) {
         match self.focus_pane {
             FocusPane::SectionRail => {
-                if self.rail_on_logout {
-                    self.rail_on_logout = false;
-                    self.selected_section = Section::Chats;
-                } else if self.selected_section == Section::Communities {
-                    self.rail_on_logout = true;
-                } else {
+                if !self.move_logout_selection_next() {
                     self.selected_section = self.selected_section.next();
                 }
             }
@@ -1199,12 +1131,7 @@ impl App<'_> {
     fn select_previous(&mut self) {
         match self.focus_pane {
             FocusPane::SectionRail => {
-                if self.rail_on_logout {
-                    self.rail_on_logout = false;
-                    self.selected_section = Section::Communities;
-                } else if self.selected_section == Section::Chats {
-                    self.rail_on_logout = true;
-                } else {
+                if !self.move_logout_selection_previous() {
                     self.selected_section = self.selected_section.previous();
                 }
             }
@@ -1236,8 +1163,7 @@ impl App<'_> {
     fn jump_top(&mut self) {
         match self.focus_pane {
             FocusPane::SectionRail => {
-                self.selected_section = crate::app::actions::Section::Chats;
-                self.rail_on_logout = false;
+                self.jump_logout_selection_top();
             }
             FocusPane::ChatList => {
                 if self.selected_section == Section::Status {
@@ -1264,8 +1190,7 @@ impl App<'_> {
     fn jump_bottom(&mut self) {
         match self.focus_pane {
             FocusPane::SectionRail => {
-                self.selected_section = crate::app::actions::Section::Communities;
-                self.rail_on_logout = true;
+                self.jump_logout_selection_bottom();
             }
             FocusPane::ChatList => {
                 if self.selected_section == Section::Status {
@@ -1539,41 +1464,6 @@ fn message_urls(message: &wr::Message) -> Vec<String> {
     };
     text.map(crate::url::extract_openable_urls)
         .unwrap_or_default()
-}
-
-/// Remove a sqlite database together with its `-wal` and `-shm` sidecars.
-/// Used during logout to guarantee a full account sign-out.
-fn wipe_sqlite_file(path: &Path) {
-    for suffix in [
-        std::ffi::OsStr::new(""),
-        std::ffi::OsStr::new("-wal"),
-        std::ffi::OsStr::new("-shm"),
-    ] {
-        let mut os = path.as_os_str().to_os_string();
-        os.push(suffix);
-        let file = std::path::PathBuf::from(&os);
-        match std::fs::remove_file(&file) {
-            Ok(()) => {}
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => log::warn!("Failed to remove {}: {err}", file.display()),
-        }
-    }
-}
-
-/// Remove every entry under the media cache directory. A missing directory is
-/// fine; a nested directory tree is removed recursively.
-fn clear_media_dir(media_path: &Path) {
-    let Ok(entries) = std::fs::read_dir(media_path) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            let _ = std::fs::remove_dir_all(&path);
-        } else {
-            let _ = std::fs::remove_file(&path);
-        }
-    }
 }
 
 pub fn composer_action_for_editing_key(key: &Key) -> ComposerAction {

--- a/src/app/logout.rs
+++ b/src/app/logout.rs
@@ -1,0 +1,150 @@
+use ratatui::crossterm::event::KeyCode;
+
+use crate::app::App;
+use crate::app::actions::{ActionNotice, Section};
+use crate::key_handler::Key;
+use whatsrust as wr;
+
+impl App<'_> {
+    pub(crate) fn handle_logout_input(&mut self, key: Key) {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                self.pending_logout = false;
+                self.confirm_logout();
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                self.pending_logout = false;
+                self.logout_menu_index = 0;
+                self.action_notice = Some(ActionNotice::Cancelled);
+            }
+            KeyCode::Enter => {
+                if self.logout_menu_index == 0 {
+                    self.pending_logout = false;
+                    self.confirm_logout();
+                } else {
+                    self.pending_logout = false;
+                    self.logout_menu_index = 0;
+                    self.action_notice = Some(ActionNotice::Cancelled);
+                }
+            }
+            KeyCode::Char('j') | KeyCode::Char('k') | KeyCode::Down | KeyCode::Up => {
+                self.logout_menu_index = (self.logout_menu_index + 1) % 2;
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn begin_logout_confirmation(&mut self) {
+        self.pending_logout = true;
+        self.logout_menu_index = 0;
+    }
+
+    fn confirm_logout(&mut self) {
+        self.pending_logout = true;
+        self.logout_in_progress = true;
+        wr::logout();
+    }
+
+    pub(crate) fn handle_logout_result(&mut self, status: wr::LogoutStatus) -> bool {
+        match status {
+            wr::LogoutStatus::LoggedOut | wr::LogoutStatus::NotLoggedIn => {
+                self.finish_logout();
+            }
+            wr::LogoutStatus::LocalOnly => {
+                log::warn!(
+                    "Logout: device was not unlinked on the phone; remove it manually in WhatsApp → Linked devices"
+                );
+                self.reset_logout_prompt();
+                self.unavailable(
+                    "Logged out locally, but the device is still linked on the phone — remove it in WhatsApp (Settings → Linked devices), then log out again to finish",
+                );
+            }
+            wr::LogoutStatus::Failed => {
+                self.reset_logout_prompt();
+                self.unavailable("Could not log out");
+            }
+        }
+        true
+    }
+
+    pub(crate) fn finish_logout(&mut self) {
+        self.reset_logout_prompt();
+        self.db_handler.stop();
+        wipe_sqlite_file(&self.whatsmeow_db);
+        wipe_sqlite_file(&self.whatsmeow_db.with_file_name("whatsapp.db"));
+        clear_media_dir(&self.media_path);
+        self.should_quit = true;
+    }
+
+    fn reset_logout_prompt(&mut self) {
+        self.pending_logout = false;
+        self.logout_in_progress = false;
+        self.logout_menu_index = 0;
+    }
+
+    pub(crate) fn move_logout_selection_next(&mut self) -> bool {
+        if self.rail_on_logout {
+            self.rail_on_logout = false;
+            self.selected_section = Section::Chats;
+            true
+        } else if self.selected_section == Section::Communities {
+            self.rail_on_logout = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn move_logout_selection_previous(&mut self) -> bool {
+        if self.rail_on_logout {
+            self.rail_on_logout = false;
+            self.selected_section = Section::Communities;
+            true
+        } else if self.selected_section == Section::Chats {
+            self.rail_on_logout = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn jump_logout_selection_top(&mut self) {
+        self.selected_section = Section::Chats;
+        self.rail_on_logout = false;
+    }
+
+    pub(crate) fn jump_logout_selection_bottom(&mut self) {
+        self.selected_section = Section::Communities;
+        self.rail_on_logout = true;
+    }
+}
+
+fn wipe_sqlite_file(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut os = path.as_os_str().to_os_string();
+        os.push(suffix);
+        let file = std::path::PathBuf::from(os);
+        match std::fs::remove_file(&file) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => log::warn!("Failed to remove {}: {err}", file.display()),
+        }
+    }
+}
+
+fn clear_media_dir(media_path: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(media_path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let _ = std::fs::remove_dir_all(path);
+        } else {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/logout/tests.rs
+++ b/src/app/logout/tests.rs
@@ -1,0 +1,98 @@
+use crate::app::actions::{AppAction, FocusPane, Section};
+use crate::app::test_support::TestApp;
+use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+#[test]
+fn rail_logout_navigation_and_confirmation_preserve_focus_and_section() {
+    let mut app = TestApp::new();
+    app.focus_pane = FocusPane::SectionRail;
+    app.selected_section = Section::Chats;
+
+    app.dispatch_action(AppAction::JumpBottom);
+    assert!(app.rail_on_logout);
+    assert_eq!(app.selected_section, Section::Communities);
+    app.on_terminal_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )));
+    assert!(app.pending_logout);
+    assert_eq!(app.logout_menu_index, 0);
+    assert_eq!(app.focus_pane, FocusPane::SectionRail);
+
+    app.on_terminal_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE,
+    )));
+    assert_eq!(app.logout_menu_index, 1);
+    app.on_terminal_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('k'),
+        KeyModifiers::NONE,
+    )));
+    assert_eq!(app.logout_menu_index, 0);
+    app.on_terminal_event(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
+    assert!(!app.pending_logout);
+    assert!(!app.logout_in_progress);
+    assert_eq!(
+        app.action_notice,
+        Some(crate::app::actions::ActionNotice::Cancelled)
+    );
+}
+
+#[test]
+fn logout_statuses_keep_local_only_and_failed_sessions_retryable() {
+    let mut app = TestApp::new();
+    app.pending_logout = true;
+    app.logout_in_progress = true;
+    assert!(app.handle_whatsapp_event(whatsrust::Event::LogoutResult(
+        whatsrust::LogoutStatus::LocalOnly,
+    )));
+    assert!(!app.pending_logout);
+    assert!(!app.logout_in_progress);
+    assert!(matches!(
+        app.action_notice,
+        Some(crate::app::actions::ActionNotice::Unavailable(_))
+    ));
+    app.focus_pane = FocusPane::SectionRail;
+    app.rail_on_logout = true;
+    app.on_terminal_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )));
+    assert!(app.pending_logout);
+
+    app.pending_logout = true;
+    app.logout_in_progress = true;
+    assert!(app.handle_whatsapp_event(whatsrust::Event::LogoutResult(
+        whatsrust::LogoutStatus::Failed,
+    )));
+    assert!(!app.pending_logout);
+    assert!(!app.logout_in_progress);
+    assert_eq!(app.logout_menu_index, 0);
+}
+
+#[test]
+fn not_logged_in_is_a_successful_terminal_result() {
+    let mut app = TestApp::new();
+    app.handle_whatsapp_event(whatsrust::Event::LogoutResult(
+        whatsrust::LogoutStatus::NotLoggedIn,
+    ));
+    assert!(app.should_quit);
+}
+
+#[test]
+fn successful_logout_cleans_both_databases_and_media() {
+    let mut app = TestApp::new();
+    std::fs::write(&app.whatsmeow_db, b"db").unwrap();
+    std::fs::write(app.whatsmeow_db.with_file_name("whatsapp.db"), b"db").unwrap();
+    std::fs::create_dir_all(&app.media_path).unwrap();
+    std::fs::write(app.media_path.join("attachment"), b"media").unwrap();
+
+    app.handle_whatsapp_event(whatsrust::Event::LogoutResult(
+        whatsrust::LogoutStatus::LoggedOut,
+    ));
+
+    assert!(app.should_quit);
+    assert!(!app.whatsmeow_db.exists());
+    assert!(!app.whatsmeow_db.with_file_name("whatsapp.db").exists());
+    assert!(std::fs::read_dir(&app.media_path).unwrap().next().is_none());
+}

--- a/src/app/whatsapp_events.rs
+++ b/src/app/whatsapp_events.rs
@@ -30,37 +30,7 @@ pub(crate) fn handle(app: &mut App<'_>, event: wr::Event) -> bool {
             app.sort_chats();
             true
         }
-        wr::Event::LogoutResult(status) => match status {
-            wr::LogoutStatus::LoggedOut | wr::LogoutStatus::NotLoggedIn => {
-                app.finish_logout();
-                true
-            }
-            wr::LogoutStatus::LocalOnly => {
-                // Remote revocation failed, so WhatsApp on the phone still
-                // lists this device. The local session is already gone;
-                // surface it instead of silently quitting, and let the
-                // user retry (a second logout resolves as NotLoggedIn and
-                // finishes) or remove the device manually.
-                log::warn!(
-                    "Logout: device was not unlinked on the phone; remove it manually in WhatsApp → Linked devices"
-                );
-                app.pending_logout = false;
-                app.logout_in_progress = false;
-                app.logout_menu_index = 0;
-                app.unavailable(
-                    "Logged out locally, but the device is still linked on the phone — remove it in WhatsApp (Settings → Linked devices), then log out again to finish",
-                );
-                true
-            }
-            wr::LogoutStatus::Failed => {
-                // Even the local cleanup failed. Surface it and keep running.
-                app.pending_logout = false;
-                app.logout_in_progress = false;
-                app.logout_menu_index = 0;
-                app.unavailable("Could not log out");
-                true
-            }
-        },
+        wr::Event::LogoutResult(status) => app.handle_logout_result(status),
         wr::Event::SyncProgress(percent) => {
             app.history_sync_percent = Some(percent);
             true


### PR DESCRIPTION
## Summary

- Extract logout confirmation, result handling, cleanup, and notices into one responsibility.
- Reduce input and WhatsApp event routers to thin delegates.
- Colocate logout lifecycle tests with the module.

## Testing

- [x] Logout tests (4 passed)
- [x] Keybinding tests (21 passed)
- [x] `cargo check --all-targets`
- [x] Formatting and diff checks
- [x] Exact shared Cargo target; no local target

Twenty-fifth responsibility in the App modularization chain.

Depends on #84.