### PR TITLE
refactor(bridge): extract action classifier

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -1122,18 +1122,8 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	}
 }
 
-const (
-	messageActionEdit uint8 = iota
-	messageActionDelete
-)
-
-type messageActionEvent struct {
-	actionID, chat, sender, targetMessageID, replacement string
-	occurredAt                                           int64
-	arrivalOrder                                         uint64
-	kind                                                 uint8
-}
-
+// messageActionProbe captures wrapper and protocol-edit structure shared by
+// action classification and diagnostics.
 type messageActionProbe struct {
 	present, deviceSent, botInvoke, ephemeral, viewOnce, viewOnceV2, viewOnceV2Extension, lottieSticker, documentWithCaption, edited, futureProof bool
 	protocol                                                                                                                                      *waE2E.ProtocolMessage
@@ -1210,10 +1200,7 @@ func messageActionProbeFromMessage(msg *waE2E.Message, path string) messageActio
 }
 
 func (probe messageActionProbe) hasActionProtocol() bool {
-	if probe.protocol == nil {
-		return false
-	}
-	return probe.protocol.GetType() == waE2E.ProtocolMessage_MESSAGE_EDIT || probe.protocol.GetType() == waE2E.ProtocolMessage_REVOKE
+	return probe.protocol != nil && (probe.protocol.GetType() == waE2E.ProtocolMessage_MESSAGE_EDIT || probe.protocol.GetType() == waE2E.ProtocolMessage_REVOKE)
 }
 
 func (probe messageActionProbe) replacementVariant() (bool, string) {
@@ -1230,8 +1217,6 @@ func (probe messageActionProbe) replacementVariant() (bool, string) {
 	return true, "none"
 }
 
-// msgContentTypes returns a compact field-presence string for the message,
-// used for diagnostics when the decrypted structure doesn't match expectations.
 func msgContentTypes(msg *waE2E.Message) string {
 	if msg == nil {
 		return "nil"
@@ -1271,28 +1256,6 @@ func msgContentTypes(msg *waE2E.Message) string {
 		return "empty"
 	}
 	return strings.Join(parts, ",")
-}
-
-func replacementText(msg *waE2E.Message) (string, bool) {
-	if msg == nil {
-		return "", false
-	}
-	// Direct text content — simplest case
-	if replacement := msg.GetConversation(); replacement != "" {
-		return replacement, true
-	}
-	if replacement := msg.GetExtendedTextMessage().GetText(); replacement != "" {
-		return replacement, true
-	}
-	// ProtocolMessage wrapper: used by BuildEdit / non-secret edits
-	if pm := msg.GetProtocolMessage(); pm != nil && pm.GetEditedMessage() != nil {
-		return replacementText(pm.GetEditedMessage())
-	}
-	// EditedMessage wrapper: FutureProofMessage -> inner Message
-	if em := msg.GetEditedMessage(); em != nil && em.GetMessage() != nil {
-		return replacementText(em.GetMessage())
-	}
-	return "", false
 }
 
 type decryptSecretEncryptedMessageFunc func(context.Context, *events.Message) (*waE2E.Message, error)
@@ -1380,61 +1343,6 @@ func messageActionEventFromSecretEncryptedMessage(evt *events.Message, decrypt d
 		arrivalOrder:    atomic.AddUint64(&messageActionArrivalOrder, 1),
 		kind:            messageActionEdit,
 	}, true
-}
-
-// messageActionEventFromMessage recognizes the protocol envelopes emitted by the
-// pinned whatsmeow builders. Unsupported or incomplete payloads stay ordinary.
-func messageActionEventFromProbe(info types.MessageInfo, probe messageActionProbe) (messageActionEvent, bool, string) {
-	protocol := probe.protocol
-	if protocol == nil {
-		return messageActionEvent{}, false, "protocol_absent"
-	}
-	if info.ID == "" {
-		return messageActionEvent{}, false, "missing_action_id"
-	}
-	if protocol.GetKey() == nil {
-		return messageActionEvent{}, false, "missing_protocol_key"
-	}
-	if protocol.GetKey().GetID() == "" {
-		return messageActionEvent{}, false, "missing_target_id"
-	}
-
-	action := messageActionEvent{
-		actionID:        info.ID,
-		chat:            info.Chat.String(),
-		sender:          info.Sender.String(),
-		targetMessageID: protocol.GetKey().GetID(),
-		occurredAt:      info.Timestamp.Unix(),
-		arrivalOrder:    atomic.AddUint64(&messageActionArrivalOrder, 1),
-	}
-	if timestampMS := protocol.GetTimestampMS(); timestampMS > 0 {
-		action.occurredAt = timestampMS / 1000
-	}
-	if participant := protocol.GetKey().GetParticipant(); participant != "" {
-		if sender, err := types.ParseJID(participant); err == nil {
-			action.sender = sender.String()
-		}
-	}
-
-	switch protocol.GetType() {
-	case waE2E.ProtocolMessage_MESSAGE_EDIT:
-		replacement, ok := replacementText(protocol.GetEditedMessage())
-		if !ok {
-			return messageActionEvent{}, false, "missing_replacement"
-		}
-		action.kind = messageActionEdit
-		action.replacement = replacement
-	case waE2E.ProtocolMessage_REVOKE:
-		action.kind = messageActionDelete
-	default:
-		return messageActionEvent{}, false, "unsupported_protocol"
-	}
-	return action, true, ""
-}
-
-func messageActionEventFromMessage(info types.MessageInfo, msg *waE2E.Message) (messageActionEvent, bool) {
-	action, ok, _ := messageActionEventFromProbe(info, messageActionProbeFromMessage(msg, "message"))
-	return action, ok
 }
 
 func messageActionStructuralLine(evt *events.Message, branch, reason string) string {

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -1104,57 +1104,6 @@ func messageCaption(message *waE2E.Message) *string {
 	}
 }
 
-func TestMessageActionEventFromMessage(t *testing.T) {
-	baseInfo := types.MessageInfo{
-		MessageSource: types.MessageSource{Chat: types.NewJID("chat", types.DefaultUserServer), Sender: types.NewJID("sender", types.DefaultUserServer)},
-		ID:            "action-id",
-		Timestamp:     time.Unix(100, 0),
-	}
-	tests := []struct {
-		name      string
-		message   *waE2E.Message
-		wantKind  uint8
-		wantText  string
-		wantTime  int64
-		wantMatch bool
-	}{
-		{
-			name: "edited wrapper preserves target replacement and protocol timestamp",
-			message: &waE2E.Message{EditedMessage: &waE2E.FutureProofMessage{Message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
-				Type:          waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
-				Key:           &waCommon.MessageKey{ID: stringPointer("target")},
-				EditedMessage: &waE2E.Message{Conversation: stringPointer("replacement")},
-				TimestampMS:   int64Pointer(42_000),
-			}}}},
-			wantKind: messageActionEdit, wantText: "replacement", wantTime: 42, wantMatch: true,
-		},
-		{
-			name: "revoke preserves target and envelope timestamp",
-			message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
-				Type: waE2E.ProtocolMessage_REVOKE.Enum(), Key: &waCommon.MessageKey{ID: stringPointer("target")},
-			}},
-			wantKind: messageActionDelete, wantTime: 100, wantMatch: true,
-		},
-		{name: "unsupported protocol is ignored", message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{}}, wantMatch: false},
-		{name: "edit without replacement is ignored", message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{Type: waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(), Key: &waCommon.MessageKey{ID: stringPointer("target")}}}, wantMatch: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			action, ok := messageActionEventFromMessage(baseInfo, tt.message)
-			if ok != tt.wantMatch {
-				t.Fatalf("matched = %v, want %v", ok, tt.wantMatch)
-			}
-			if !ok {
-				return
-			}
-			if action.actionID != "action-id" || action.targetMessageID != "target" || action.kind != tt.wantKind || action.replacement != tt.wantText || action.occurredAt != tt.wantTime {
-				t.Fatalf("action = %#v", action)
-			}
-		})
-	}
-}
-
 func TestForwardingStateExtractsEverySupportedMessageContext(t *testing.T) {
 	forwarded, score := proto.Bool(true), uint32(5)
 	context := &waE2E.ContextInfo{IsForwarded: forwarded, ForwardingScore: &score}

--- a/whatsrust/lib/message_action_classifier.go
+++ b/whatsrust/lib/message_action_classifier.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"sync/atomic"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+const (
+	messageActionEdit uint8 = iota
+	messageActionDelete
+)
+
+type messageActionEvent struct {
+	actionID, chat, sender, targetMessageID, replacement string
+	occurredAt                                           int64
+	arrivalOrder                                         uint64
+	kind                                                 uint8
+}
+
+func replacementText(msg *waE2E.Message) (string, bool) {
+	if msg == nil {
+		return "", false
+	}
+	if replacement := msg.GetConversation(); replacement != "" {
+		return replacement, true
+	}
+	if replacement := msg.GetExtendedTextMessage().GetText(); replacement != "" {
+		return replacement, true
+	}
+	if pm := msg.GetProtocolMessage(); pm != nil && pm.GetEditedMessage() != nil {
+		return replacementText(pm.GetEditedMessage())
+	}
+	if em := msg.GetEditedMessage(); em != nil && em.GetMessage() != nil {
+		return replacementText(em.GetMessage())
+	}
+	return "", false
+}
+
+// messageActionEventFromProbe converts a previously located protocol envelope
+// into the bridge action model. Unsupported or incomplete payloads stay ordinary.
+func messageActionEventFromProbe(info types.MessageInfo, probe messageActionProbe) (messageActionEvent, bool, string) {
+	protocol := probe.protocol
+	if protocol == nil {
+		return messageActionEvent{}, false, "protocol_absent"
+	}
+	if info.ID == "" {
+		return messageActionEvent{}, false, "missing_action_id"
+	}
+	if protocol.GetKey() == nil {
+		return messageActionEvent{}, false, "missing_protocol_key"
+	}
+	if protocol.GetKey().GetID() == "" {
+		return messageActionEvent{}, false, "missing_target_id"
+	}
+
+	action := messageActionEvent{
+		actionID: info.ID, chat: info.Chat.String(), sender: info.Sender.String(),
+		targetMessageID: protocol.GetKey().GetID(), occurredAt: info.Timestamp.Unix(),
+		arrivalOrder: atomic.AddUint64(&messageActionArrivalOrder, 1),
+	}
+	if timestampMS := protocol.GetTimestampMS(); timestampMS > 0 {
+		action.occurredAt = timestampMS / 1000
+	}
+	if participant := protocol.GetKey().GetParticipant(); participant != "" {
+		if sender, err := types.ParseJID(participant); err == nil {
+			action.sender = sender.String()
+		}
+	}
+
+	switch protocol.GetType() {
+	case waE2E.ProtocolMessage_MESSAGE_EDIT:
+		replacement, ok := replacementText(protocol.GetEditedMessage())
+		if !ok {
+			return messageActionEvent{}, false, "missing_replacement"
+		}
+		action.kind, action.replacement = messageActionEdit, replacement
+	case waE2E.ProtocolMessage_REVOKE:
+		action.kind = messageActionDelete
+	default:
+		return messageActionEvent{}, false, "unsupported_protocol"
+	}
+	return action, true, ""
+}
+
+func messageActionEventFromMessage(info types.MessageInfo, msg *waE2E.Message) (messageActionEvent, bool) {
+	action, ok, _ := messageActionEventFromProbe(info, messageActionProbeFromMessage(msg, "message"))
+	return action, ok
+}

--- a/whatsrust/lib/message_action_classifier_test.go
+++ b/whatsrust/lib/message_action_classifier_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestMessageActionEventFromMessage(t *testing.T) {
+	baseInfo := types.MessageInfo{
+		MessageSource: types.MessageSource{Chat: types.NewJID("chat", types.DefaultUserServer), Sender: types.NewJID("sender", types.DefaultUserServer)},
+		ID:            "action-id",
+		Timestamp:     time.Unix(100, 0),
+	}
+	tests := []struct {
+		name      string
+		message   *waE2E.Message
+		wantKind  uint8
+		wantText  string
+		wantTime  int64
+		wantMatch bool
+	}{
+		{
+			name: "edited wrapper preserves target replacement and protocol timestamp",
+			message: &waE2E.Message{EditedMessage: &waE2E.FutureProofMessage{Message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
+				Type:          waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+				Key:           &waCommon.MessageKey{ID: stringPointer("target")},
+				EditedMessage: &waE2E.Message{Conversation: stringPointer("replacement")},
+				TimestampMS:   int64Pointer(42_000),
+			}}}},
+			wantKind: messageActionEdit, wantText: "replacement", wantTime: 42, wantMatch: true,
+		},
+		{
+			name: "revoke preserves target and envelope timestamp",
+			message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
+				Type: waE2E.ProtocolMessage_REVOKE.Enum(), Key: &waCommon.MessageKey{ID: stringPointer("target")},
+			}},
+			wantKind: messageActionDelete, wantTime: 100, wantMatch: true,
+		},
+		{name: "unsupported protocol is ignored", message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{}}, wantMatch: false},
+		{name: "edit without replacement is ignored", message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{Type: waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(), Key: &waCommon.MessageKey{ID: stringPointer("target")}}}, wantMatch: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, ok := messageActionEventFromMessage(baseInfo, tt.message)
+			if ok != tt.wantMatch {
+				t.Fatalf("matched = %v, want %v", ok, tt.wantMatch)
+			}
+			if !ok {
+				return
+			}
+			if action.actionID != "action-id" || action.targetMessageID != "target" || action.kind != tt.wantKind || action.replacement != tt.wantText || action.occurredAt != tt.wantTime {
+				t.Fatalf("action = %#v", action)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extract the message-action model and protocol classifier from `main.go`.
- Keep classifier tests colocated in a dedicated test file.
- Preserve C ABI and message-routing behavior.

## Chain context

`#98 action census` → `#103 message conversion` → **📍 action classifier** → `forwarding state`

- Starts after #103.
- Ends with action classification isolated in `message_action_classifier.go`.
- Follow-up: forwarding-state conversion.
- Out of scope: forwarding-state and message-delivery orchestration.

## Testing

- [x] Focused classifier tests
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt` and `git diff --check`
- [x] Independent read-only validation
- [x] CI passed before chain split

Depends on #103.