### PR TITLE
refactor(app): extract composer clipboard paste handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,7 @@ pub mod community_bridge;
 pub mod community_hierarchy;
 pub mod composer;
 pub mod composer_input_mapping;
+pub mod composer_input_paste;
 pub mod contact_avatars;
 pub mod download_worker;
 pub mod events;

--- a/src/app/composer_input_paste.rs
+++ b/src/app/composer_input_paste.rs
@@ -1,0 +1,112 @@
+use std::path::Path;
+
+use crate::app::composer::Composer;
+use crate::clipboard::{self, ClipboardError, ClipboardPaste};
+
+/// Applies a clipboard payload to the composer without changing existing text or attachments.
+pub fn apply_clipboard_paste(
+    composer: &mut Composer<'_>,
+    media_path: &Path,
+    paste: Result<ClipboardPaste, ClipboardError>,
+) -> Result<(), ClipboardError> {
+    match paste? {
+        ClipboardPaste::Text(text) => composer.insert_text(&text),
+        ClipboardPaste::Paths(paths) => {
+            for path in paths {
+                let kind = clipboard::file_kind(&path);
+                composer.queue_attachment(path.to_string_lossy().into_owned().into(), kind);
+            }
+        }
+        ClipboardPaste::Png(png) => {
+            let path = clipboard::persist_png(media_path, &png)?;
+            composer.queue_attachment(
+                path.to_string_lossy().into_owned().into(),
+                whatsrust::FileKind::Image,
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn applies_text_without_replacing_existing_composer_content() {
+        let mut composer = Composer::default();
+        composer.insert_text("draft ");
+
+        apply_clipboard_paste(
+            &mut composer,
+            Path::new("/unused"),
+            Ok(ClipboardPaste::Text("message".into())),
+        )
+        .unwrap();
+
+        assert_eq!(composer.text(), "draft message");
+    }
+
+    #[test]
+    fn queues_paths_with_their_detected_file_kind() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("image.png");
+        fs::write(&path, []).unwrap();
+        let mut composer = Composer::default();
+
+        apply_clipboard_paste(
+            &mut composer,
+            directory.path(),
+            Ok(ClipboardPaste::Paths(vec![path.clone()])),
+        )
+        .unwrap();
+
+        assert_eq!(composer.pending.len(), 1);
+        assert_eq!(composer.pending[0].path.as_ref(), path.to_string_lossy());
+        assert!(matches!(
+            composer.pending[0].kind,
+            whatsrust::FileKind::Image
+        ));
+    }
+
+    #[test]
+    fn persists_png_payloads_as_image_attachments() {
+        let directory = tempdir().unwrap();
+        let mut composer = Composer::default();
+
+        apply_clipboard_paste(
+            &mut composer,
+            directory.path(),
+            Ok(ClipboardPaste::Png(vec![1, 2, 3])),
+        )
+        .unwrap();
+
+        assert_eq!(composer.pending.len(), 1);
+        assert!(composer.pending[0].path.ends_with(".png"));
+        assert!(matches!(
+            composer.pending[0].kind,
+            whatsrust::FileKind::Image
+        ));
+    }
+
+    #[test]
+    fn clipboard_errors_leave_composer_state_unchanged() {
+        let mut composer = Composer::default();
+        composer.insert_text("draft message");
+        composer.queue_attachment("existing.pdf".into(), whatsrust::FileKind::Document);
+
+        let result = apply_clipboard_paste(
+            &mut composer,
+            Path::new("/unused"),
+            Err(ClipboardError::EmptyText),
+        );
+
+        assert_eq!(result, Err(ClipboardError::EmptyText));
+        assert_eq!(composer.text(), "draft message");
+        assert_eq!(composer.pending.len(), 1);
+    }
+}

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -7,13 +7,13 @@ use crate::app::actions::{
 use std::path::Path;
 
 use crate::app::App;
-use crate::app::composer::{Composer, ComposerOutcome};
+use crate::app::composer::ComposerOutcome;
 pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
+pub use crate::app::composer_input_paste::apply_clipboard_paste;
 use crate::app::input_mapping::{
     attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
     message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
 };
-use crate::clipboard::{self, ClipboardError, ClipboardPaste};
 use crate::file_picker::FilePickerState;
 use crate::key_handler::Key;
 use whatsrust as wr;
@@ -1200,30 +1200,6 @@ mod tests {
             assert!(!status_view_allows(&blocked), "{blocked:?} must be blocked");
         }
     }
-}
-
-pub fn apply_clipboard_paste(
-    composer: &mut Composer<'_>,
-    media_path: &Path,
-    paste: Result<ClipboardPaste, ClipboardError>,
-) -> Result<(), ClipboardError> {
-    match paste? {
-        ClipboardPaste::Text(text) => composer.insert_text(&text),
-        ClipboardPaste::Paths(paths) => {
-            for path in paths {
-                let kind = clipboard::file_kind(&path);
-                composer.queue_attachment(path.to_string_lossy().into_owned().into(), kind);
-            }
-        }
-        ClipboardPaste::Png(png) => {
-            let path = clipboard::persist_png(media_path, &png)?;
-            composer.queue_attachment(
-                path.to_string_lossy().into_owned().into(),
-                whatsrust::FileKind::Image,
-            );
-        }
-    }
-    Ok(())
 }
 
 fn message_urls(message: &wr::Message) -> Vec<String> {


### PR DESCRIPTION
## Summary
- Extract the composer clipboard payload application pipeline from `src/app/inputs.rs`.
- Preserve the public `inputs::apply_clipboard_paste` compatibility path and existing behavior.
- Add focused colocated tests for text, file paths, PNG payloads, and error preservation.

## Changes
- `src/app/composer_input_paste.rs`: owns clipboard payload application and unit tests.
- `src/app/inputs.rs`: re-exports the helper while keeping terminal routing unchanged.
- `src/app.rs`: registers the extracted module.

## Testing
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test composer_input_paste -- --test-threads=1`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -- --test-threads=1`
- [x] No Go verification required; the Go boundary was not changed.
- [x] No functional behavior changed.

Closes #127