### PR TITLE
refactor(bridge): extract web message metadata parsing

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -202,7 +202,6 @@ import (
 
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
-	"go.mau.fi/whatsmeow/proto/waWeb"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
@@ -542,32 +541,6 @@ func C_SetPresenceHandler(callback C.PresenceHandlerCallback, data unsafe.Pointe
 		callback:  callback,
 		user_data: data,
 	}
-}
-
-func ParseWebMessageInfo(selfJid types.JID, chatJid types.JID, webMsg *waWeb.WebMessageInfo) *types.MessageInfo {
-	info := types.MessageInfo{
-		MessageSource: types.MessageSource{
-			Chat:     chatJid,
-			IsFromMe: webMsg.GetKey().GetFromMe(),
-			IsGroup:  chatJid.Server == types.GroupServer,
-		},
-		ID:        webMsg.GetKey().GetID(),
-		PushName:  webMsg.GetPushName(),
-		Timestamp: time.Unix(int64(webMsg.GetMessageTimestamp()), 0),
-	}
-	if info.IsFromMe {
-		info.Sender = selfJid.ToNonAD()
-	} else if webMsg.GetParticipant() != "" {
-		info.Sender, _ = types.ParseJID(webMsg.GetParticipant())
-	} else if webMsg.GetKey().GetParticipant() != "" {
-		info.Sender, _ = types.ParseJID(webMsg.GetKey().GetParticipant())
-	} else {
-		info.Sender = chatJid
-	}
-	if info.Sender.IsEmpty() {
-		return nil
-	}
-	return &info
 }
 
 const (

--- a/whatsrust/lib/web_message_info.go
+++ b/whatsrust/lib/web_message_info.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"time"
+
+	"go.mau.fi/whatsmeow/proto/waWeb"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// ParseWebMessageInfo maps a WhatsApp Web message envelope into the bridge's
+// normalized message metadata while preserving the sender precedence used by
+// the history and live-message paths.
+func ParseWebMessageInfo(selfJid types.JID, chatJid types.JID, webMsg *waWeb.WebMessageInfo) *types.MessageInfo {
+	info := types.MessageInfo{
+		MessageSource: types.MessageSource{
+			Chat:     chatJid,
+			IsFromMe: webMsg.GetKey().GetFromMe(),
+			IsGroup:  chatJid.Server == types.GroupServer,
+		},
+		ID:        webMsg.GetKey().GetID(),
+		PushName:  webMsg.GetPushName(),
+		Timestamp: time.Unix(int64(webMsg.GetMessageTimestamp()), 0),
+	}
+	if info.IsFromMe {
+		info.Sender = selfJid.ToNonAD()
+	} else if webMsg.GetParticipant() != "" {
+		info.Sender, _ = types.ParseJID(webMsg.GetParticipant())
+	} else if webMsg.GetKey().GetParticipant() != "" {
+		info.Sender, _ = types.ParseJID(webMsg.GetKey().GetParticipant())
+	} else {
+		info.Sender = chatJid
+	}
+	if info.Sender.IsEmpty() {
+		return nil
+	}
+	return &info
+}

--- a/whatsrust/lib/web_message_info_test.go
+++ b/whatsrust/lib/web_message_info_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waWeb"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestParseWebMessageInfoPreservesMetadataAndSenderPrecedence(t *testing.T) {
+	self := types.NewJID("self", types.DefaultUserServer)
+	chat := types.NewJID("group", types.GroupServer)
+	cases := []struct {
+		name        string
+		fromMe      bool
+		participant string
+		keySender   string
+		wantSender  types.JID
+	}{
+		{name: "from me uses self", fromMe: true, participant: "other@s.whatsapp.net", keySender: "key@s.whatsapp.net", wantSender: self},
+		{name: "envelope participant wins", participant: "envelope@s.whatsapp.net", keySender: "key@s.whatsapp.net", wantSender: types.NewJID("envelope", types.DefaultUserServer)},
+		{name: "key participant is fallback", keySender: "key@s.whatsapp.net", wantSender: types.NewJID("key", types.DefaultUserServer)},
+		{name: "chat is final fallback", wantSender: chat},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			message := &waWeb.WebMessageInfo{
+				Key:              &waCommon.MessageKey{FromMe: &testCase.fromMe, Participant: stringPointer(testCase.keySender), ID: stringPointer("message-id")},
+				Participant:      stringPointer(testCase.participant),
+				PushName:         stringPointer("Push Name"),
+				MessageTimestamp: uint64Pointer(42),
+			}
+			got := ParseWebMessageInfo(self, chat, message)
+			if got == nil || got.Sender != testCase.wantSender || got.Chat != chat || got.ID != "message-id" || got.PushName != "Push Name" || !got.IsGroup || !got.Timestamp.Equal(time.Unix(42, 0)) {
+				t.Fatalf("parsed info = %#v, want sender %s and preserved metadata", got, testCase.wantSender)
+			}
+		})
+	}
+}
+
+func uint64Pointer(value uint64) *uint64 { return &value }
+
+func TestParseWebMessageInfoRejectsAnUnusableSender(t *testing.T) {
+	message := &waWeb.WebMessageInfo{Key: &waCommon.MessageKey{ID: stringPointer("message-id")}}
+	if got := ParseWebMessageInfo(types.JID{}, types.JID{}, message); got != nil {
+		t.Fatalf("parsed info = %#v, want nil for empty sender", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract the WhatsApp Web message metadata parser from the bridge composition file.
- Keep sender precedence, metadata mapping, and the existing Go signature unchanged.
- This keeps the next modularization unit cohesive and bounded; see #125.

## Changes

- Added `whatsrust/lib/web_message_info.go` with `ParseWebMessageInfo`.
- Added colocated sender-precedence and invalid-sender regression tests in `whatsrust/lib/web_message_info_test.go`.
- Removed the extracted implementation and unused import from `whatsrust/lib/main.go`.

## Testing

- [x] `cd whatsrust/lib && go test ./... -run '^TestParseWebMessageInfo' -count=1`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `gofmt` applied to changed Go files.
- [x] `git diff --check`
- [ ] Cargo checks: not run; Go-only responsibility and user guard.
- [ ] Race tests: not run by instruction.
- [ ] CI: not awaited after PR creation by instruction.

Closes #125