### PR TITLE
refactor(app): extract composer input mapping

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ pub mod chat_store;
 pub mod community_bridge;
 pub mod community_hierarchy;
 pub mod composer;
+pub mod composer_input_mapping;
 pub mod contact_avatars;
 pub mod download_worker;
 pub mod events;

--- a/src/app/composer_input_mapping.rs
+++ b/src/app/composer_input_mapping.rs
@@ -1,0 +1,45 @@
+use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+
+use crate::app::actions::ComposerAction;
+use crate::key_handler::Key;
+
+/// Maps a key pressed while editing the composer to its semantic action.
+pub fn composer_action_for_editing_key(key: &Key) -> ComposerAction {
+    match (key.code, key.modifiers) {
+        (KeyCode::Enter, KeyModifiers::NONE) => ComposerAction::Submit,
+        (KeyCode::Char('v'), KeyModifiers::CONTROL) => ComposerAction::Paste,
+        _ => ComposerAction::Edit(key.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+
+    use super::*;
+
+    #[test]
+    fn maps_submit_and_paste_keys() {
+        assert_eq!(
+            composer_action_for_editing_key(&Key::k(KeyCode::Enter)),
+            ComposerAction::Submit
+        );
+        assert_eq!(
+            composer_action_for_editing_key(&Key::ctrl('v')),
+            ComposerAction::Paste
+        );
+    }
+
+    #[test]
+    fn preserves_other_editing_keys() {
+        let key = Key {
+            code: KeyCode::Char('V'),
+            modifiers: KeyModifiers::SHIFT,
+        };
+
+        assert_eq!(
+            composer_action_for_editing_key(&key),
+            ComposerAction::Edit(key)
+        );
+    }
+}

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use crate::app::App;
 use crate::app::composer::{Composer, ComposerOutcome};
+pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
 use crate::app::input_mapping::{
     attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
     message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
@@ -1232,12 +1233,4 @@ fn message_urls(message: &wr::Message) -> Vec<String> {
     };
     text.map(crate::url::extract_openable_urls)
         .unwrap_or_default()
-}
-
-pub fn composer_action_for_editing_key(key: &Key) -> ComposerAction {
-    match (key.code, key.modifiers) {
-        (KeyCode::Enter, KeyModifiers::NONE) => ComposerAction::Submit,
-        (KeyCode::Char('v'), KeyModifiers::CONTROL) => ComposerAction::Paste,
-        _ => ComposerAction::Edit(key.clone()),
-    }
 }


### PR DESCRIPTION
## Summary
- Extract the pure composer editing key-to-`ComposerAction` translation from `src/app/inputs.rs`.
- Preserve the public `inputs::composer_action_for_editing_key` compatibility path and all existing behavior.
- Add colocated unit tests for submit, paste, and ordinary editing keys.

## Changes
- `src/app/composer_input_mapping.rs`: owns composer editing key translation and focused tests.
- `src/app/inputs.rs`: re-exports the existing helper while keeping the terminal router unchanged.
- `src/app.rs`: registers the extracted module.

## Testing
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test composer_input_mapping -- --test-threads=1`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -- --test-threads=1`
- [x] No Go verification required; the Go boundary was not changed.
- [x] No functional behavior changed.

Closes #121