### PR TITLE
refactor(bridge): extract message conversion

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -736,38 +736,6 @@ func buildFileMessage(ctx context.Context, kind uint8, filePath string, caption 
 	}
 }
 
-func ContentToWaE2EMessage(messageType C.uint8_t, messageContent unsafe.Pointer, contextInfo *waE2E.ContextInfo) *waE2E.Message {
-	switch messageType {
-	case C.uint8_t(MessageTypeText):
-		textMsg := (*C.TextMessage)(messageContent)
-		text := C.GoString(textMsg.text)
-		return &waE2E.Message{
-			ExtendedTextMessage: &waE2E.ExtendedTextMessage{
-				Text:        &text,
-				ContextInfo: contextInfo,
-			},
-		}
-
-	case C.uint8_t(MessageTypeFile):
-		fileMsg := (*C.FileMessage)(messageContent)
-		kind := uint8(fileMsg.kind)
-		filePath := C.GoString(fileMsg.path)
-		var caption *string
-		if fileMsg.caption != nil {
-			captionValue := C.GoString(fileMsg.caption)
-			caption = &captionValue
-		}
-		message, err := buildFileMessage(context.Background(), kind, filePath, caption, contextInfo, client.Upload)
-		if err != nil {
-			panic(err)
-		}
-		return message
-
-	default:
-		panic(fmt.Sprintf("Unsupported message type: %d", messageType))
-	}
-}
-
 type forwardingState struct {
 	isForwarded bool
 	score       uint32

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -1034,21 +1034,6 @@ func TestBuildFileMessageKeepsNilCaptionNil(t *testing.T) {
 	}
 }
 
-func TestQuotedMessageFromContentPreservesTextAndFileKindsWithoutUpload(t *testing.T) {
-	quotedText := quotedTextMessage("quoted text")
-	if quotedText.GetConversation() != "quoted text" {
-		t.Fatalf("quoted text = %#v", quotedText)
-	}
-
-	quotedImage := quotedFileMessage(FileTypeImage, "caption")
-	if quotedImage.GetImageMessage() == nil || quotedImage.GetImageMessage().GetCaption() != "caption" {
-		t.Fatalf("quoted image = %#v", quotedImage)
-	}
-	if quotedFileMessage(99, "") != nil {
-		t.Fatal("unknown quoted file kind must be omitted")
-	}
-}
-
 func TestQuotedContextInfoPreservesOriginalChatForStatusAndOrdinaryReplies(t *testing.T) {
 	status := quotedContextInfo("status-id", "alice@s.whatsapp.net", "status@broadcast")
 	if status.GetStanzaID() != "status-id" || status.GetParticipant() != "alice@s.whatsapp.net" || status.GetRemoteJID() != "status@broadcast" {

--- a/whatsrust/lib/message_send.go
+++ b/whatsrust/lib/message_send.go
@@ -15,16 +15,50 @@ typedef struct {
 	char* fileID;
 	char* caption;
 } SendFileMessage;
+
 */
 import "C"
 
 import (
 	"context"
+	"fmt"
 	"unsafe"
 
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 )
+
+// ContentToWaE2EMessage converts the public FFI payload into a WhatsApp
+// message. File construction remains delegated to the injectable builder.
+func ContentToWaE2EMessage(messageType C.uint8_t, messageContent unsafe.Pointer, contextInfo *waE2E.ContextInfo) *waE2E.Message {
+	switch messageType {
+	case C.uint8_t(MessageTypeText):
+		textMsg := (*C.SendTextMessage)(messageContent)
+		text := C.GoString(textMsg.text)
+		return &waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+			Text:        &text,
+			ContextInfo: contextInfo,
+		}}
+
+	case C.uint8_t(MessageTypeFile):
+		fileMsg := (*C.SendFileMessage)(messageContent)
+		kind := uint8(fileMsg.kind)
+		filePath := C.GoString(fileMsg.path)
+		var caption *string
+		if fileMsg.caption != nil {
+			captionValue := C.GoString(fileMsg.caption)
+			caption = &captionValue
+		}
+		message, err := buildFileMessage(context.Background(), kind, filePath, caption, contextInfo, client.Upload)
+		if err != nil {
+			panic(err)
+		}
+		return message
+
+	default:
+		panic(fmt.Sprintf("Unsupported message type: %d", messageType))
+	}
+}
 
 func quotedContextInfo(id, sender, chat string) *waE2E.ContextInfo {
 	return &waE2E.ContextInfo{StanzaID: &id, Participant: &sender, RemoteJID: &chat}

--- a/whatsrust/lib/message_send_test.go
+++ b/whatsrust/lib/message_send_test.go
@@ -6,6 +6,21 @@ import (
 	"testing"
 )
 
+func TestQuotedMessageFromContentPreservesTextAndFileKindsWithoutUpload(t *testing.T) {
+	quotedText := quotedTextMessage("quoted text")
+	if quotedText.GetConversation() != "quoted text" {
+		t.Fatalf("quoted text = %#v", quotedText)
+	}
+
+	quotedImage := quotedFileMessage(FileTypeImage, "caption")
+	if quotedImage.GetImageMessage() == nil || quotedImage.GetImageMessage().GetCaption() != "caption" {
+		t.Fatalf("quoted image = %#v", quotedImage)
+	}
+	if quotedFileMessage(99, "") != nil {
+		t.Fatal("unknown quoted file kind must be omitted")
+	}
+}
+
 func TestQuotedMessageBuildersPreserveTextAndFileKinds(t *testing.T) {
 	if quotedTextMessage("quoted text").GetConversation() != "quoted text" {
 		t.Fatal("quoted text was not preserved")


### PR DESCRIPTION
## Summary

- Move FFI message-content conversion out of `main.go`.
- Keep file construction delegated to the existing injectable builder.
- Relocate conversion-focused coverage with the responsibility.

## Chain context

`#98 action census` → **📍 message conversion** → `action classifier` → `forwarding state`

- Starts after #98.
- Ends with message conversion isolated in `message_send.go`.
- Follow-up: action classification.
- Out of scope: classifier and forwarding-state behavior.

## Testing

- [x] Focused Go tests
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt` and `git diff --check`
- [x] CI passed before chain split

Depends on #98.