### PR TITLE
fix(ui): align community chat rows

### DIFF
--- a/src/app/chat_navigation.rs
+++ b/src/app/chat_navigation.rs
@@ -22,14 +22,13 @@ impl App<'_> {
         }
     }
 
-    pub(crate) fn update_filtered_chats(&mut self) {
+    pub(crate) fn update_filtered_chats(&mut self, selected: Option<wr::JID>) {
         self.filtered_chats = self
             .visible_chat_rows()
             .into_iter()
             .map(|row| row.target)
             .collect();
-        self.chat_list_state
-            .select((!self.filtered_chats.is_empty()).then_some(0));
+        self.select_chat(selected);
     }
 
     pub(crate) fn handle_chat_search_key(&mut self, key: Key) {
@@ -45,12 +44,14 @@ impl App<'_> {
                 self.dispatch_action(AppAction::OpenChat);
             }
             KeyCode::Char(character) => {
+                let selected = self.get_selected_chat();
                 self.contact_search.enter_char(character);
-                self.update_filtered_chats();
+                self.update_filtered_chats(selected);
             }
             KeyCode::Backspace => {
+                let selected = self.get_selected_chat();
                 self.contact_search.delete_char();
-                self.update_filtered_chats();
+                self.update_filtered_chats(selected);
             }
             KeyCode::Left => self.contact_search.move_cursor_left(),
             KeyCode::Right => self.contact_search.move_cursor_right(),
@@ -127,11 +128,7 @@ impl App<'_> {
     }
 
     fn clamp_chat_selection(&mut self) {
-        let count = if self.contact_search.input.is_empty() {
-            self.visible_chat_rows().len()
-        } else {
-            self.filtered_chats.len()
-        };
+        let count = self.visible_chat_rows().len();
         clamp_list_state(&mut self.chat_list_state, count);
     }
 

--- a/src/app/chat_projection/tests.rs
+++ b/src/app/chat_projection/tests.rs
@@ -56,3 +56,66 @@ fn selected_chat_follows_the_visible_row_target() {
 
     assert_eq!(app.get_selected_chat(), Some(chat));
 }
+
+#[test]
+fn community_row_aggregates_groups_and_opens_the_selected_target() {
+    let mut app = TestApp::new();
+    let first = jid("first@g.us");
+    let second = jid("second@g.us");
+    let normal = jid("normal@s.whatsapp.net");
+
+    for (chat, timestamp) in [(&first, 10), (&second, 20), (&normal, 5)] {
+        app.chats.insert(
+            chat.clone(),
+            Chat {
+                jid: chat.clone(),
+                last_message_time: Some(timestamp),
+            },
+        );
+    }
+    app.sorted_chats = vec![first.clone(), second.clone(), normal.clone()];
+    app.communities = vec![CommunityNode {
+        jid: jid("community@g.us"),
+        name: "Project Team".into(),
+        is_root: true,
+        linked_groups: vec![first, second.clone()],
+    }];
+
+    let rows = app.visible_chat_rows();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].label, "Project Team");
+    assert_eq!(rows[0].members, vec![jid("first@g.us"), second.clone()]);
+    assert_eq!(rows[0].target, second.clone());
+    assert_eq!(rows[1].label, "normal@s.whatsapp.net");
+
+    app.chat_list_state.select(Some(0));
+    app.open_selected_chat();
+    assert_eq!(app.open_chat(), Some(second));
+}
+
+#[test]
+fn community_search_matches_linked_group_contact_names() {
+    let mut app = TestApp::new();
+    let group = jid("group@g.us");
+    app.contacts
+        .insert(group.clone(), "Engineering Alerts".into());
+    app.chats.insert(
+        group.clone(),
+        Chat {
+            jid: group.clone(),
+            last_message_time: Some(1),
+        },
+    );
+    app.sorted_chats = vec![group];
+    app.communities = vec![CommunityNode {
+        jid: jid("community@g.us"),
+        name: "Project Team".into(),
+        is_root: true,
+        linked_groups: vec![jid("group@g.us")],
+    }];
+    app.contact_search.input = "engineering".into();
+
+    let rows = app.visible_chat_rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].label, "Project Team");
+}

--- a/src/ui/contacts.rs
+++ b/src/ui/contacts.rs
@@ -16,14 +16,14 @@ use ratatui::{
 use ratatui_image::StatefulImage;
 
 pub(super) fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let chats = if app.contact_search.input.is_empty() {
-        app.sorted_chats.clone()
-    } else {
-        app.filtered_chats.clone()
-    };
-    let items = chats
+    let rows = app.visible_chat_rows();
+    let targets = rows
         .iter()
-        .map(|chat| ContactListItem::from_chat(app, chat))
+        .map(|row| row.target.clone())
+        .collect::<Vec<_>>();
+    let items = rows
+        .iter()
+        .map(|row| ContactListItem::from_row(app, row))
         .collect::<Vec<_>>();
 
     let mut list_area = area;
@@ -67,11 +67,11 @@ pub(super) fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
     let visible = contact_visible_range(
         app.chat_list_state.offset(),
         contacts_area.height,
-        chats.len(),
+        rows.len(),
     );
     app.contact_avatars.schedule(
         prioritized_avatar_requests(
-            &chats,
+            &targets,
             app.chat_list_state.selected(),
             visible.start,
             visible.len(),
@@ -93,7 +93,7 @@ pub(super) fn render_contacts(frame: &mut Frame, app: &mut App, area: Rect) {
         // Partial Kitty placements can leave terminal artifacts after a scroll.
         if avatar_area.width == AVATAR_WIDTH
             && avatar_area.height == AVATAR_HEIGHT
-            && let Some(protocol) = app.contact_avatars.protocol_mut(&chats[index])
+            && let Some(protocol) = app.contact_avatars.protocol_mut(&targets[index])
         {
             StatefulImage::default().render(avatar_area, frame.buffer_mut(), protocol);
         }

--- a/tests/contact_list_rows.rs
+++ b/tests/contact_list_rows.rs
@@ -7,8 +7,11 @@ use ratatui::{
     widgets::{ListState, StatefulWidget},
 };
 use whatsrust::{JID, Message, MessageContent, MessageInfo};
-use wp_tui::app::actions::{PaneVisibility, Section};
 use wp_tui::app::contact_avatars::prioritized_avatar_requests;
+use wp_tui::app::{
+    Chat, CommunityNode,
+    actions::{PaneVisibility, Section},
+};
 use wp_tui::ui::{
     self,
     contact_list::{
@@ -152,6 +155,51 @@ fn search_list_renders_the_same_two_row_item_and_preserves_its_selection() {
     assert!(rows.iter().any(|row| row.contains("Visible Contact")));
     assert!(rows.iter().any(|row| row.contains("preview")));
     assert!(!rows.iter().any(|row| row.contains("Hidden Contact")));
+}
+
+#[test]
+fn chats_render_one_aggregated_community_row_and_one_normal_chat_row() {
+    let mut app = TestApp::new();
+    app.selected_section = Section::Chats;
+    let first = JID::from("first@g.us".to_owned());
+    let second = JID::from("second@g.us".to_owned());
+    let normal = JID::from("normal@s.whatsapp.net".to_owned());
+    app.contacts.insert(normal.clone(), "Normal Contact".into());
+    for chat in [&first, &second, &normal] {
+        app.chats.insert(
+            chat.clone(),
+            Chat {
+                jid: chat.clone(),
+                last_message_time: Some(if *chat == second { 20 } else { 10 }),
+            },
+        );
+    }
+    app.sorted_chats = vec![first, second, normal];
+    app.communities = vec![CommunityNode {
+        jid: JID::from("community@g.us".to_owned()),
+        name: "Project Team".into(),
+        is_root: true,
+        linked_groups: vec![
+            JID::from("first@g.us".to_owned()),
+            JID::from("second@g.us".to_owned()),
+        ],
+    }];
+
+    let mut terminal = Terminal::new(TestBackend::new(100, 10)).unwrap();
+    terminal.draw(|frame| ui::draw(frame, &mut app)).unwrap();
+    let rendered = terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|cell| cell.symbol().to_owned())
+        .collect::<String>();
+
+    assert_eq!(app.visible_chat_rows().len(), 2);
+    assert_eq!(rendered.matches("Project Team").count(), 1);
+    assert!(!rendered.contains("first@g.us"));
+    assert!(!rendered.contains("second@g.us"));
+    assert!(rendered.contains("Normal Contact"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Render one aggregated Chats row per community instead of displaying its linked groups as separate visual rows.
- Keep rendering, search, avatars, selection, and opening aligned to the same `ChatRow` projection.
- Preserve child-group navigation in the dedicated Communities section.

## Root cause

The contact list rendered raw `sorted_chats`, while navigation resolved the selected index through aggregated `visible_chat_rows()`. When a community contained multiple groups, the visual and logical row indices diverged and selecting one row opened another contact.

## Changes

- Render contact items directly from projected Chat rows.
- Use each row target as the deterministic avatar identity.
- Preserve selected-row identity through search updates.
- Add projection, search, rendering, and exact-target selection coverage.

## Testing

- [x] Chat projection tests: 4 passed
- [x] Contact row tests: 14 passed
- [x] Full Rust suite: 339 passed
- [x] `cargo fmt --all --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] Manual validation with a real multi-group community

Closes #115