### PR TITLE
refactor(bridge): extract view-once sanitization

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -545,39 +545,6 @@ func C_SetPresenceHandler(callback C.PresenceHandlerCallback, data unsafe.Pointe
 	}
 }
 
-const viewOnceUnavailablePlaceholder = "View-once media is unavailable here. View it on your phone."
-
-func unavailableViewOnceMessage(message *waE2E.Message) (*waE2E.Message, bool) {
-	if !containsViewOnceWrapper(message) {
-		return message, false
-	}
-	return &waE2E.Message{Conversation: proto.String(viewOnceUnavailablePlaceholder)}, true
-}
-
-func containsViewOnceWrapper(message *waE2E.Message) bool {
-	for message != nil {
-		switch {
-		case message.GetViewOnceMessage() != nil || message.GetViewOnceMessageV2() != nil || message.GetViewOnceMessageV2Extension() != nil:
-			return true
-		case message.GetDeviceSentMessage().GetMessage() != nil:
-			message = message.GetDeviceSentMessage().GetMessage()
-		case message.GetBotInvokeMessage().GetMessage() != nil:
-			message = message.GetBotInvokeMessage().GetMessage()
-		case message.GetEphemeralMessage().GetMessage() != nil:
-			message = message.GetEphemeralMessage().GetMessage()
-		case message.GetLottieStickerMessage().GetMessage() != nil:
-			message = message.GetLottieStickerMessage().GetMessage()
-		case message.GetDocumentWithCaptionMessage().GetMessage() != nil:
-			message = message.GetDocumentWithCaptionMessage().GetMessage()
-		case message.GetEditedMessage().GetMessage() != nil:
-			message = message.GetEditedMessage().GetMessage()
-		default:
-			return false
-		}
-	}
-	return false
-}
-
 func ParseWebMessageInfo(selfJid types.JID, chatJid types.JID, webMsg *waWeb.WebMessageInfo) *types.MessageInfo {
 	info := types.MessageInfo{
 		MessageSource: types.MessageSource{

--- a/whatsrust/lib/main_test.go
+++ b/whatsrust/lib/main_test.go
@@ -67,51 +67,6 @@ func TestFetchProfilePictureAvailablePreview(t *testing.T) {
 	}
 }
 
-func TestViewOnceWrappersBecomeUnavailablePlaceholders(t *testing.T) {
-	for _, testCase := range []struct {
-		name string
-		wrap func(*waE2E.Message) *waE2E.Message
-	}{
-		{"v1", func(message *waE2E.Message) *waE2E.Message {
-			return &waE2E.Message{ViewOnceMessage: &waE2E.FutureProofMessage{Message: message}}
-		}},
-		{"v2", func(message *waE2E.Message) *waE2E.Message {
-			return &waE2E.Message{ViewOnceMessageV2: &waE2E.FutureProofMessage{Message: message}}
-		}},
-		{"v2 extension", func(message *waE2E.Message) *waE2E.Message {
-			return &waE2E.Message{ViewOnceMessageV2Extension: &waE2E.FutureProofMessage{Message: message}}
-		}},
-		{"ephemeral v2", func(message *waE2E.Message) *waE2E.Message {
-			return &waE2E.Message{EphemeralMessage: &waE2E.FutureProofMessage{Message: &waE2E.Message{ViewOnceMessageV2: &waE2E.FutureProofMessage{Message: message}}}}
-		}},
-	} {
-		t.Run(testCase.name, func(t *testing.T) {
-			wrapped := testCase.wrap(&waE2E.Message{ImageMessage: &waE2E.ImageMessage{Caption: stringPointer("private media")}})
-			placeholder, unavailable := unavailableViewOnceMessage(wrapped)
-			if !unavailable {
-				t.Fatal("view-once wrapper must be unavailable")
-			}
-			if got := placeholder.GetConversation(); got != viewOnceUnavailablePlaceholder {
-				t.Fatalf("placeholder = %q, want %q", got, viewOnceUnavailablePlaceholder)
-			}
-			if placeholder.GetImageMessage() != nil || placeholder.GetVideoMessage() != nil {
-				t.Fatal("view-once media must not reach the public message model")
-			}
-		})
-	}
-}
-
-func TestOrdinaryAndEphemeralMessagesRemainAvailable(t *testing.T) {
-	ordinary := &waE2E.Message{Conversation: stringPointer("ordinary")}
-	if got, unavailable := unavailableViewOnceMessage(ordinary); unavailable || got != ordinary {
-		t.Fatal("ordinary message must remain unchanged")
-	}
-	ephemeral := &waE2E.Message{EphemeralMessage: &waE2E.FutureProofMessage{Message: ordinary}}
-	if got, unavailable := unavailableViewOnceMessage(ephemeral); unavailable || got != ephemeral {
-		t.Fatal("ephemeral message must remain unchanged")
-	}
-}
-
 func TestPinnedWhatsmeowMessageActionBuilders(t *testing.T) {
 	var _ func(*whatsmeow.Client, types.JID, types.JID, types.MessageID, string) *waE2E.Message = (*whatsmeow.Client).BuildReaction
 	var _ func(*whatsmeow.Client, types.JID, types.MessageID, *waE2E.Message) *waE2E.Message = (*whatsmeow.Client).BuildEdit

--- a/whatsrust/lib/view_once.go
+++ b/whatsrust/lib/view_once.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+)
+
+const viewOnceUnavailablePlaceholder = "View-once media is unavailable here. View it on your phone."
+
+func unavailableViewOnceMessage(message *waE2E.Message) (*waE2E.Message, bool) {
+	if !containsViewOnceWrapper(message) {
+		return message, false
+	}
+	return &waE2E.Message{Conversation: proto.String(viewOnceUnavailablePlaceholder)}, true
+}
+
+func containsViewOnceWrapper(message *waE2E.Message) bool {
+	for message != nil {
+		switch {
+		case message.GetViewOnceMessage() != nil || message.GetViewOnceMessageV2() != nil || message.GetViewOnceMessageV2Extension() != nil:
+			return true
+		case message.GetDeviceSentMessage().GetMessage() != nil:
+			message = message.GetDeviceSentMessage().GetMessage()
+		case message.GetBotInvokeMessage().GetMessage() != nil:
+			message = message.GetBotInvokeMessage().GetMessage()
+		case message.GetEphemeralMessage().GetMessage() != nil:
+			message = message.GetEphemeralMessage().GetMessage()
+		case message.GetLottieStickerMessage().GetMessage() != nil:
+			message = message.GetLottieStickerMessage().GetMessage()
+		case message.GetDocumentWithCaptionMessage().GetMessage() != nil:
+			message = message.GetDocumentWithCaptionMessage().GetMessage()
+		case message.GetEditedMessage().GetMessage() != nil:
+			message = message.GetEditedMessage().GetMessage()
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/whatsrust/lib/view_once_test.go
+++ b/whatsrust/lib/view_once_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+)
+
+func TestViewOnceWrappersBecomeUnavailablePlaceholders(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		wrap func(*waE2E.Message) *waE2E.Message
+	}{
+		{"v1", func(message *waE2E.Message) *waE2E.Message {
+			return &waE2E.Message{ViewOnceMessage: &waE2E.FutureProofMessage{Message: message}}
+		}},
+		{"v2", func(message *waE2E.Message) *waE2E.Message {
+			return &waE2E.Message{ViewOnceMessageV2: &waE2E.FutureProofMessage{Message: message}}
+		}},
+		{"v2 extension", func(message *waE2E.Message) *waE2E.Message {
+			return &waE2E.Message{ViewOnceMessageV2Extension: &waE2E.FutureProofMessage{Message: message}}
+		}},
+		{"ephemeral v2", func(message *waE2E.Message) *waE2E.Message {
+			return &waE2E.Message{EphemeralMessage: &waE2E.FutureProofMessage{Message: &waE2E.Message{ViewOnceMessageV2: &waE2E.FutureProofMessage{Message: message}}}}
+		}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			wrapped := testCase.wrap(&waE2E.Message{ImageMessage: &waE2E.ImageMessage{Caption: stringPointer("private media")}})
+			placeholder, unavailable := unavailableViewOnceMessage(wrapped)
+			if !unavailable {
+				t.Fatal("view-once wrapper must be unavailable")
+			}
+			if got := placeholder.GetConversation(); got != viewOnceUnavailablePlaceholder {
+				t.Fatalf("placeholder = %q, want %q", got, viewOnceUnavailablePlaceholder)
+			}
+			if placeholder.GetImageMessage() != nil || placeholder.GetVideoMessage() != nil {
+				t.Fatal("view-once media must not reach the public message model")
+			}
+		})
+	}
+}
+
+func TestOrdinaryAndEphemeralMessagesRemainAvailable(t *testing.T) {
+	ordinary := &waE2E.Message{Conversation: stringPointer("ordinary")}
+	if got, unavailable := unavailableViewOnceMessage(ordinary); unavailable || got != ordinary {
+		t.Fatal("ordinary message must remain unchanged")
+	}
+	ephemeral := &waE2E.Message{EphemeralMessage: &waE2E.FutureProofMessage{Message: ordinary}}
+	if got, unavailable := unavailableViewOnceMessage(ephemeral); unavailable || got != ephemeral {
+		t.Fatal("ephemeral message must remain unchanged")
+	}
+}


### PR DESCRIPTION
## Summary

- Extract view-once wrapper detection and unavailable-message sanitization from the Go bridge composition root.
- Preserve existing message semantics and cgo-facing behavior.
- Keep the change to one single-responsibility refactoring unit.

## Changes

- Move view-once sanitization into `whatsrust/lib/view_once.go`.
- Move the focused view-once tests into `whatsrust/lib/view_once_test.go`.
- Remove the extracted implementation and tests from `main.go` and `main_test.go`.

## Testing

- [x] Focused view-once tests: `go test ./... -run 'Test(ViewOnce|OrdinaryAndEphemeral)' -count=1`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt` check
- [x] `git diff --check`
- [x] Independent verification found no ABI/semantic changes, duplicate symbols, or broken references.
- [x] No Cargo/Rust or race tests run; this unit is limited to the Go bridge.

## Chain context

This is the child PR of #105, targeting `refactor/go-forwarding-state`. It continues the chained Go bridge refactor with exactly one responsibility: extracting view-once sanitization. It does not modify forwarding state or unrelated bridge behavior.

Closes #112