### PR TITLE
refactor(bridge): extract sync events

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -202,9 +202,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"go.mau.fi/whatsmeow"
-	"go.mau.fi/whatsmeow/appstate"
 	"go.mau.fi/whatsmeow/proto/waE2E"
-	"go.mau.fi/whatsmeow/proto/waHistorySync"
 	"go.mau.fi/whatsmeow/proto/waWeb"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
@@ -1769,16 +1767,7 @@ func AddEventHandlers() {
 			LOG_DEBUG("MarkChatAsRead %v", evt.JID)
 
 		case *events.AppStateSyncComplete:
-			LOG_INFO("AppStateSyncComplete %v", evt)
-			if evt.Name == appstate.WAPatchRegular {
-				LOG_INFO("AppStateSyncComplete (WAPatchRegular) %v", evt)
-
-				cevent := C.Event{
-					kind: C.uint8_t(EventTypeAppStateSyncComplete),
-					data: nil,
-				}
-				C.callEventCallback(eventHandler, &cevent)
-			}
+			dispatchAppStateSyncComplete(evt)
 
 		case *events.Message:
 			dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage)
@@ -1790,82 +1779,18 @@ func AddEventHandlers() {
 			}
 
 		case *events.HistorySync:
-			percent := evt.Data.GetProgress()
-			LOG_INFO(
-				"History sync: type=%s chunk=%d progress=%d conversations=%d messages=%d",
-				evt.Data.GetSyncType().String(),
-				evt.Data.GetChunkOrder(),
-				percent,
-				len(evt.Data.GetConversations()),
-				countSyncMessages(evt.Data.GetConversations()),
-			)
-			cpercent := (*C.uint8_t)(C.malloc(C.size_t(unsafe.Sizeof(uint8(0)))))
-			*cpercent = C.uint8_t(percent)
-
-			cevent := C.Event{
-				kind: C.uint8_t(EventTypeSyncProgress),
-				data: unsafe.Pointer(cpercent),
-			}
-
-			C.callEventCallback(eventHandler, &cevent)
-
-			C.free(unsafe.Pointer(cpercent))
-
-			conversations := evt.Data.GetConversations()
-			// The default history downloader may store secrets asynchronously. Store
-			// them synchronously here before parsing encrypted history edits.
-			client.DangerousInternals().StoreHistoricalMessageSecrets(context.Background(), conversations)
-			for _, conversation := range conversations {
-				chatJid, err := types.ParseJID(conversation.GetID())
-				if err != nil {
-					LOG_WARN("history message ignored source=history_sync reason=invalid_chat")
-					continue
-				}
-
-				// Register the chat itself even when the sync batch carries no
-				// messages (older/archived/muted conversations). Previously only
-				// conversations that shipped at least one message became chats,
-				// which left the chat list stuck at the messages-only subset.
-				var lastMsgTime int64
-				if ts := conversation.GetLastMsgTimestamp(); ts != 0 {
-					lastMsgTime = int64(ts)
-				}
-				chatEvent := (*C.ChatEvent)(C.malloc(C.sizeof_ChatEvent))
-				chatEvent.chat = jidToC(chatJid)
-				chatEvent.lastMessageTime = C.int64_t(lastMsgTime)
-				cevent := C.Event{
-					kind: C.uint8_t(EventTypeChat),
-					data: unsafe.Pointer(chatEvent),
-				}
-				C.callEventCallback(eventHandler, &cevent)
-
-				syncMessages := conversation.GetMessages()
-
-				for _, syncMessage := range syncMessages {
-					webMessageInfo := syncMessage.Message
-					if webMessageInfo == nil {
-						continue
-					}
-					parsed, err := client.ParseWebMessage(chatJid, webMessageInfo)
-					if err != nil {
-						LOG_WARN("history message ignored source=history_sync reason=parse_failed")
-						continue
-					}
+			dispatchHistorySync(
+				evt,
+				client.DangerousInternals().StoreHistoricalMessageSecrets,
+				client.ParseWebMessage,
+				func(parsed *events.Message) {
 					dispatchIncomingMessage(parsed, dispatchMessageActionEvent, func(info types.MessageInfo, message *waE2E.Message, _ bool) {
 						HandleMessage(info, message, true)
 					})
-				}
-			}
+				},
+			)
 		}
 	})
-}
-
-func countSyncMessages(conversations []*waHistorySync.Conversation) int {
-	total := 0
-	for _, conversation := range conversations {
-		total += len(conversation.GetMessages())
-	}
-	return total
 }
 
 //export C_TestEmitPresenceEvent

--- a/whatsrust/lib/sync_events.go
+++ b/whatsrust/lib/sync_events.go
@@ -1,0 +1,145 @@
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef const char* JID;
+
+typedef struct {
+	JID chat;
+	int64_t lastMessageTime;
+} ChatEvent;
+
+typedef struct {
+	uint8_t kind;
+	void* data;
+} Event;
+
+typedef void (*EventCallback)(const Event*, void*);
+typedef struct {
+	EventCallback callback;
+	void* user_data;
+} EventHandler;
+
+static void callSyncEventCallback(EventHandler hdl, const Event* event) {
+	hdl.callback(event, hdl.user_data);
+}
+*/
+import "C"
+
+import (
+	"context"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/appstate"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/proto/waWeb"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+type syncMessageDispatcher func(*events.Message)
+
+type chatSyncEvent struct {
+	chat            types.JID
+	lastMessageTime int64
+}
+
+func appStateSyncComplete(evt *events.AppStateSyncComplete) bool {
+	return evt != nil && evt.Name == appstate.WAPatchRegular
+}
+
+func chatSyncEventFromConversation(conversation *waHistorySync.Conversation) (chatSyncEvent, bool) {
+	if conversation == nil {
+		return chatSyncEvent{}, false
+	}
+	chatJID, err := types.ParseJID(conversation.GetID())
+	if err != nil {
+		return chatSyncEvent{}, false
+	}
+	var lastMessageTime int64
+	if timestamp := conversation.GetLastMsgTimestamp(); timestamp != 0 {
+		lastMessageTime = int64(timestamp)
+	}
+	return chatSyncEvent{chat: chatJID, lastMessageTime: lastMessageTime}, true
+}
+
+func countSyncMessages(conversations []*waHistorySync.Conversation) int {
+	total := 0
+	for _, conversation := range conversations {
+		total += len(conversation.GetMessages())
+	}
+	return total
+}
+
+func dispatchAppStateSyncComplete(evt *events.AppStateSyncComplete) {
+	if evt == nil {
+		return
+	}
+	LOG_INFO("AppStateSyncComplete %v", evt)
+	if !appStateSyncComplete(evt) {
+		return
+	}
+	LOG_INFO("AppStateSyncComplete (WAPatchRegular) %v", evt)
+	C.callSyncEventCallback(eventHandler, &C.Event{
+		kind: C.uint8_t(EventTypeAppStateSyncComplete),
+		data: nil,
+	})
+}
+
+func dispatchHistorySync(
+	evt *events.HistorySync,
+	storeHistoricalSecrets func(context.Context, []*waHistorySync.Conversation),
+	parseWebMessage func(types.JID, *waWeb.WebMessageInfo) (*events.Message, error),
+	dispatchMessage syncMessageDispatcher,
+) {
+	percent := evt.Data.GetProgress()
+	conversations := evt.Data.GetConversations()
+	LOG_INFO(
+		"History sync: type=%s chunk=%d progress=%d conversations=%d messages=%d",
+		evt.Data.GetSyncType().String(),
+		evt.Data.GetChunkOrder(),
+		percent,
+		len(conversations),
+		countSyncMessages(conversations),
+	)
+	cpercent := (*C.uint8_t)(C.malloc(C.size_t(unsafe.Sizeof(uint8(0)))))
+	*cpercent = C.uint8_t(percent)
+	C.callSyncEventCallback(eventHandler, &C.Event{
+		kind: C.uint8_t(EventTypeSyncProgress),
+		data: unsafe.Pointer(cpercent),
+	})
+	C.free(unsafe.Pointer(cpercent))
+
+	// Store secrets before parsing encrypted history edits.
+	storeHistoricalSecrets(context.Background(), conversations)
+	for _, conversation := range conversations {
+		chatEvent, ok := chatSyncEventFromConversation(conversation)
+		if !ok {
+			LOG_WARN("history message ignored source=history_sync reason=invalid_chat")
+			continue
+		}
+		// Register chats even when a sync batch carries no messages.
+		payload := (*C.ChatEvent)(C.malloc(C.sizeof_ChatEvent))
+		payload.chat = jidToC(chatEvent.chat)
+		payload.lastMessageTime = C.int64_t(chatEvent.lastMessageTime)
+		C.callSyncEventCallback(eventHandler, &C.Event{
+			kind: C.uint8_t(EventTypeChat),
+			data: unsafe.Pointer(payload),
+		})
+
+		for _, syncMessage := range conversation.GetMessages() {
+			webMessageInfo := syncMessage.Message
+			if webMessageInfo == nil {
+				continue
+			}
+			parsed, err := parseWebMessage(chatEvent.chat, webMessageInfo)
+			if err != nil {
+				LOG_WARN("history message ignored source=history_sync reason=parse_failed")
+				continue
+			}
+			dispatchMessage(parsed)
+		}
+	}
+}

--- a/whatsrust/lib/sync_events_test.go
+++ b/whatsrust/lib/sync_events_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow/appstate"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func TestAppStateSyncCompleteOnlyAcceptsRegularPatch(t *testing.T) {
+	cases := []struct {
+		caseName  string
+		patchName appstate.WAPatchName
+		want      bool
+	}{
+		{caseName: "regular", patchName: appstate.WAPatchRegular, want: true},
+		{caseName: "critical", patchName: appstate.WAPatchCriticalBlock, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := appStateSyncComplete(&events.AppStateSyncComplete{Name: tc.patchName}); got != tc.want {
+				t.Fatalf("appStateSyncComplete() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	if appStateSyncComplete(nil) {
+		t.Fatal("nil app-state event must be ignored")
+	}
+}
+
+func TestChatSyncEventPreservesIdentityAndTimestamp(t *testing.T) {
+	chat := types.NewJID("1234567890", types.DefaultUserServer)
+	cases := []struct {
+		name string
+		id   string
+		ts   uint64
+		want int64
+		ok   bool
+	}{
+		{name: "timestamp", id: chat.String(), ts: 42, want: 42, ok: true},
+		{name: "empty timestamp", id: chat.String(), want: 0, ok: true},
+		{name: "invalid chat", id: "1.2.3@server"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := chatSyncEventFromConversation(&waHistorySync.Conversation{ID: &tc.id, LastMsgTimestamp: &tc.ts})
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && (got.chat != chat || got.lastMessageTime != tc.want) {
+				t.Fatalf("chat event = %#v, want %v at %d", got, chat, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountSyncMessagesIncludesEmptyAndNilConversations(t *testing.T) {
+	if got := countSyncMessages([]*waHistorySync.Conversation{
+		{Messages: []*waHistorySync.HistorySyncMsg{{}, {}}},
+		{},
+		nil,
+	}); got != 2 {
+		t.Fatalf("countSyncMessages() = %d, want 2", got)
+	}
+}
+
+func TestHistorySyncDispatchKeepsProgressChatAndMessageOrdering(t *testing.T) {
+	source, err := os.ReadFile("sync_events.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, ok := extractFunctionBody(string(source), "func dispatchHistorySync(")
+	if !ok {
+		t.Fatal("dispatchHistorySync function body not found")
+	}
+	for _, fragment := range []string{
+		"C.malloc(C.size_t(unsafe.Sizeof(uint8(0)))",
+		"EventTypeSyncProgress",
+		"C.free(unsafe.Pointer(cpercent))",
+		"EventTypeChat",
+		"conversation.GetMessages()",
+		"dispatchMessage(parsed)",
+	} {
+		if !strings.Contains(body, fragment) {
+			t.Fatalf("history sync dispatch must contain %q", fragment)
+		}
+	}
+	if strings.Index(body, "EventTypeSyncProgress") > strings.Index(body, "EventTypeChat") {
+		t.Fatal("sync progress must be emitted before chat lifecycle events")
+	}
+}


### PR DESCRIPTION
## Summary

- Extract sync progress, app-state completion, chat lifecycle, and history message dispatch.
- Preserve callback ownership, ordering, timestamps, percentages, and empty/error behavior.
- Keep reaction, receipt, presence, and client lifecycle separate.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No target directory created

Twenty-first responsibility in the Go bridge modularization chain.

Depends on #91.