### PR TITLE
refactor(app): extract message navigation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,7 @@ pub mod media_support;
 pub mod message_action_diagnostics;
 pub mod message_actions;
 pub mod message_ingestion;
+pub mod message_navigation;
 pub mod notifications;
 pub mod presence;
 pub mod presence_bridge;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -1070,120 +1070,6 @@ impl App<'_> {
         }
     }
 
-    fn select_next(&mut self) {
-        match self.focus_pane {
-            FocusPane::SectionRail => {
-                if !self.move_logout_selection_next() {
-                    self.selected_section = self.selected_section.next();
-                }
-            }
-            FocusPane::ChatList => {
-                self.move_selection_next();
-            }
-            // In Conversation, j moves UP (older) in the time-ascending list.
-            FocusPane::Conversation => {
-                if self.selected_section == Section::Status {
-                    self.message_list_state
-                        .select_previous_bounded(self.status_message_count());
-                } else {
-                    self.message_list_state
-                        .select_previous_bounded(self.message_count());
-                }
-            }
-        }
-    }
-
-    fn select_previous(&mut self) {
-        match self.focus_pane {
-            FocusPane::SectionRail => {
-                if !self.move_logout_selection_previous() {
-                    self.selected_section = self.selected_section.previous();
-                }
-            }
-            FocusPane::ChatList => {
-                self.move_selection_previous();
-            }
-            // In Conversation, k moves DOWN (newer) in the time-ascending list.
-            FocusPane::Conversation => {
-                if self.selected_section == Section::Status {
-                    self.message_list_state
-                        .select_next_bounded(self.status_message_count());
-                } else {
-                    self.message_list_state
-                        .select_next_bounded(self.message_count());
-                }
-            }
-        }
-    }
-
-    fn jump_top(&mut self) {
-        match self.focus_pane {
-            FocusPane::SectionRail => {
-                self.jump_logout_selection_top();
-            }
-            FocusPane::ChatList => {
-                self.jump_selection_top();
-            }
-            // En Conversation el render invierte: items[0]=más nuevo (abajo).
-            // gg va al principio del chat (más viejo arriba) = último índice.
-            FocusPane::Conversation => {
-                if self.selected_section == Section::Status {
-                    self.message_list_state
-                        .jump_bottom_bounded(self.status_message_count());
-                } else {
-                    self.message_list_state
-                        .jump_bottom_bounded(self.message_count());
-                }
-            }
-        }
-    }
-
-    fn jump_bottom(&mut self) {
-        match self.focus_pane {
-            FocusPane::SectionRail => {
-                self.jump_logout_selection_bottom();
-            }
-            FocusPane::ChatList => {
-                self.jump_selection_bottom();
-            }
-            // En Conversation el render invierte: items[0]=más nuevo (abajo).
-            // G va al final del chat (más nuevo abajo) = índice 0.
-            FocusPane::Conversation => {
-                if self.selected_section == Section::Status {
-                    self.message_list_state
-                        .jump_top_bounded(self.status_message_count());
-                } else {
-                    self.message_list_state
-                        .jump_top_bounded(self.message_count());
-                }
-            }
-        }
-    }
-
-    fn half_page_down(&mut self) {
-        if self.focus_pane == FocusPane::Conversation {
-            if self.selected_section == Section::Status {
-                self.message_list_state
-                    .half_page_down_bounded(self.status_message_count(), 10);
-            } else {
-                self.message_list_state
-                    .half_page_down_bounded(self.message_count(), 10);
-            }
-        }
-    }
-
-    fn half_page_up(&mut self) {
-        if self.focus_pane == FocusPane::Conversation {
-            if self.selected_section == Section::Status {
-                self.message_list_state
-                    .half_page_up_bounded(self.status_message_count(), 10);
-            } else {
-                self.message_list_state
-                    .half_page_up_bounded(self.message_count(), 10);
-            }
-        }
-    }
-
     fn dispatch_composer_action(&mut self, action: ComposerAction) {
         if self.composer_blocked() {
             return;
@@ -1216,18 +1102,6 @@ impl App<'_> {
                 }
             },
         }
-    }
-
-    fn message_count(&self) -> usize {
-        self.open_chat()
-            .and_then(|chat| self.chat_messages.get(&chat))
-            .map_or(0, Vec::len)
-    }
-
-    fn status_message_count(&self) -> usize {
-        self.open_status_contact()
-            .map(|contact| self.status_messages(&contact).len())
-            .unwrap_or(0)
     }
 }
 

--- a/src/app/message_navigation.rs
+++ b/src/app/message_navigation.rs
@@ -1,0 +1,99 @@
+use super::App;
+use super::actions::{FocusPane, Section};
+
+impl App<'_> {
+    pub(crate) fn select_next(&mut self) {
+        match self.focus_pane {
+            FocusPane::SectionRail => {
+                if !self.move_logout_selection_next() {
+                    self.selected_section = self.selected_section.next();
+                }
+            }
+            FocusPane::ChatList => self.move_selection_next(),
+            FocusPane::Conversation => self.move_message_selection(-1),
+        }
+    }
+
+    pub(crate) fn select_previous(&mut self) {
+        match self.focus_pane {
+            FocusPane::SectionRail => {
+                if !self.move_logout_selection_previous() {
+                    self.selected_section = self.selected_section.previous();
+                }
+            }
+            FocusPane::ChatList => self.move_selection_previous(),
+            FocusPane::Conversation => self.move_message_selection(1),
+        }
+    }
+
+    pub(crate) fn jump_top(&mut self) {
+        match self.focus_pane {
+            FocusPane::SectionRail => self.jump_logout_selection_top(),
+            FocusPane::ChatList => self.jump_selection_top(),
+            FocusPane::Conversation => self.jump_message_selection(false),
+        }
+    }
+
+    pub(crate) fn jump_bottom(&mut self) {
+        match self.focus_pane {
+            FocusPane::SectionRail => self.jump_logout_selection_bottom(),
+            FocusPane::ChatList => self.jump_selection_bottom(),
+            FocusPane::Conversation => self.jump_message_selection(true),
+        }
+    }
+
+    pub(crate) fn half_page_down(&mut self) {
+        if self.focus_pane == FocusPane::Conversation {
+            self.message_list_state
+                .half_page_down_bounded(self.message_count_for_navigation(), 10);
+        }
+    }
+
+    pub(crate) fn half_page_up(&mut self) {
+        if self.focus_pane == FocusPane::Conversation {
+            self.message_list_state
+                .half_page_up_bounded(self.message_count_for_navigation(), 10);
+        }
+    }
+
+    fn move_message_selection(&mut self, delta: isize) {
+        let count = self.message_count_for_navigation();
+        if delta < 0 {
+            self.message_list_state.select_previous_bounded(count);
+        } else {
+            self.message_list_state.select_next_bounded(count);
+        }
+    }
+
+    fn jump_message_selection(&mut self, bottom: bool) {
+        let count = self.message_count_for_navigation();
+        if bottom {
+            self.message_list_state.jump_top_bounded(count);
+        } else {
+            self.message_list_state.jump_bottom_bounded(count);
+        }
+    }
+
+    fn message_count_for_navigation(&self) -> usize {
+        if self.selected_section == Section::Status {
+            self.status_message_count()
+        } else {
+            self.message_count()
+        }
+    }
+
+    pub(crate) fn message_count(&self) -> usize {
+        self.open_chat()
+            .and_then(|chat| self.chat_messages.get(&chat))
+            .map_or(0, Vec::len)
+    }
+
+    pub(crate) fn status_message_count(&self) -> usize {
+        self.open_status_contact()
+            .map(|contact| self.status_messages(&contact).len())
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/message_navigation/tests.rs
+++ b/src/app/message_navigation/tests.rs
@@ -1,0 +1,60 @@
+use super::super::actions::{ConversationMode, FocusPane, Section};
+use super::super::test_support::TestApp;
+use whatsrust as wr;
+
+fn app_with_messages() -> TestApp {
+    let mut app = TestApp::new();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+    app.open_chat = Some(chat.clone());
+    app.chat_messages.insert(
+        chat,
+        vec!["newest".into(), "middle".into(), "oldest".into()],
+    );
+    app.focus_pane = FocusPane::Conversation;
+    app.selected_section = Section::Chats;
+    app.conversation_mode = ConversationMode::MessageNavigation;
+    app
+}
+
+#[test]
+fn message_navigation_is_bounded_and_requests_visible_selection_update() {
+    let mut app = app_with_messages();
+
+    app.select_previous();
+    assert_eq!(app.message_list_state.selected, Some(0));
+    assert!(app.message_list_state.update_selected);
+
+    app.message_list_state.update_selected = false;
+    app.jump_top();
+    assert_eq!(app.message_list_state.selected, Some(2));
+    assert!(app.message_list_state.update_selected);
+
+    app.jump_bottom();
+    assert_eq!(app.message_list_state.selected, Some(0));
+}
+
+#[test]
+fn empty_message_navigation_clears_selection_and_offset() {
+    let mut app = app_with_messages();
+    app.chat_messages.values_mut().next().unwrap().clear();
+    app.message_list_state.selected = Some(2);
+    app.message_list_state.offset = 9;
+    app.message_list_state.set_selected_message("middle".into());
+
+    app.select_next();
+
+    assert_eq!(app.message_list_state.selected, None);
+    assert_eq!(app.message_list_state.offset, 0);
+    assert_eq!(app.message_list_state.get_selected_message(), None);
+}
+
+#[test]
+fn navigation_outside_conversation_does_not_move_message_selection() {
+    let mut app = app_with_messages();
+    app.message_list_state.select(Some(1));
+    app.focus_pane = FocusPane::SectionRail;
+
+    app.select_next();
+
+    assert_eq!(app.message_list_state.selected, Some(1));
+}


### PR DESCRIPTION
## Summary

- Extract message-list selection, bounds, and navigation policy from input routing.
- Preserve selected-message anchoring, focus rules, empty states, and viewport update requests.
- Keep rendering/layout and message actions separate.

## Testing

- [x] Message-navigation tests (3 passed)
- [x] Keybinding integration tests (21 passed)
- [x] Message-action tests (19 passed)
- [x] `cargo check --all-targets`
- [x] Reverified using the exact shared Cargo target
- [x] Removed accidental 4.0G worktree-local target

Twenty-seventh responsibility in the App modularization chain.

Depends on #88.