### PR TITLE
refactor(app): extract chat navigation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use std::{
 
 pub mod actions;
 pub mod bootstrap;
+pub mod chat_navigation;
 pub mod chat_opening;
 pub mod chat_ordering;
 pub mod chat_projection;
@@ -304,36 +305,6 @@ impl App<'_> {
     /// pane (set by pressing Enter on a contact), mirroring `open_chat`.
     pub fn open_status_contact(&self) -> Option<wr::JID> {
         self.open_status_contact.clone()
-    }
-
-    pub fn select_chat(&mut self, jid: Option<wr::JID>) {
-        let target_list = self.visible_chat_rows();
-
-        if let Some(jid) = jid
-            && let Some(index) = target_list
-                .iter()
-                .position(|row| row.target == jid || row.members.contains(&jid))
-        {
-            self.chat_list_state.select(Some(index));
-        } else if !target_list.is_empty() {
-            self.chat_list_state.select(Some(0));
-        } else {
-            self.chat_list_state.select(None);
-        }
-    }
-
-    fn update_filtered_chats(&mut self) {
-        self.filtered_chats = self
-            .visible_chat_rows()
-            .into_iter()
-            .map(|row| row.target)
-            .collect();
-
-        if !self.filtered_chats.is_empty() {
-            self.chat_list_state.select(Some(0));
-        } else {
-            self.chat_list_state.select(None);
-        }
     }
 }
 

--- a/src/app/chat_navigation.rs
+++ b/src/app/chat_navigation.rs
@@ -1,0 +1,152 @@
+use ratatui::crossterm::event::KeyCode;
+
+use super::App;
+use super::actions::{AppAction, FocusPane, Section};
+use crate::key_handler::Key;
+use whatsrust as wr;
+
+impl App<'_> {
+    pub fn select_chat(&mut self, jid: Option<wr::JID>) {
+        let rows = self.visible_chat_rows();
+        if let Some(jid) = jid
+            && let Some(index) = rows
+                .iter()
+                .position(|row| row.target == jid || row.members.contains(&jid))
+        {
+            self.chat_list_state.select(Some(index));
+        } else if rows.is_empty() {
+            self.chat_list_state.select(None);
+        } else {
+            self.chat_list_state.select(Some(0));
+        }
+    }
+
+    pub(crate) fn update_filtered_chats(&mut self) {
+        self.filtered_chats = self
+            .visible_chat_rows()
+            .into_iter()
+            .map(|row| row.target)
+            .collect();
+        self.chat_list_state
+            .select((!self.filtered_chats.is_empty()).then_some(0));
+    }
+
+    pub(crate) fn handle_chat_search_key(&mut self, key: Key) {
+        match key.code {
+            KeyCode::Esc => {
+                let chat = self.get_selected_chat();
+                self.contact_search_active = false;
+                self.contact_search.clean();
+                self.select_chat(chat);
+            }
+            KeyCode::Enter => {
+                self.contact_search_active = false;
+                self.dispatch_action(AppAction::OpenChat);
+            }
+            KeyCode::Char(character) => {
+                self.contact_search.enter_char(character);
+                self.update_filtered_chats();
+            }
+            KeyCode::Backspace => {
+                self.contact_search.delete_char();
+                self.update_filtered_chats();
+            }
+            KeyCode::Left => self.contact_search.move_cursor_left(),
+            KeyCode::Right => self.contact_search.move_cursor_right(),
+            _ => {}
+        }
+    }
+
+    pub(crate) fn move_selection_next(&mut self) {
+        if self.focus_pane == FocusPane::ChatList {
+            self.move_chat_selection(1);
+        }
+    }
+
+    pub(crate) fn move_selection_previous(&mut self) {
+        if self.focus_pane == FocusPane::ChatList {
+            self.move_chat_selection(-1);
+        }
+    }
+
+    fn move_chat_selection(&mut self, delta: isize) {
+        match self.selected_section {
+            Section::Status => {
+                if delta > 0 {
+                    self.status_selection.select_next();
+                } else {
+                    self.status_selection.select_previous();
+                }
+                self.clamp_status_selection();
+            }
+            Section::Communities => {
+                if delta > 0 {
+                    self.chat_list_state.select_next();
+                } else {
+                    self.chat_list_state.select_previous();
+                }
+                self.clamp_community_selection();
+            }
+            Section::Chats => {
+                if delta > 0 {
+                    self.chat_list_state.select_next();
+                } else {
+                    self.chat_list_state.select_previous();
+                }
+                self.clamp_chat_selection();
+            }
+        }
+    }
+
+    pub(crate) fn jump_selection_top(&mut self) {
+        match self.focus_pane {
+            FocusPane::ChatList => match self.selected_section {
+                Section::Status => {
+                    self.status_selection.select_first();
+                    self.clamp_status_selection();
+                }
+                Section::Chats | Section::Communities => self.chat_list_state.select_first(),
+            },
+            FocusPane::Conversation | FocusPane::SectionRail => {}
+        }
+    }
+
+    pub(crate) fn jump_selection_bottom(&mut self) {
+        match self.focus_pane {
+            FocusPane::ChatList => match self.selected_section {
+                Section::Status => {
+                    self.status_selection.select_last();
+                    self.clamp_status_selection();
+                }
+                Section::Chats | Section::Communities => self.chat_list_state.select_last(),
+            },
+            FocusPane::Conversation | FocusPane::SectionRail => {}
+        }
+        self.clamp_chat_selection();
+    }
+
+    fn clamp_chat_selection(&mut self) {
+        let count = if self.contact_search.input.is_empty() {
+            self.visible_chat_rows().len()
+        } else {
+            self.filtered_chats.len()
+        };
+        clamp_list_state(&mut self.chat_list_state, count);
+    }
+
+    fn clamp_community_selection(&mut self) {
+        let count = self.selectable_community_nodes().len();
+        clamp_list_state(&mut self.chat_list_state, count);
+    }
+}
+
+fn clamp_list_state(state: &mut ratatui::widgets::ListState, count: usize) {
+    match (count, state.selected()) {
+        (0, _) => state.select(None),
+        (len, Some(selected)) if selected >= len => state.select(Some(len - 1)),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/chat_navigation/tests.rs
+++ b/src/app/chat_navigation/tests.rs
@@ -1,0 +1,101 @@
+use super::super::Chat;
+use crate::app::actions::FocusPane;
+use crate::app::test_support::TestApp;
+use crate::key_handler::Key;
+use ratatui::crossterm::event::KeyCode;
+use whatsrust as wr;
+
+fn jid(value: &str) -> wr::JID {
+    wr::JID::from(value.to_owned())
+}
+
+#[test]
+fn select_chat_reanchors_a_row_without_changing_open_chat_or_message_selection() {
+    let mut app = TestApp::new();
+    let first = jid("first@example.test");
+    let second = jid("second@example.test");
+    app.chats.insert(
+        first.clone(),
+        Chat {
+            jid: first.clone(),
+            last_message_time: Some(2),
+        },
+    );
+    app.chats.insert(
+        second.clone(),
+        Chat {
+            jid: second.clone(),
+            last_message_time: Some(1),
+        },
+    );
+    app.sorted_chats = vec![first, second.clone()];
+    app.open_chat = Some(jid("open@example.test"));
+    app.message_list_state.selected = Some(3);
+
+    app.select_chat(Some(second.clone()));
+
+    assert_eq!(app.get_selected_chat(), Some(second));
+    assert_eq!(app.open_chat(), Some(jid("open@example.test")));
+    assert_eq!(app.message_list_state.selected, Some(3));
+}
+
+#[test]
+fn chat_list_movement_keeps_open_conversation_and_message_selection() {
+    let mut app = TestApp::new();
+    let first = jid("first@example.test");
+    let second = jid("second@example.test");
+    app.chats.insert(
+        first.clone(),
+        Chat {
+            jid: first.clone(),
+            last_message_time: Some(2),
+        },
+    );
+    app.chats.insert(
+        second.clone(),
+        Chat {
+            jid: second.clone(),
+            last_message_time: Some(1),
+        },
+    );
+    app.sorted_chats = vec![first.clone(), second.clone()];
+    app.chat_list_state.select(Some(0));
+    app.open_chat = Some(first.clone());
+    app.message_list_state.selected = Some(2);
+    app.focus_pane = FocusPane::ChatList;
+
+    app.move_selection_next();
+
+    assert_eq!(app.get_selected_chat(), Some(second));
+    assert_eq!(app.open_chat(), Some(first));
+    assert_eq!(app.message_list_state.selected, Some(2));
+}
+
+#[test]
+fn leaving_search_restores_the_pre_search_chat_selection() {
+    let mut app = TestApp::new();
+    let first = jid("alice@example.test");
+    let second = jid("bob@example.test");
+    app.chats.insert(
+        first.clone(),
+        Chat {
+            jid: first.clone(),
+            last_message_time: Some(2),
+        },
+    );
+    app.chats.insert(
+        second.clone(),
+        Chat {
+            jid: second.clone(),
+            last_message_time: Some(1),
+        },
+    );
+    app.sorted_chats = vec![first, second.clone()];
+    app.chat_list_state.select(Some(1));
+    app.contact_search_active = true;
+
+    app.handle_chat_search_key(Key::k(KeyCode::Esc));
+
+    assert_eq!(app.get_selected_chat(), Some(second));
+    assert!(!app.contact_search_active);
+}

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -174,32 +174,6 @@ impl App<'_> {
         }
     }
 
-    fn handle_chat_search_key(&mut self, key: Key) {
-        match key.code {
-            KeyCode::Esc => {
-                let chat = self.get_selected_chat();
-                self.contact_search_active = false;
-                self.contact_search.clean();
-                self.select_chat(chat);
-            }
-            KeyCode::Enter => {
-                self.contact_search_active = false;
-                self.dispatch_action(AppAction::OpenChat);
-            }
-            KeyCode::Char(character) => {
-                self.contact_search.enter_char(character);
-                self.update_filtered_chats();
-            }
-            KeyCode::Backspace => {
-                self.contact_search.delete_char();
-                self.update_filtered_chats();
-            }
-            KeyCode::Left => self.contact_search.move_cursor_left(),
-            KeyCode::Right => self.contact_search.move_cursor_right(),
-            _ => {}
-        }
-    }
-
     pub fn dispatch_action(&mut self, action: AppAction) {
         self.focus_pane = focus_after(self.focus_pane, &action, self.pane_visibility);
 
@@ -1104,16 +1078,7 @@ impl App<'_> {
                 }
             }
             FocusPane::ChatList => {
-                if self.selected_section == Section::Status {
-                    self.status_selection.select_next();
-                    self.clamp_status_selection();
-                } else if self.selected_section == Section::Communities {
-                    self.chat_list_state.select_next();
-                    self.clamp_community_selection();
-                } else {
-                    self.chat_list_state.select_next();
-                    self.clamp_chat_selection();
-                }
+                self.move_selection_next();
             }
             // In Conversation, j moves UP (older) in the time-ascending list.
             FocusPane::Conversation => {
@@ -1136,16 +1101,7 @@ impl App<'_> {
                 }
             }
             FocusPane::ChatList => {
-                if self.selected_section == Section::Status {
-                    self.status_selection.select_previous();
-                    self.clamp_status_selection();
-                } else if self.selected_section == Section::Communities {
-                    self.chat_list_state.select_previous();
-                    self.clamp_community_selection();
-                } else {
-                    self.chat_list_state.select_previous();
-                    self.clamp_chat_selection();
-                }
+                self.move_selection_previous();
             }
             // In Conversation, k moves DOWN (newer) in the time-ascending list.
             FocusPane::Conversation => {
@@ -1166,12 +1122,7 @@ impl App<'_> {
                 self.jump_logout_selection_top();
             }
             FocusPane::ChatList => {
-                if self.selected_section == Section::Status {
-                    self.status_selection.select_first();
-                    self.clamp_status_selection();
-                } else {
-                    self.chat_list_state.select_first();
-                }
+                self.jump_selection_top();
             }
             // En Conversation el render invierte: items[0]=más nuevo (abajo).
             // gg va al principio del chat (más viejo arriba) = último índice.
@@ -1193,12 +1144,7 @@ impl App<'_> {
                 self.jump_logout_selection_bottom();
             }
             FocusPane::ChatList => {
-                if self.selected_section == Section::Status {
-                    self.status_selection.select_last();
-                    self.clamp_status_selection();
-                } else {
-                    self.chat_list_state.select_last();
-                }
+                self.jump_selection_bottom();
             }
             // En Conversation el render invierte: items[0]=más nuevo (abajo).
             // G va al final del chat (más nuevo abajo) = índice 0.
@@ -1212,7 +1158,6 @@ impl App<'_> {
                 }
             }
         }
-        self.clamp_chat_selection();
     }
 
     fn half_page_down(&mut self) {
@@ -1270,30 +1215,6 @@ impl App<'_> {
                     }
                 }
             },
-        }
-    }
-
-    fn clamp_chat_selection(&mut self) {
-        let chats = if self.contact_search.input.is_empty() {
-            &self.sorted_chats
-        } else {
-            &self.filtered_chats
-        };
-        match (chats.len(), self.chat_list_state.selected()) {
-            (0, _) => self.chat_list_state.select(None),
-            (len, Some(selected)) if selected >= len => self.chat_list_state.select(Some(len - 1)),
-            _ => {}
-        }
-    }
-
-    fn clamp_community_selection(&mut self) {
-        match (
-            self.selectable_community_nodes().len(),
-            self.chat_list_state.selected(),
-        ) {
-            (0, _) => self.chat_list_state.select(None),
-            (len, Some(selected)) if selected >= len => self.chat_list_state.select(Some(len - 1)),
-            _ => {}
         }
     }
 


### PR DESCRIPTION
## Summary

- Extract chat-list movement, selection, filtering, and bounds policy.
- Keep chat projection, ordering, and opening in their existing responsibilities.
- Reduce input routing to delegation and colocate navigation tests.

## Testing

- [x] Chat-navigation tests (3 passed)
- [x] Keybinding integration tests (21 passed)
- [x] `cargo check --all-targets`
- [x] Formatting and diff checks
- [x] Exact shared Cargo target; no local target

Twenty-sixth responsibility in the App modularization chain.

Depends on #86.