### PR TITLE
fix(notifications): suppress alerts for the open chat

### DIFF
--- a/src/app/message_ingestion.rs
+++ b/src/app/message_ingestion.rs
@@ -83,7 +83,7 @@ impl App<'_> {
     }
 
     fn should_notify(&self, message: &wr::Message) -> bool {
-        notification_eligibility(message)
+        notification_eligibility(message, self.open_chat.as_ref())
     }
 }
 

--- a/src/app/notifications.rs
+++ b/src/app/notifications.rs
@@ -45,8 +45,10 @@ impl Notifier for NotifyRustNotifier {
     }
 }
 
-pub(crate) fn notification_eligibility(message: &wr::Message) -> bool {
-    !message.info.is_from_me && message.info.chat.0.as_ref() != STATUS_BROADCAST_CHAT
+pub(crate) fn notification_eligibility(message: &wr::Message, open_chat: Option<&wr::JID>) -> bool {
+    !message.info.is_from_me
+        && message.info.chat.0.as_ref() != STATUS_BROADCAST_CHAT
+        && open_chat != Some(&message.info.chat)
 }
 
 pub(crate) fn notification_is_muted(found: bool, muted_until: i64, now: i64) -> bool {

--- a/src/app/notifications/tests.rs
+++ b/src/app/notifications/tests.rs
@@ -21,15 +21,32 @@ fn message(chat: &str, text: &str) -> wr::Message {
 
 #[test]
 fn eligibility_skips_status_and_own_messages() {
-    assert!(notification_eligibility(&message("chat@g.us", "incoming")));
+    assert!(notification_eligibility(
+        &message("chat@g.us", "incoming"),
+        None
+    ));
 
     let mut own = message("chat@g.us", "own");
     own.info.is_from_me = true;
-    assert!(!notification_eligibility(&own));
-    assert!(!notification_eligibility(&message(
-        STATUS_BROADCAST_CHAT,
-        "status"
-    )));
+    assert!(!notification_eligibility(&own, None));
+    assert!(!notification_eligibility(
+        &message(STATUS_BROADCAST_CHAT, "status"),
+        None
+    ));
+}
+
+#[test]
+fn eligibility_suppresses_only_the_open_chat() {
+    let open_chat = wr::JID::from("open@g.us".to_owned());
+    let highlighted_chat = message("highlighted@g.us", "incoming");
+    let open_message = message("open@g.us", "incoming");
+
+    assert!(notification_eligibility(&highlighted_chat, None));
+    assert!(!notification_eligibility(&open_message, Some(&open_chat)));
+    assert!(notification_eligibility(
+        &message("other@g.us", "incoming"),
+        Some(&open_chat)
+    ));
 }
 
 #[test]

--- a/src/app/notifications/tests.rs
+++ b/src/app/notifications/tests.rs
@@ -41,7 +41,10 @@ fn eligibility_suppresses_only_the_open_chat() {
     let highlighted_chat = message("highlighted@g.us", "incoming");
     let open_message = message("open@g.us", "incoming");
 
-    assert!(notification_eligibility(&highlighted_chat, None));
+    assert!(notification_eligibility(
+        &highlighted_chat,
+        Some(&open_chat)
+    ));
     assert!(!notification_eligibility(&open_message, Some(&open_chat)));
     assert!(notification_eligibility(
         &message("other@g.us", "incoming"),


### PR DESCRIPTION
## Summary

- Suppress redundant desktop notifications for messages in the conversation currently rendered by the TUI.
- Keep notifications enabled for other chats, including a highlighted chat that is not actually open.
- Preserve existing suppression for own messages and status broadcasts.

## Architecture

- Extend the extracted notification policy instead of reintroducing business logic into `src/app.rs`.
- Keep message ingestion responsible only for passing the current open-chat context to the policy.

## Testing

- [x] Notification policy tests: 5 passed
- [x] Full Rust suite: 385 passed
- [x] `cargo fmt --all --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`

Closes #111