### PR TITLE
refactor(app): extract picker key mapping

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,7 @@ pub mod composer;
 pub mod contact_avatars;
 pub mod download_worker;
 pub mod events;
+pub mod input_mapping;
 pub mod input_reader;
 pub mod inputs;
 pub mod logout;

--- a/src/app/input_mapping.rs
+++ b/src/app/input_mapping.rs
@@ -1,0 +1,87 @@
+use ratatui::crossterm::event::KeyCode;
+
+use crate::app::actions::AppAction;
+use crate::key_handler::Key;
+
+pub(crate) fn attachment_viewer_action(key: &Key) -> Option<AppAction> {
+    Some(match key.code {
+        KeyCode::Char('h') | KeyCode::Left => AppAction::ViewerPrevious,
+        KeyCode::Char('l') | KeyCode::Right => AppAction::ViewerNext,
+        KeyCode::Char('-') => AppAction::ViewerZoomOut,
+        KeyCode::Char('=') => AppAction::ViewerZoomIn,
+        KeyCode::Char('x') => AppAction::ViewerOpenExternal,
+        KeyCode::Esc | KeyCode::Char('q') => AppAction::CloseAttachmentViewer,
+        _ => return None,
+    })
+}
+
+pub(crate) fn url_picker_action(key: &Key) -> Option<AppAction> {
+    Some(match key.code {
+        KeyCode::Char('j') | KeyCode::Down => AppAction::UrlPickerNext,
+        KeyCode::Char('k') | KeyCode::Up => AppAction::UrlPickerPrevious,
+        KeyCode::Enter => AppAction::ConfirmUrlPicker,
+        KeyCode::Esc => AppAction::CancelUrlPicker,
+        _ => return None,
+    })
+}
+
+pub(crate) fn file_picker_search_action(key: &Key) -> Option<AppAction> {
+    Some(match key.code {
+        KeyCode::Backspace => AppAction::FilePickerBackspace,
+        KeyCode::Esc => AppAction::FilePickerEndSearch,
+        KeyCode::Char(character) => AppAction::FilePickerCharacter(character),
+        KeyCode::Enter => AppAction::FilePickerConfirm,
+        _ => return None,
+    })
+}
+
+pub(crate) fn file_picker_navigation_action(key: &Key) -> Option<AppAction> {
+    Some(match key.code {
+        KeyCode::Char('j') | KeyCode::Down => AppAction::FilePickerNext,
+        KeyCode::Char('k') | KeyCode::Up => AppAction::FilePickerPrevious,
+        KeyCode::Char('h') | KeyCode::Left => AppAction::FilePickerParent,
+        KeyCode::Char('l') | KeyCode::Right => AppAction::FilePickerDescend,
+        KeyCode::Char(' ') => AppAction::FilePickerToggle,
+        KeyCode::Char('/') => AppAction::FilePickerEnterSearch,
+        KeyCode::Enter => AppAction::FilePickerConfirm,
+        KeyCode::Backspace => AppAction::FilePickerParent,
+        KeyCode::Esc => AppAction::CancelFilePicker,
+        _ => return None,
+    })
+}
+
+pub(crate) fn share_picker_action(key: &Key) -> Option<AppAction> {
+    Some(match key.code {
+        KeyCode::Char('j') | KeyCode::Down => AppAction::SharePickerNext,
+        KeyCode::Char('k') | KeyCode::Up => AppAction::SharePickerPrevious,
+        KeyCode::Char(' ') => AppAction::ToggleShareRecipient,
+        KeyCode::Enter => AppAction::ConfirmShare,
+        KeyCode::Esc => AppAction::CancelShare,
+        KeyCode::Backspace => AppAction::ShareSearchBackspace,
+        KeyCode::Char(character) => AppAction::ShareSearchCharacter(character),
+        _ => return None,
+    })
+}
+
+pub(crate) fn reaction_picker_action(key: &Key) -> Option<AppAction> {
+    Some(match key.code {
+        KeyCode::Char('h') | KeyCode::Left => AppAction::ReactionPrev,
+        KeyCode::Char('l') | KeyCode::Right => AppAction::ReactionNext,
+        KeyCode::Enter => AppAction::ConfirmReaction,
+        KeyCode::Esc => AppAction::CancelReaction,
+        _ => return None,
+    })
+}
+
+pub(crate) fn message_menu_action(key: &Key) -> Option<AppAction> {
+    Some(match key.code {
+        KeyCode::Char('j') | KeyCode::Down => AppAction::MenuNext,
+        KeyCode::Char('k') | KeyCode::Up => AppAction::MenuPrevious,
+        KeyCode::Enter => AppAction::ConfirmMessageMenu,
+        KeyCode::Esc => AppAction::CancelMessageMenu,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/input_mapping/tests.rs
+++ b/src/app/input_mapping/tests.rs
@@ -1,0 +1,54 @@
+use super::*;
+use ratatui::crossterm::event::KeyCode;
+
+fn key(code: KeyCode) -> Key {
+    Key::k(code)
+}
+
+#[test]
+fn maps_picker_navigation_and_controls() {
+    assert_eq!(
+        url_picker_action(&key(KeyCode::Down)),
+        Some(AppAction::UrlPickerNext)
+    );
+    assert_eq!(
+        file_picker_navigation_action(&key(KeyCode::Char('h'))),
+        Some(AppAction::FilePickerParent)
+    );
+    assert_eq!(
+        reaction_picker_action(&key(KeyCode::Enter)),
+        Some(AppAction::ConfirmReaction)
+    );
+    assert_eq!(
+        message_menu_action(&key(KeyCode::Esc)),
+        Some(AppAction::CancelMessageMenu)
+    );
+}
+
+#[test]
+fn maps_picker_search_and_viewer_keys() {
+    assert_eq!(
+        file_picker_search_action(&key(KeyCode::Char('x'))),
+        Some(AppAction::FilePickerCharacter('x'))
+    );
+    assert_eq!(
+        share_picker_action(&key(KeyCode::Backspace)),
+        Some(AppAction::ShareSearchBackspace)
+    );
+    assert_eq!(
+        attachment_viewer_action(&key(KeyCode::Char('l'))),
+        Some(AppAction::ViewerNext)
+    );
+}
+
+#[test]
+fn ignores_keys_outside_each_picker_context() {
+    let unknown = key(KeyCode::Tab);
+    assert_eq!(attachment_viewer_action(&unknown), None);
+    assert_eq!(url_picker_action(&unknown), None);
+    assert_eq!(file_picker_search_action(&unknown), None);
+    assert_eq!(file_picker_navigation_action(&unknown), None);
+    assert_eq!(share_picker_action(&unknown), None);
+    assert_eq!(reaction_picker_action(&unknown), None);
+    assert_eq!(message_menu_action(&unknown), None);
+}

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -8,6 +8,10 @@ use std::path::Path;
 
 use crate::app::App;
 use crate::app::composer::{Composer, ComposerOutcome};
+use crate::app::input_mapping::{
+    attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
+    message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
+};
 use crate::clipboard::{self, ClipboardError, ClipboardPaste};
 use crate::file_picker::FilePickerState;
 use crate::key_handler::Key;
@@ -58,76 +62,45 @@ impl App<'_> {
                     self.dispatch_composer_action(composer_action_for_editing_key(&key));
                 }
             } else if self.attachment_viewer.is_some() {
-                self.dispatch_action(match key.code {
-                    KeyCode::Char('h') | KeyCode::Left => AppAction::ViewerPrevious,
-                    KeyCode::Char('l') | KeyCode::Right => AppAction::ViewerNext,
-                    KeyCode::Char('-') => AppAction::ViewerZoomOut,
-                    KeyCode::Char('=') => AppAction::ViewerZoomIn,
-                    KeyCode::Char('x') => AppAction::ViewerOpenExternal,
-                    KeyCode::Esc | KeyCode::Char('q') => AppAction::CloseAttachmentViewer,
-                    _ => return,
-                });
+                let Some(action) = attachment_viewer_action(&key) else {
+                    return;
+                };
+                self.dispatch_action(action);
             } else if self.url_picker.is_some() {
-                self.dispatch_action(match key.code {
-                    KeyCode::Char('j') | KeyCode::Down => AppAction::UrlPickerNext,
-                    KeyCode::Char('k') | KeyCode::Up => AppAction::UrlPickerPrevious,
-                    KeyCode::Enter => AppAction::ConfirmUrlPicker,
-                    KeyCode::Esc => AppAction::CancelUrlPicker,
-                    _ => return,
-                });
+                let Some(action) = url_picker_action(&key) else {
+                    return;
+                };
+                self.dispatch_action(action);
             } else if self.file_picker.is_some() && self.file_picker.as_ref().unwrap().searching {
                 // Search mode: the keyboard buffer owns every key except the
                 // explicit exits, so `h/j/k/l` build the filter instead of
                 // moving. Esc leaves search mode back to navigation.
-                self.dispatch_action(match key.code {
-                    KeyCode::Backspace => AppAction::FilePickerBackspace,
-                    KeyCode::Esc => AppAction::FilePickerEndSearch,
-                    KeyCode::Char(character) => AppAction::FilePickerCharacter(character),
-                    KeyCode::Enter => AppAction::FilePickerConfirm,
-                    _ => return,
-                });
+                let Some(action) = file_picker_search_action(&key) else {
+                    return;
+                };
+                self.dispatch_action(action);
             } else if self.file_picker.is_some() {
                 // Navigation mode. `h/l` move across the tree, `Enter` commits
                 // (files under the cursor, or every `Space`-selected file).
-                self.dispatch_action(match key.code {
-                    KeyCode::Char('j') | KeyCode::Down => AppAction::FilePickerNext,
-                    KeyCode::Char('k') | KeyCode::Up => AppAction::FilePickerPrevious,
-                    KeyCode::Char('h') | KeyCode::Left => AppAction::FilePickerParent,
-                    KeyCode::Char('l') | KeyCode::Right => AppAction::FilePickerDescend,
-                    KeyCode::Char(' ') => AppAction::FilePickerToggle,
-                    KeyCode::Char('/') => AppAction::FilePickerEnterSearch,
-                    KeyCode::Enter => AppAction::FilePickerConfirm,
-                    KeyCode::Backspace => AppAction::FilePickerParent,
-                    KeyCode::Esc => AppAction::CancelFilePicker,
-                    _ => return,
-                });
+                let Some(action) = file_picker_navigation_action(&key) else {
+                    return;
+                };
+                self.dispatch_action(action);
             } else if self.share_picker.is_some() {
-                self.dispatch_action(match key.code {
-                    KeyCode::Char('j') | KeyCode::Down => AppAction::SharePickerNext,
-                    KeyCode::Char('k') | KeyCode::Up => AppAction::SharePickerPrevious,
-                    KeyCode::Char(' ') => AppAction::ToggleShareRecipient,
-                    KeyCode::Enter => AppAction::ConfirmShare,
-                    KeyCode::Esc => AppAction::CancelShare,
-                    KeyCode::Backspace => AppAction::ShareSearchBackspace,
-                    KeyCode::Char(character) => AppAction::ShareSearchCharacter(character),
-                    _ => return,
-                });
+                let Some(action) = share_picker_action(&key) else {
+                    return;
+                };
+                self.dispatch_action(action);
             } else if self.reaction_picker.is_some() {
-                self.dispatch_action(match key.code {
-                    KeyCode::Char('h') | KeyCode::Left => AppAction::ReactionPrev,
-                    KeyCode::Char('l') | KeyCode::Right => AppAction::ReactionNext,
-                    KeyCode::Enter => AppAction::ConfirmReaction,
-                    KeyCode::Esc => AppAction::CancelReaction,
-                    _ => return,
-                });
+                let Some(action) = reaction_picker_action(&key) else {
+                    return;
+                };
+                self.dispatch_action(action);
             } else if self.message_menu.is_some() {
-                self.dispatch_action(match key.code {
-                    KeyCode::Char('j') | KeyCode::Down => AppAction::MenuNext,
-                    KeyCode::Char('k') | KeyCode::Up => AppAction::MenuPrevious,
-                    KeyCode::Enter => AppAction::ConfirmMessageMenu,
-                    KeyCode::Esc => AppAction::CancelMessageMenu,
-                    _ => return,
-                });
+                let Some(action) = message_menu_action(&key) else {
+                    return;
+                };
+                self.dispatch_action(action);
             } else if self.focus_pane == FocusPane::Conversation
                 && self.selected_section == Section::Status
             {


### PR DESCRIPTION
## Summary
- Extract pure picker and modal key-to-`AppAction` translations from the terminal input router.
- Preserve all existing bindings and keep `AppAction` as the stable action vocabulary.
- Add focused unit tests beside the extracted mapping module.

## Changes
- `src/app/input_mapping.rs`: owns picker key mapping functions.
- `src/app/input_mapping/tests.rs`: covers navigation, controls, search, viewer, and unknown-key behavior.
- `src/app/inputs.rs`: delegates picker contexts to the mapping module.
- `src/app.rs`: registers the module.

## Testing
- [x] `CARGO_TARGET_DIR=... cargo fmt --all`
- [x] `CARGO_TARGET_DIR=... cargo test -- --test-threads=1`
- [x] `CARGO_TARGET_DIR=... cargo fmt --all --check`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] Manual testing: not applicable; behavior-preserving refactor.

Closes #119