### PR TITLE
refactor(app): extract message opening from inputs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,7 @@ pub mod message_action_diagnostics;
 pub mod message_actions;
 pub mod message_ingestion;
 pub mod message_navigation;
+pub mod message_opening;
 pub mod notifications;
 pub mod presence;
 pub mod presence_bridge;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -1,12 +1,10 @@
 use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 
+use crate::app::App;
 use crate::app::actions::{
     AppAction, COMMON_REACTIONS, ComposerAction, ConversationMode, FocusPane, Section,
     SequenceResolution, focus_after, focus_after_visibility_change,
 };
-use std::path::Path;
-
-use crate::app::App;
 use crate::app::composer::ComposerOutcome;
 pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
 pub use crate::app::composer_input_paste::apply_clipboard_paste;
@@ -17,6 +15,7 @@ use crate::app::input_mapping::{
 use crate::app::status_input::status_view_allows;
 use crate::file_picker::FilePickerState;
 use crate::key_handler::Key;
+use std::path::Path;
 use whatsrust as wr;
 
 impl App<'_> {
@@ -331,99 +330,9 @@ impl App<'_> {
         ));
     }
 
-    fn selected_message_is_deleted(&self) -> bool {
+    pub(crate) fn selected_message_is_deleted(&self) -> bool {
         self.selected_message()
             .is_some_and(|message| self.message_status(&message.info.id).deleted)
-    }
-
-    fn open_selected_url(&mut self) {
-        if self.selected_message_is_deleted() {
-            return self.unavailable("This message was deleted.");
-        }
-        let urls = self
-            .selected_message()
-            .map(message_urls)
-            .unwrap_or_default();
-        match urls.len() {
-            0 => self.open_selected_document(),
-            1 => self.launch_url(&urls[0]),
-            _ => self.url_picker = Some((urls, 0)),
-        }
-    }
-
-    fn open_selected_document(&mut self) {
-        let Some(message) = self.selected_message() else {
-            return self.unavailable("Open is not available");
-        };
-        let wr::MessageContent::File(file) = &message.message else {
-            return self.unavailable("Open is not available");
-        };
-        if !matches!(file.kind, wr::FileKind::Document) {
-            return self.unavailable("Open is not available");
-        }
-        if !matches!(
-            self.metadata.get(&message.info.id),
-            Some(crate::app::Metadata::File(
-                crate::app::FileMeta::Downloaded | crate::app::FileMeta::Loaded
-            ))
-        ) {
-            return self.unavailable("Media is not downloaded");
-        }
-        let opener =
-            match crate::media::document_opener_from_environment(Path::new(file.path.as_ref())) {
-                Ok(opener) => opener,
-                Err(_) => {
-                    return self.unavailable(
-                        "Set WPTUI_PDF_VIEWER or WPTUI_DOCUMENT_VIEWER to one executable name",
-                    );
-                }
-            };
-        match crate::media::plan_media_launch(
-            Some(&self.media_path),
-            Some(&opener),
-            Some(Path::new(file.path.as_ref())),
-        ) {
-            Ok(Some(plan)) => {
-                match crate::media::execute_launch(&plan, &mut crate::media::CommandLaunchExecutor)
-                {
-                    Ok(()) => {
-                        self.action_notice = Some(crate::app::actions::ActionNotice::Unavailable(
-                            "Document viewer started".into(),
-                        ))
-                    }
-                    Err(error) => {
-                        self.unavailable(&format!("Could not start document viewer: {error:?}"))
-                    }
-                }
-            }
-            Ok(None) | Err(_) => self.unavailable("Media launch is unavailable"),
-        }
-    }
-
-    fn move_url_picker(&mut self, delta: isize) {
-        if let Some((urls, selected)) = &mut self.url_picker {
-            *selected = selected
-                .saturating_add_signed(delta)
-                .min(urls.len().saturating_sub(1));
-        }
-    }
-
-    fn confirm_url_picker(&mut self) {
-        let Some((urls, selected)) = self.url_picker.take() else {
-            return;
-        };
-        if let Some(url) = urls.get(selected) {
-            self.launch_url(url);
-        } else {
-            self.unavailable("Open is not available");
-        }
-    }
-
-    fn launch_url(&mut self, url: &str) {
-        let plan = crate::url::url_launch_plan(url);
-        if self.url_opener.open(&plan).is_err() {
-            self.unavailable("Could not open URL");
-        }
     }
 
     fn open_file_picker(&mut self) {
@@ -1120,13 +1029,4 @@ mod tests {
         assert_eq!(log_level_for_logs(true), LevelFilter::Info);
         assert_eq!(log_level_for_logs(false), LevelFilter::Warn);
     }
-}
-
-fn message_urls(message: &wr::Message) -> Vec<String> {
-    let text = match &message.message {
-        wr::MessageContent::Text(text) => Some(text.as_ref()),
-        wr::MessageContent::File(file) => file.caption.as_deref(),
-    };
-    text.map(crate::url::extract_openable_urls)
-        .unwrap_or_default()
 }

--- a/src/app/message_opening.rs
+++ b/src/app/message_opening.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+use super::App;
+use whatsrust as wr;
+
+impl App<'_> {
+    pub(crate) fn open_selected_url(&mut self) {
+        if self.selected_message_is_deleted() {
+            return self.unavailable("This message was deleted.");
+        }
+        let urls = self
+            .selected_message()
+            .map(message_urls)
+            .unwrap_or_default();
+        match urls.len() {
+            0 => self.open_selected_document(),
+            1 => self.launch_url(&urls[0]),
+            _ => self.url_picker = Some((urls, 0)),
+        }
+    }
+
+    fn open_selected_document(&mut self) {
+        let Some(message) = self.selected_message() else {
+            return self.unavailable("Open is not available");
+        };
+        let wr::MessageContent::File(file) = &message.message else {
+            return self.unavailable("Open is not available");
+        };
+        if !matches!(file.kind, wr::FileKind::Document) {
+            return self.unavailable("Open is not available");
+        }
+        if !matches!(
+            self.metadata.get(&message.info.id),
+            Some(crate::app::Metadata::File(
+                crate::app::FileMeta::Downloaded | crate::app::FileMeta::Loaded
+            ))
+        ) {
+            return self.unavailable("Media is not downloaded");
+        }
+        let opener =
+            match crate::media::document_opener_from_environment(Path::new(file.path.as_ref())) {
+                Ok(opener) => opener,
+                Err(_) => {
+                    return self.unavailable(
+                        "Set WPTUI_PDF_VIEWER or WPTUI_DOCUMENT_VIEWER to one executable name",
+                    );
+                }
+            };
+        match crate::media::plan_media_launch(
+            Some(&self.media_path),
+            Some(&opener),
+            Some(Path::new(file.path.as_ref())),
+        ) {
+            Ok(Some(plan)) => {
+                match crate::media::execute_launch(&plan, &mut crate::media::CommandLaunchExecutor)
+                {
+                    Ok(()) => {
+                        self.action_notice = Some(crate::app::actions::ActionNotice::Unavailable(
+                            "Document viewer started".into(),
+                        ))
+                    }
+                    Err(error) => {
+                        self.unavailable(&format!("Could not start document viewer: {error:?}"))
+                    }
+                }
+            }
+            Ok(None) | Err(_) => self.unavailable("Media launch is unavailable"),
+        }
+    }
+
+    pub(crate) fn move_url_picker(&mut self, delta: isize) {
+        if let Some((urls, selected)) = &mut self.url_picker {
+            *selected = selected
+                .saturating_add_signed(delta)
+                .min(urls.len().saturating_sub(1));
+        }
+    }
+
+    pub(crate) fn confirm_url_picker(&mut self) {
+        let Some((urls, selected)) = self.url_picker.take() else {
+            return;
+        };
+        if let Some(url) = urls.get(selected) {
+            self.launch_url(url);
+        } else {
+            self.unavailable("Open is not available");
+        }
+    }
+
+    fn launch_url(&mut self, url: &str) {
+        let plan = crate::url::url_launch_plan(url);
+        if self.url_opener.open(&plan).is_err() {
+            self.unavailable("Could not open URL");
+        }
+    }
+}
+
+fn message_urls(message: &wr::Message) -> Vec<String> {
+    let text = match &message.message {
+        wr::MessageContent::Text(text) => Some(text.as_ref()),
+        wr::MessageContent::File(file) => file.caption.as_deref(),
+    };
+    text.map(crate::url::extract_openable_urls)
+        .unwrap_or_default()
+}


### PR DESCRIPTION
## Summary

- Extract selected-message URL and document opening into `src/app/message_opening.rs`.
- Keep URL picker navigation, document-launch notices, and `AppAction` dispatch behavior unchanged.
- Retain the existing `tests/open_message.rs` coverage for the extracted responsibility.

## Changes

- `src/app/message_opening.rs`: owns URL extraction, URL picker transitions, URL launching, and document opening.
- `src/app/inputs.rs`: keeps input orchestration and delegates message-opening actions.
- `src/app.rs`: registers the extracted module.

## Testing

- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --test open_message -- --test-threads=1` (9 passed)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -- --test-threads=1` (started serially; local command exceeded the 300-second tool timeout after passing 161 unit tests and multiple integration targets; focused suite passed)
- [x] No Go verification required; the Go boundary was not changed.
- [x] No functional behavior changed.

Closes #134