### PR TITLE
refactor(bridge): extract message content census

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -949,47 +949,6 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	}
 }
 
-func msgContentTypes(msg *waE2E.Message) string {
-	if msg == nil {
-		return "nil"
-	}
-	parts := make([]string, 0, 8)
-	if msg.Conversation != nil {
-		parts = append(parts, "conversation")
-	}
-	if msg.ExtendedTextMessage != nil {
-		parts = append(parts, "extended_text")
-	}
-	if msg.ProtocolMessage != nil {
-		pm := msg.ProtocolMessage
-		s := "protocol"
-		if pm.GetEditedMessage() != nil {
-			s += "+edited"
-		}
-		parts = append(parts, s)
-	}
-	if msg.EditedMessage != nil {
-		s := "edited"
-		if em := msg.EditedMessage.GetMessage(); em != nil {
-			s += "+inner"
-			if em.Conversation != nil {
-				s += "_conv"
-			}
-			if em.ExtendedTextMessage != nil {
-				s += "_ext"
-			}
-		}
-		parts = append(parts, s)
-	}
-	if msg.ReactionMessage != nil {
-		parts = append(parts, "reaction")
-	}
-	if len(parts) == 0 {
-		return "empty"
-	}
-	return strings.Join(parts, ",")
-}
-
 // messageActionEventFromIncomingMessage also supports whatsmeow's normalized edit
 // event: UnwrapRaw has already replaced Message with the edited body and Info.ID
 // with the target ID. IsEdit is the library's explicit discriminator, so normal

--- a/whatsrust/lib/message_content_census.go
+++ b/whatsrust/lib/message_content_census.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+)
+
+func msgContentTypes(msg *waE2E.Message) string {
+	if msg == nil {
+		return "nil"
+	}
+	parts := make([]string, 0, 8)
+	if msg.Conversation != nil {
+		parts = append(parts, "conversation")
+	}
+	if msg.ExtendedTextMessage != nil {
+		parts = append(parts, "extended_text")
+	}
+	if msg.ProtocolMessage != nil {
+		pm := msg.ProtocolMessage
+		s := "protocol"
+		if pm.GetEditedMessage() != nil {
+			s += "+edited"
+		}
+		parts = append(parts, s)
+	}
+	if msg.EditedMessage != nil {
+		s := "edited"
+		if em := msg.EditedMessage.GetMessage(); em != nil {
+			s += "+inner"
+			if em.Conversation != nil {
+				s += "_conv"
+			}
+			if em.ExtendedTextMessage != nil {
+				s += "_ext"
+			}
+		}
+		parts = append(parts, s)
+	}
+	if msg.ReactionMessage != nil {
+		parts = append(parts, "reaction")
+	}
+	if len(parts) == 0 {
+		return "empty"
+	}
+	return strings.Join(parts, ",")
+}

--- a/whatsrust/lib/message_content_census_test.go
+++ b/whatsrust/lib/message_content_census_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+)
+
+func TestMessageContentTypesClassifiesMessageShapes(t *testing.T) {
+	text := "text"
+	tests := []struct {
+		name string
+		msg  *waE2E.Message
+		want string
+	}{
+		{name: "nil", want: "nil"},
+		{name: "empty", msg: &waE2E.Message{}, want: "empty"},
+		{
+			name: "ordinary text shapes",
+			msg:  &waE2E.Message{Conversation: &text, ExtendedTextMessage: &waE2E.ExtendedTextMessage{}},
+			want: "conversation,extended_text",
+		},
+		{
+			name: "protocol edit",
+			msg:  &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{EditedMessage: &waE2E.Message{}}},
+			want: "protocol+edited",
+		},
+		{
+			name: "nested edit shapes",
+			msg: &waE2E.Message{EditedMessage: &waE2E.FutureProofMessage{Message: &waE2E.Message{
+				Conversation: &text, ExtendedTextMessage: &waE2E.ExtendedTextMessage{},
+			}}},
+			want: "edited+inner_conv_ext",
+		},
+		{
+			name: "reaction",
+			msg:  &waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{}},
+			want: "reaction",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := msgContentTypes(tt.msg); got != tt.want {
+				t.Fatalf("msgContentTypes() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Move the focused `msgContentTypes` diagnostic formatter out of `whatsrust/lib/main.go`.
- Preserve the existing output used by secret-encrypted edit diagnostics.

## Changes

- Add a dedicated message content census module.
- Add table-driven coverage for nil, empty, text, protocol edit, nested edit, and reaction shapes.
- Keep `main.go` free of this non-ABI diagnostic responsibility.

## Testing

- [x] `gofmt`
- [x] `cd whatsrust/lib && go test ./... -run TestMessageContentTypesClassifiesMessageShapes`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `git diff --check`
- [x] Authored diff: 138 lines including tests.
- [x] No Cargo/Rust, race, merge, or CI commands run.

Closes #147