### PR TITLE
refactor(bridge): extract receipt events

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -1784,34 +1784,9 @@ func AddEventHandlers() {
 			dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage)
 
 		case *events.Receipt:
-
-			receiptKind := -1
-			if evt.Type == types.ReceiptTypeRead || evt.Type == types.ReceiptTypeReadSelf {
-				receiptKind = 0
-			}
-
-			if receiptKind != -1 {
+			if receipt, ok := receiptEventFromEvent(evt); ok {
 				LOG_DEBUG("%#v was read by %s at %s", evt.MessageIDs, evt.SourceString(), evt.Timestamp)
-				n := len(evt.MessageIDs)
-				cmessageIds := (**C.char)(C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0)))))
-				messageIds := unsafe.Slice(cmessageIds, len(evt.MessageIDs))
-				for i, id := range evt.MessageIDs {
-					messageIds[i] = C.CString(id)
-				}
-
-				cchatId := jidToC(evt.MessageSource.Chat)
-
-				creceipt := (*C.ReceiptEvent)(C.malloc(C.sizeof_ReceiptEvent))
-				creceipt.kind = C.uint8_t(EventTypeReceipt)
-				creceipt.id = cchatId
-				creceipt.messageIDs = cmessageIds
-				creceipt.size = C.size_t(n)
-
-				cevent := C.Event{
-					kind: C.uint8_t(EventTypeReceipt),
-					data: unsafe.Pointer(creceipt),
-				}
-				C.callEventCallback(eventHandler, &cevent)
+				dispatchReceiptEvent(receipt)
 			}
 
 		case *events.HistorySync:

--- a/whatsrust/lib/receipt_events.go
+++ b/whatsrust/lib/receipt_events.go
@@ -1,0 +1,74 @@
+package main
+
+/*
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef const char* JID;
+
+typedef struct {
+	uint8_t kind;
+	JID id;
+	char* const* messageIDs;
+	size_t size;
+} ReceiptEvent;
+
+typedef struct {
+	uint8_t kind;
+	void* data;
+} Event;
+
+typedef void (*EventCallback)(const Event*, void*);
+typedef struct {
+	EventCallback callback;
+	void* user_data;
+} EventHandler;
+
+static void callReceiptEventCallback(EventHandler hdl, const Event* event) {
+	hdl.callback(event, hdl.user_data);
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+type receiptEvent struct {
+	chat       types.JID
+	messageIDs []string
+}
+
+func receiptEventFromEvent(event *events.Receipt) (receiptEvent, bool) {
+	if event == nil || (event.Type != types.ReceiptTypeRead && event.Type != types.ReceiptTypeReadSelf) {
+		return receiptEvent{}, false
+	}
+	return receiptEvent{
+		chat:       event.MessageSource.Chat,
+		messageIDs: event.MessageIDs,
+	}, true
+}
+
+func dispatchReceiptEvent(receipt receiptEvent) {
+	n := len(receipt.messageIDs)
+	cmessageIDs := (**C.char)(C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0)))))
+	messageIDs := unsafe.Slice(cmessageIDs, n)
+	for i, id := range receipt.messageIDs {
+		messageIDs[i] = C.CString(id)
+	}
+
+	creceipt := (*C.ReceiptEvent)(C.malloc(C.sizeof_ReceiptEvent))
+	creceipt.kind = C.uint8_t(EventTypeReceipt)
+	creceipt.id = jidToC(receipt.chat)
+	creceipt.messageIDs = cmessageIDs
+	creceipt.size = C.size_t(n)
+
+	C.callReceiptEventCallback(eventHandler, &C.Event{
+		kind: C.uint8_t(EventTypeReceipt),
+		data: unsafe.Pointer(creceipt),
+	})
+}

--- a/whatsrust/lib/receipt_events_test.go
+++ b/whatsrust/lib/receipt_events_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func TestReceiptEventConversionMapsReadReceiptsAndRejectsOthers(t *testing.T) {
+	chat := types.NewJID("1234567890", types.DefaultUserServer)
+	cases := []struct {
+		name     string
+		type_    types.ReceiptType
+		wantOK   bool
+		wantIDs  []string
+		wantChat types.JID
+	}{
+		{name: "read", type_: types.ReceiptTypeRead, wantOK: true, wantIDs: []string{"first", "second"}, wantChat: chat},
+		{name: "read self", type_: types.ReceiptTypeReadSelf, wantOK: true, wantIDs: []string{}, wantChat: chat},
+		{name: "delivered is ignored", type_: types.ReceiptTypeDelivered},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := &events.Receipt{Type: tc.type_, MessageSource: types.MessageSource{Chat: chat}, MessageIDs: tc.wantIDs}
+			got, ok := receiptEventFromEvent(event)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.chat != tc.wantChat || len(got.messageIDs) != len(tc.wantIDs) {
+				t.Fatalf("receipt = %#v, want chat %v and %d IDs", got, tc.wantChat, len(tc.wantIDs))
+			}
+			for i := range tc.wantIDs {
+				if got.messageIDs[i] != tc.wantIDs[i] {
+					t.Fatalf("message ID %d = %q, want %q", i, got.messageIDs[i], tc.wantIDs[i])
+				}
+			}
+		})
+	}
+
+	if _, ok := receiptEventFromEvent(nil); ok {
+		t.Fatal("nil receipt must be ignored")
+	}
+}
+
+func TestReceiptDispatchKeepsCArrayAndPayloadThroughCallback(t *testing.T) {
+	source, err := os.ReadFile("receipt_events.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, ok := extractFunctionBody(string(source), "func dispatchReceiptEvent(receipt receiptEvent)")
+	if !ok {
+		t.Fatal("dispatchReceiptEvent function body not found in receipt_events.go")
+	}
+	for _, fragment := range []string{
+		"C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0))))",
+		"unsafe.Slice(cmessageIDs, n)",
+		"C.CString(id)",
+		"C.malloc(C.sizeof_ReceiptEvent)",
+		"C.callReceiptEventCallback(eventHandler, &C.Event{",
+	} {
+		if !strings.Contains(body, fragment) {
+			t.Fatalf("receipt dispatch must contain %q", fragment)
+		}
+	}
+	callback := strings.Index(body, "C.callReceiptEventCallback(eventHandler, &C.Event{")
+	arrayBuild := strings.Index(body, "unsafe.Slice(cmessageIDs, n)")
+	if callback < arrayBuild {
+		t.Fatal("receipt C array must be populated before the callback")
+	}
+}


### PR DESCRIPTION
## Summary

- Extract receipt-event mapping and callback payload ownership from the Go bridge.
- Preserve receipt kinds, message ordering, empty semantics, callback layout, and allocation lifetime.
- Keep reaction, presence, sync, and chat event families separate.

## Testing

- [x] Focused receipt tests
- [x] `cd whatsrust/lib && go test ./...`
- [x] `gofmt` and diff checks
- [x] No target directory created

Twentieth responsibility in the Go bridge modularization chain.

Depends on #89.