### PR TITLE
refactor(bridge): extract forwarding state

### DIFF
--- a/whatsrust/lib/forwarding_state.go
+++ b/whatsrust/lib/forwarding_state.go
@@ -1,0 +1,36 @@
+package main
+
+import waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+
+type forwardingState struct {
+	isForwarded bool
+	score       uint32
+}
+
+func forwardingStateFromContext(context *waE2E.ContextInfo) forwardingState {
+	if context == nil {
+		return forwardingState{}
+	}
+	return forwardingState{isForwarded: context.GetIsForwarded(), score: context.GetForwardingScore()}
+}
+
+func forwardingStateFromMessage(message *waE2E.Message) forwardingState {
+	switch {
+	case message == nil:
+		return forwardingState{}
+	case message.GetExtendedTextMessage() != nil:
+		return forwardingStateFromContext(message.GetExtendedTextMessage().GetContextInfo())
+	case message.GetImageMessage() != nil:
+		return forwardingStateFromContext(message.GetImageMessage().GetContextInfo())
+	case message.GetVideoMessage() != nil:
+		return forwardingStateFromContext(message.GetVideoMessage().GetContextInfo())
+	case message.GetAudioMessage() != nil:
+		return forwardingStateFromContext(message.GetAudioMessage().GetContextInfo())
+	case message.GetDocumentMessage() != nil:
+		return forwardingStateFromContext(message.GetDocumentMessage().GetContextInfo())
+	case message.GetStickerMessage() != nil:
+		return forwardingStateFromContext(message.GetStickerMessage().GetContextInfo())
+	default:
+		return forwardingState{}
+	}
+}

--- a/whatsrust/lib/forwarding_state_test.go
+++ b/whatsrust/lib/forwarding_state_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestForwardingStateExtractsEverySupportedMessageContext(t *testing.T) {
+	forwarded, score := proto.Bool(true), uint32(5)
+	context := &waE2E.ContextInfo{IsForwarded: forwarded, ForwardingScore: &score}
+	for _, message := range []*waE2E.Message{
+		{ExtendedTextMessage: &waE2E.ExtendedTextMessage{ContextInfo: context}},
+		{ImageMessage: &waE2E.ImageMessage{ContextInfo: context}}, {VideoMessage: &waE2E.VideoMessage{ContextInfo: context}},
+		{AudioMessage: &waE2E.AudioMessage{ContextInfo: context}}, {DocumentMessage: &waE2E.DocumentMessage{ContextInfo: context}},
+		{StickerMessage: &waE2E.StickerMessage{ContextInfo: context}},
+	} {
+		state := forwardingStateFromMessage(message)
+		if !state.isForwarded || state.score != 5 {
+			t.Fatalf("forwarding state = %#v", state)
+		}
+	}
+	if state := forwardingStateFromMessage(&waE2E.Message{Conversation: proto.String("text")}); state != (forwardingState{}) {
+		t.Fatalf("conversation forwarding state = %#v", state)
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -736,39 +736,6 @@ func buildFileMessage(ctx context.Context, kind uint8, filePath string, caption 
 	}
 }
 
-type forwardingState struct {
-	isForwarded bool
-	score       uint32
-}
-
-func forwardingStateFromContext(context *waE2E.ContextInfo) forwardingState {
-	if context == nil {
-		return forwardingState{}
-	}
-	return forwardingState{isForwarded: context.GetIsForwarded(), score: context.GetForwardingScore()}
-}
-
-func forwardingStateFromMessage(message *waE2E.Message) forwardingState {
-	switch {
-	case message == nil:
-		return forwardingState{}
-	case message.GetExtendedTextMessage() != nil:
-		return forwardingStateFromContext(message.GetExtendedTextMessage().GetContextInfo())
-	case message.GetImageMessage() != nil:
-		return forwardingStateFromContext(message.GetImageMessage().GetContextInfo())
-	case message.GetVideoMessage() != nil:
-		return forwardingStateFromContext(message.GetVideoMessage().GetContextInfo())
-	case message.GetAudioMessage() != nil:
-		return forwardingStateFromContext(message.GetAudioMessage().GetContextInfo())
-	case message.GetDocumentMessage() != nil:
-		return forwardingStateFromContext(message.GetDocumentMessage().GetContextInfo())
-	case message.GetStickerMessage() != nil:
-		return forwardingStateFromContext(message.GetStickerMessage().GetContextInfo())
-	default:
-		return forwardingState{}
-	}
-}
-
 func isStatusProtocolContext(context *waE2E.ContextInfo) bool {
 	return context.GetRemoteJID() == "status@broadcast" ||
 		context.GetPosterStatusID() != "" ||

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -21,7 +21,6 @@ import (
 	"go.mau.fi/whatsmeow/proto/waWeb"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
-	"google.golang.org/protobuf/proto"
 )
 
 func profilePicturePNG(t *testing.T) []byte {
@@ -1101,25 +1100,6 @@ func messageCaption(message *waE2E.Message) *string {
 		return message.DocumentMessage.Caption
 	default:
 		return nil
-	}
-}
-
-func TestForwardingStateExtractsEverySupportedMessageContext(t *testing.T) {
-	forwarded, score := proto.Bool(true), uint32(5)
-	context := &waE2E.ContextInfo{IsForwarded: forwarded, ForwardingScore: &score}
-	for _, message := range []*waE2E.Message{
-		{ExtendedTextMessage: &waE2E.ExtendedTextMessage{ContextInfo: context}},
-		{ImageMessage: &waE2E.ImageMessage{ContextInfo: context}}, {VideoMessage: &waE2E.VideoMessage{ContextInfo: context}},
-		{AudioMessage: &waE2E.AudioMessage{ContextInfo: context}}, {DocumentMessage: &waE2E.DocumentMessage{ContextInfo: context}},
-		{StickerMessage: &waE2E.StickerMessage{ContextInfo: context}},
-	} {
-		state := forwardingStateFromMessage(message)
-		if !state.isForwarded || state.score != 5 {
-			t.Fatalf("forwarding state = %#v", state)
-		}
-	}
-	if state := forwardingStateFromMessage(&waE2E.Message{Conversation: stringPointer("text")}); state != (forwardingState{}) {
-		t.Fatalf("conversation forwarding state = %#v", state)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract forwarding-state model and message/context conversion from `main.go`.
- Add focused coverage for every supported message context.
- Preserve message delivery and C ABI behavior.

## Chain context

`#98 action census` → `#103 message conversion` → `#104 action classifier` → **📍 forwarding state**

- Starts after #104.
- Ends with forwarding-state conversion isolated in `forwarding_state.go`.
- Follow-up: the next bounded `main.go` responsibility.
- Out of scope: message delivery and diagnostics.

## Testing

- [x] Focused forwarding-state tests
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt` and `git diff --check`
- [x] RDD reliability review approved
- [x] CI passed before chain split

Depends on #104.