### PR TITLE
refactor(bridge): extract action census

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -216,15 +216,6 @@ var presenceHandler C.PresenceHandler
 
 var messageActionArrivalOrder uint64
 
-const messageActionCensusLimit = 100
-
-type messageActionCensus struct {
-	mu      sync.Mutex
-	nextSeq uint64
-	entries []string
-}
-
-var eventCensus messageActionCensus
 var messageCallbackMu sync.Mutex
 
 const (
@@ -254,18 +245,6 @@ func messageActionCensusDiagnostic(rawEvt any) {
 		return
 	}
 	messageActionCensusAppend(messageActionCensusLine(rawEvt))
-}
-
-func messageActionCensusAppend(entry string) {
-	eventCensus.mu.Lock()
-	eventCensus.nextSeq++
-	entry = fmt.Sprintf("census=event seq=%d %s", eventCensus.nextSeq, entry)
-	if len(eventCensus.entries) == messageActionCensusLimit {
-		eventCensus.entries = eventCensus.entries[1:]
-	}
-	eventCensus.entries = append(eventCensus.entries, entry)
-	eventCensus.mu.Unlock()
-	messageActionDiagnostic("%s", entry)
 }
 
 func messageActionCensusLine(rawEvt any) string {

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -323,24 +323,6 @@ func TestMessageActionStructuralDiagnosticsAreSignalScopedAndRedacted(t *testing
 	}
 }
 
-func resetEventCensusForTest() {
-	eventCensus.mu.Lock()
-	defer eventCensus.mu.Unlock()
-	eventCensus.nextSeq = 0
-	eventCensus.entries = nil
-}
-
-func TestMessageActionEventCensusIsDisabledWithoutDebug(t *testing.T) {
-	t.Setenv("WPTUI_MESSAGE_ACTION_DEBUG", "")
-	resetEventCensusForTest()
-	messageActionCensusDiagnostic(&events.Receipt{Type: types.ReceiptTypeRead})
-	eventCensus.mu.Lock()
-	defer eventCensus.mu.Unlock()
-	if len(eventCensus.entries) != 0 {
-		t.Fatalf("disabled census recorded %d entries", len(eventCensus.entries))
-	}
-}
-
 func TestMessageActionEventCensusRedactsOrdinaryMessageAndLabelsNonMessage(t *testing.T) {
 	chat := types.NewJID("chat-secret", types.DefaultUserServer)
 	sender := types.NewJID("sender-secret", types.DefaultUserServer)
@@ -364,22 +346,6 @@ func TestMessageActionEventCensusRedactsOrdinaryMessageAndLabelsNonMessage(t *te
 	receipt := messageActionCensusLine(&events.Receipt{Type: types.ReceiptTypeRead})
 	if !strings.Contains(receipt, "event_type=events_receipt subtype=receipt_read") {
 		t.Fatalf("receipt census = %s", receipt)
-	}
-}
-
-func TestMessageActionEventCensusIsBoundedAndOrdered(t *testing.T) {
-	t.Setenv("WPTUI_MESSAGE_ACTION_DEBUG", "1")
-	resetEventCensusForTest()
-	for range messageActionCensusLimit + 1 {
-		messageActionCensusDiagnostic(&events.Receipt{Type: types.ReceiptTypeRead})
-	}
-	eventCensus.mu.Lock()
-	defer eventCensus.mu.Unlock()
-	if len(eventCensus.entries) != messageActionCensusLimit {
-		t.Fatalf("census length = %d, want %d", len(eventCensus.entries), messageActionCensusLimit)
-	}
-	if !strings.HasPrefix(eventCensus.entries[0], "census=event seq=2 ") || !strings.HasPrefix(eventCensus.entries[len(eventCensus.entries)-1], "census=event seq=101 ") {
-		t.Fatalf("census order = first %q, last %q", eventCensus.entries[0], eventCensus.entries[len(eventCensus.entries)-1])
 	}
 }
 

--- a/whatsrust/lib/message_action_census.go
+++ b/whatsrust/lib/message_action_census.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+const messageActionCensusLimit = 100
+
+type messageActionCensus struct {
+	mu      sync.Mutex
+	nextSeq uint64
+	entries []string
+}
+
+var eventCensus messageActionCensus
+
+func messageActionCensusAppend(entry string) {
+	eventCensus.mu.Lock()
+	eventCensus.nextSeq++
+	entry = fmt.Sprintf("census=event seq=%d %s", eventCensus.nextSeq, entry)
+	if len(eventCensus.entries) == messageActionCensusLimit {
+		eventCensus.entries = eventCensus.entries[1:]
+	}
+	eventCensus.entries = append(eventCensus.entries, entry)
+	eventCensus.mu.Unlock()
+	messageActionDiagnostic("%s", entry)
+}

--- a/whatsrust/lib/message_action_census_test.go
+++ b/whatsrust/lib/message_action_census_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func resetEventCensusForTest() {
+	eventCensus.mu.Lock()
+	defer eventCensus.mu.Unlock()
+	eventCensus.nextSeq = 0
+	eventCensus.entries = nil
+}
+
+func TestMessageActionEventCensusIsDisabledWithoutDebug(t *testing.T) {
+	t.Setenv("WPTUI_MESSAGE_ACTION_DEBUG", "")
+	resetEventCensusForTest()
+	messageActionCensusDiagnostic(&events.Receipt{Type: types.ReceiptTypeRead})
+	eventCensus.mu.Lock()
+	defer eventCensus.mu.Unlock()
+	if len(eventCensus.entries) != 0 {
+		t.Fatalf("disabled census recorded %d entries", len(eventCensus.entries))
+	}
+}
+
+func TestMessageActionEventCensusIsBoundedAndOrdered(t *testing.T) {
+	t.Setenv("WPTUI_MESSAGE_ACTION_DEBUG", "1")
+	resetEventCensusForTest()
+	for range messageActionCensusLimit + 1 {
+		messageActionCensusDiagnostic(&events.Receipt{Type: types.ReceiptTypeRead})
+	}
+	eventCensus.mu.Lock()
+	defer eventCensus.mu.Unlock()
+	if len(eventCensus.entries) != messageActionCensusLimit {
+		t.Fatalf("census length = %d, want %d", len(eventCensus.entries), messageActionCensusLimit)
+	}
+	if !strings.HasPrefix(eventCensus.entries[0], "census=event seq=2 ") || !strings.HasPrefix(eventCensus.entries[len(eventCensus.entries)-1], "census=event seq=101 ") {
+		t.Fatalf("census order = first %q, last %q", eventCensus.entries[0], eventCensus.entries[len(eventCensus.entries)-1])
+	}
+}


### PR DESCRIPTION
## Summary

- Extract bounded message-action census state, sequencing, buffering, and snapshots.
- Preserve mutex protection, capacity, ordering, and enabled gating.
- Leave formatting, redaction, reports, and log filtering as separate responsibilities.

## Chain context

`#97 status protocol` → **📍 #98 action census** → `#103 message conversion` → `#104 action classifier` → `#105 forwarding state`

- Starts after #97.
- Ends with action-census buffering isolated.
- Follow-up work is split into dependent PRs #103–#105.
- Out of scope: message conversion, action classification, and forwarding state.

## Testing

- [x] Focused census tests
- [x] `cd whatsrust/lib && go test ./...`
- [x] `gofmt` and diff checks
- [x] 126 authored lines; no target directory

Twenty-fourth responsibility in the Go bridge modularization chain.

Depends on #97.