### PR TITLE
refactor(app): extract share recipient policy

### DIFF
--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -12,6 +12,7 @@ use crate::app::input_mapping::{
     attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
     message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
 };
+use crate::app::share_picker::is_forwardable_recipient;
 use crate::app::status_input::status_view_allows;
 use crate::key_handler::Key;
 use whatsrust as wr;
@@ -349,13 +350,13 @@ impl App<'_> {
         let Some(message) = self.selected_message() else {
             return self.unavailable("Forward is not available");
         };
-        if !forwardable_jid(&message.info.chat) {
+        if !is_forwardable_recipient(&message.info.chat) {
             return self.unavailable("Forward is not available");
         }
         let contacts = self
             .contacts
             .keys()
-            .filter(|jid| forwardable_jid(jid))
+            .filter(|jid| is_forwardable_recipient(jid))
             .cloned()
             .collect();
         let labels = self
@@ -699,10 +700,6 @@ impl App<'_> {
             },
         }
     }
-}
-
-fn forwardable_jid(jid: &wr::JID) -> bool {
-    !jid.0.ends_with("@broadcast") && !jid.0.ends_with("@newsletter")
 }
 
 fn is_toggle_logs_key(key: &Key) -> bool {

--- a/src/app/share_picker.rs
+++ b/src/app/share_picker.rs
@@ -5,6 +5,10 @@ use whatsrust as wr;
 #[cfg(test)]
 mod tests;
 
+pub(crate) fn is_forwardable_recipient(jid: &wr::JID) -> bool {
+    !jid.0.ends_with("@broadcast") && !jid.0.ends_with("@newsletter")
+}
+
 pub struct SharePicker {
     contacts: Vec<wr::JID>,
     labels: HashMap<wr::JID, String>,

--- a/src/app/share_picker/tests.rs
+++ b/src/app/share_picker/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use whatsrust::JID;
 
-use super::SharePicker;
+use super::{SharePicker, is_forwardable_recipient};
 
 fn jid(value: &str) -> JID {
     JID::from(value.to_owned())
@@ -73,4 +73,11 @@ fn search_reset_returns_to_first_visible_row() {
     assert_eq!((picker.selected, picker.offset), (0, 0));
     picker.search_backspace();
     assert_eq!((picker.selected, picker.offset), (0, 0));
+}
+
+#[test]
+fn recipient_policy_excludes_broadcast_and_newsletter_chats() {
+    assert!(is_forwardable_recipient(&jid("alice@s.whatsapp.net")));
+    assert!(!is_forwardable_recipient(&jid("status@broadcast")));
+    assert!(!is_forwardable_recipient(&jid("channel@newsletter")));
 }


### PR DESCRIPTION
## Summary

- Move the share/forward recipient eligibility predicate out of `src/app/inputs.rs` and into the share picker responsibility.
- Add colocated tests for ordinary, broadcast, and newsletter JIDs.
- Preserve `AppAction`, picker behavior, and forwarding contracts without runtime behavior changes.

## Changes

- `src/app/share_picker.rs`: owns `is_forwardable_recipient`.
- `src/app/share_picker/tests.rs`: covers recipient eligibility policy.
- `src/app/inputs.rs`: delegates both source and destination checks to the extracted policy.

## Testing

- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test app::share_picker -- --test-threads=1` (5 passed)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo check --all-targets`
- [x] `git diff --check`
- [x] No runtime harness: Rust-only internal refactor; no user-visible behavior changed.

Closes #148