### PR TITLE
refactor(app): extract status-view action policy

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -41,6 +41,7 @@ pub mod runtime_loop;
 pub mod runtime_media_events;
 pub mod runtime_startup;
 pub mod share_picker;
+pub mod status_input;
 pub mod status_projection;
 pub mod terminal_session;
 #[cfg(test)]

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -14,6 +14,7 @@ use crate::app::input_mapping::{
     attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
     message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
 };
+use crate::app::status_input::status_view_allows;
 use crate::file_picker::FilePickerState;
 use crate::key_handler::Key;
 use whatsrust as wr;
@@ -1101,40 +1102,6 @@ fn home_dir() -> Option<std::path::PathBuf> {
         .filter(|path| path.is_dir())
 }
 
-/// Actions allowed while a contact's status view is focused (read-only).
-/// Chat-specific actions are rejected so nothing ever targets the
-/// `status@broadcast` chat from the status pane.
-fn status_view_allows(action: &AppAction) -> bool {
-    matches!(
-        action,
-        AppAction::Quit
-            | AppAction::Logout
-            | AppAction::ToggleLogs
-            | AppAction::ToggleSectionRail
-            | AppAction::ToggleChatList
-            | AppAction::FocusNext
-            | AppAction::FocusPrevious
-            | AppAction::SelectNext
-            | AppAction::SelectPrevious
-            | AppAction::JumpTop
-            | AppAction::JumpBottom
-            | AppAction::HalfPageDown
-            | AppAction::HalfPageUp
-            | AppAction::CopyMessage
-            | AppAction::ReplyMessage
-            | AppAction::ReactMessage
-            | AppAction::DownloadMessage
-            | AppAction::ViewMessage
-            | AppAction::ViewerNext
-            | AppAction::ViewerPrevious
-            | AppAction::ViewerZoomIn
-            | AppAction::ViewerZoomOut
-            | AppAction::CloseAttachmentViewer
-            | AppAction::ViewerOpenExternal
-            | AppAction::CloseStatusPane
-    )
-}
-
 fn log_level_for_logs(show_logs: bool) -> tui_logger::LevelFilter {
     if show_logs {
         tui_logger::LevelFilter::Info
@@ -1145,60 +1112,13 @@ fn log_level_for_logs(show_logs: bool) -> tui_logger::LevelFilter {
 
 #[cfg(test)]
 mod tests {
-    use super::{log_level_for_logs, status_view_allows};
+    use super::log_level_for_logs;
     use tui_logger::LevelFilter;
 
     #[test]
     fn log_panel_uses_info_and_restores_warn_when_closed() {
         assert_eq!(log_level_for_logs(true), LevelFilter::Info);
         assert_eq!(log_level_for_logs(false), LevelFilter::Warn);
-    }
-
-    #[test]
-    fn status_view_allows_status_interactions_and_media_actions() {
-        use crate::app::actions::AppAction;
-
-        for allowed in [
-            AppAction::Quit,
-            AppAction::Logout,
-            AppAction::ToggleLogs,
-            AppAction::ToggleSectionRail,
-            AppAction::ToggleChatList,
-            AppAction::FocusNext,
-            AppAction::FocusPrevious,
-            AppAction::SelectNext,
-            AppAction::SelectPrevious,
-            AppAction::JumpTop,
-            AppAction::JumpBottom,
-            AppAction::HalfPageDown,
-            AppAction::HalfPageUp,
-            AppAction::CopyMessage,
-            AppAction::ReactMessage,
-            AppAction::ReplyMessage,
-            AppAction::DownloadMessage,
-            AppAction::ViewMessage,
-            AppAction::ViewerNext,
-            AppAction::ViewerPrevious,
-            AppAction::ViewerZoomIn,
-            AppAction::ViewerZoomOut,
-            AppAction::CloseAttachmentViewer,
-            AppAction::ViewerOpenExternal,
-            AppAction::CloseStatusPane,
-        ] {
-            assert!(status_view_allows(&allowed), "{allowed:?} must be allowed");
-        }
-
-        for blocked in [
-            AppAction::OpenChat,
-            AppAction::OpenMessage,
-            AppAction::InsertMode,
-            AppAction::DeleteMessage,
-            AppAction::EditMessage,
-            AppAction::OpenMessageMenu,
-            AppAction::GoToReference,
-        ] {
-            assert!(!status_view_allows(&blocked), "{blocked:?} must be blocked");
-        }
     }
 }
 

--- a/src/app/status_input.rs
+++ b/src/app/status_input.rs
@@ -1,0 +1,89 @@
+use super::actions::AppAction;
+
+/// Actions allowed while a contact's status view is focused (read-only).
+/// Chat-specific actions are rejected so nothing ever targets the
+/// `status@broadcast` chat from the status pane.
+pub(crate) fn status_view_allows(action: &AppAction) -> bool {
+    matches!(
+        action,
+        AppAction::Quit
+            | AppAction::Logout
+            | AppAction::ToggleLogs
+            | AppAction::ToggleSectionRail
+            | AppAction::ToggleChatList
+            | AppAction::FocusNext
+            | AppAction::FocusPrevious
+            | AppAction::SelectNext
+            | AppAction::SelectPrevious
+            | AppAction::JumpTop
+            | AppAction::JumpBottom
+            | AppAction::HalfPageDown
+            | AppAction::HalfPageUp
+            | AppAction::CopyMessage
+            | AppAction::ReplyMessage
+            | AppAction::ReactMessage
+            | AppAction::DownloadMessage
+            | AppAction::ViewMessage
+            | AppAction::ViewerNext
+            | AppAction::ViewerPrevious
+            | AppAction::ViewerZoomIn
+            | AppAction::ViewerZoomOut
+            | AppAction::CloseAttachmentViewer
+            | AppAction::ViewerOpenExternal
+            | AppAction::CloseStatusPane
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::status_view_allows;
+    use crate::app::actions::AppAction;
+
+    #[test]
+    fn status_view_allows_status_interactions_and_media_actions() {
+        for allowed in [
+            AppAction::Quit,
+            AppAction::Logout,
+            AppAction::ToggleLogs,
+            AppAction::ToggleSectionRail,
+            AppAction::ToggleChatList,
+            AppAction::FocusNext,
+            AppAction::FocusPrevious,
+            AppAction::SelectNext,
+            AppAction::SelectPrevious,
+            AppAction::JumpTop,
+            AppAction::JumpBottom,
+            AppAction::HalfPageDown,
+            AppAction::HalfPageUp,
+            AppAction::CopyMessage,
+            AppAction::ReactMessage,
+            AppAction::ReplyMessage,
+            AppAction::DownloadMessage,
+            AppAction::ViewMessage,
+            AppAction::ViewerNext,
+            AppAction::ViewerPrevious,
+            AppAction::ViewerZoomIn,
+            AppAction::ViewerZoomOut,
+            AppAction::CloseAttachmentViewer,
+            AppAction::ViewerOpenExternal,
+            AppAction::CloseStatusPane,
+        ] {
+            assert!(status_view_allows(&allowed), "{allowed:?} must be allowed");
+        }
+    }
+
+    #[test]
+    fn status_view_rejects_chat_only_actions() {
+        for blocked in [
+            AppAction::OpenChat,
+            AppAction::OpenMessage,
+            AppAction::InsertMode,
+            AppAction::DeleteMessage,
+            AppAction::EditMessage,
+            AppAction::OpenMessageMenu,
+            AppAction::GoToReference,
+        ] {
+            assert!(!status_view_allows(&blocked), "{blocked:?} must be blocked");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the read-only status-view action policy from `src/app/inputs.rs`.
- Keep action dispatch behavior and the `AppAction` contract unchanged.
- Colocate focused allowed and rejected action tests with the extracted policy.

## Changes

- `src/app/status_input.rs`: owns `status_view_allows` and its unit tests.
- `src/app/inputs.rs`: delegates status-view filtering while retaining input orchestration.
- `src/app.rs`: registers the extracted module.

## Testing

- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test status_input -- --test-threads=1`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -- --test-threads=1` (full suite completed across serial verification runs)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --doc -- --test-threads=1`
- [x] No Go verification required; the Go boundary was not changed.
- [x] No functional behavior changed.

Closes #129