### PR TITLE
refactor(bridge): extract connection events

### DIFF
--- a/whatsrust/lib/connection_events.go
+++ b/whatsrust/lib/connection_events.go
@@ -1,0 +1,54 @@
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+    uint8_t status;
+} LogoutResultEvent;
+
+typedef struct {
+    uint8_t kind;
+    void* data;
+} Event;
+
+typedef void (*EventCallback)(const Event*, void*);
+typedef struct {
+    EventCallback callback;
+    void* user_data;
+} EventHandler;
+
+static void callConnectionEventCallback(EventHandler hdl, const Event* event) {
+    hdl.callback(event, hdl.user_data);
+}
+*/
+import "C"
+
+import "unsafe"
+
+func dispatchConnectedEvent() {
+	if eventHandler.callback == nil {
+		return
+	}
+	C.callConnectionEventCallback(eventHandler, &C.Event{
+		kind: C.uint8_t(EventTypeConnected),
+		data: nil,
+	})
+}
+
+func emitLogoutResult(status uint8) {
+	if eventHandler.callback == nil {
+		return
+	}
+	payload := (*C.LogoutResultEvent)(C.malloc(C.sizeof_LogoutResultEvent))
+	if payload == nil {
+		return
+	}
+	payload.status = C.uint8_t(status)
+	C.callConnectionEventCallback(eventHandler, &C.Event{
+		kind: C.uint8_t(EventTypeLogoutResult),
+		data: unsafe.Pointer(payload),
+	})
+	C.free(unsafe.Pointer(payload))
+}

--- a/whatsrust/lib/connection_events_test.go
+++ b/whatsrust/lib/connection_events_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestConnectionEventDispatchKeepsCallbackGuardAndKinds(t *testing.T) {
+	source, err := os.ReadFile("connection_events.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(source)
+	for _, expected := range []string{
+		"func dispatchConnectedEvent()",
+		"if eventHandler.callback == nil",
+		"kind: C.uint8_t(EventTypeConnected)",
+		"func emitLogoutResult(status uint8)",
+		"kind: C.uint8_t(EventTypeLogoutResult)",
+		"C.free(unsafe.Pointer(payload))",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("connection event conversion missing %q", expected)
+		}
+	}
+}
+
+func TestConnectionEventDispatchLeavesMainHandlerAsRouter(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(source)
+	if !strings.Contains(body, "dispatchConnectedEvent,") {
+		t.Fatal("main handler does not delegate connected events")
+	}
+	if strings.Contains(body, "func emitLogoutResult(status uint8)") {
+		t.Fatal("logout result conversion remains in main.go")
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -1750,9 +1750,7 @@ func AddEventHandlers() {
 		case *events.Connected:
 			handleConnected(
 				client.SendPresence,
-				func() {
-					C.callEventCallback(eventHandler, &C.Event{kind: C.uint8_t(EventTypeConnected), data: nil})
-				},
+				dispatchConnectedEvent,
 				LOG_WARN,
 			)
 
@@ -1940,19 +1938,3 @@ func C_MarkAsRead(msg_id *C.char, chat_jid C.JID, sender_jid C.JID) {
 }
 
 func main() {} // Required for CGO
-
-func emitLogoutResult(status uint8) {
-	if eventHandler.callback == nil {
-		return
-	}
-	payload := (*C.LogoutResultEvent)(C.malloc(C.sizeof_LogoutResultEvent))
-	if payload == nil {
-		return
-	}
-	payload.status = C.uint8_t(status)
-	C.callEventCallback(eventHandler, &C.Event{
-		kind: C.uint8_t(EventTypeLogoutResult),
-		data: unsafe.Pointer(payload),
-	})
-	C.free(unsafe.Pointer(payload))
-}


### PR DESCRIPTION
## Summary

- Extract connected and logout-result event conversion from the Go bridge.
- Preserve event types, callback order, payload layout, and ownership/free semantics.
- Leave message-action callbacks with their owning module.

## Testing

- [x] `gofmt` on touched Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] No target directory created

Twenty-second responsibility in the Go bridge modularization chain.

Depends on #93.