### PR TITLE
refactor(app): extract reaction picker handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -39,6 +39,7 @@ pub mod notifications;
 pub mod presence;
 pub mod presence_bridge;
 pub mod private_reply;
+pub mod reaction_picker;
 pub mod read_receipts;
 pub mod runtime_callbacks;
 pub mod runtime_loop;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -2,8 +2,8 @@ use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 
 use crate::app::App;
 use crate::app::actions::{
-    AppAction, COMMON_REACTIONS, ComposerAction, ConversationMode, FocusPane, Section,
-    SequenceResolution, focus_after, focus_after_visibility_change,
+    AppAction, ComposerAction, ConversationMode, FocusPane, Section, SequenceResolution,
+    focus_after, focus_after_visibility_change,
 };
 use crate::app::composer::ComposerOutcome;
 pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
@@ -276,13 +276,10 @@ impl App<'_> {
             }
             AppAction::ShareSearchBackspace => self.share_search_backspace(),
             AppAction::ShareSearchCharacter(character) => self.share_search_character(character),
-            AppAction::ReactionPrev => self.move_reaction(-1),
-            AppAction::ReactionNext => self.move_reaction(1),
-            AppAction::ConfirmReaction => self.confirm_reaction(),
-            AppAction::CancelReaction => {
-                self.reaction_picker = None;
-                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
-            }
+            action @ (AppAction::ReactionPrev
+            | AppAction::ReactionNext
+            | AppAction::ConfirmReaction
+            | AppAction::CancelReaction) => self.dispatch_reaction_picker_action(action),
             AppAction::UrlPickerPrevious => self.move_url_picker(-1),
             AppAction::UrlPickerNext => self.move_url_picker(1),
             AppAction::ConfirmUrlPicker => self.confirm_url_picker(),
@@ -392,53 +389,6 @@ impl App<'_> {
             failed: report.failed,
             failure: report.failure,
         });
-    }
-
-    fn open_reaction_picker(&mut self) {
-        if self.selected_message().is_none() {
-            return self.unavailable("Reaction is not available");
-        }
-        self.reaction_picker = Some((
-            COMMON_REACTIONS
-                .iter()
-                .map(|reaction| (*reaction).into())
-                .collect(),
-            0,
-        ));
-    }
-
-    fn move_reaction(&mut self, delta: isize) {
-        if let Some((reactions, selected)) = &mut self.reaction_picker {
-            *selected = selected
-                .saturating_add_signed(delta)
-                .min(reactions.len() - 1);
-        }
-    }
-
-    fn confirm_reaction(&mut self) {
-        let Some((reactions, selected)) = self.reaction_picker.take() else {
-            return;
-        };
-        let Some(reaction) = reactions.get(selected).cloned() else {
-            return;
-        };
-        let Some(message) = self.selected_message().cloned() else {
-            return self.unavailable("Reaction is not available");
-        };
-        if self
-            .message_reactor
-            .react_to_message(
-                &message.info.chat,
-                &message.info.sender,
-                &message.info.id,
-                &reaction,
-            )
-            .is_ok()
-        {
-            self.action_notice = Some(crate::app::actions::ActionNotice::Reacted);
-        } else {
-            self.unavailable("Could not react to message");
-        }
     }
 
     /// Reply from a status: switches to the contact's private chat with

--- a/src/app/reaction_picker.rs
+++ b/src/app/reaction_picker.rs
@@ -1,0 +1,128 @@
+use crate::app::App;
+use crate::app::actions::{ActionNotice, AppAction, COMMON_REACTIONS};
+
+impl App<'_> {
+    pub(crate) fn dispatch_reaction_picker_action(&mut self, action: AppAction) {
+        match action {
+            AppAction::ReactionPrev => self.move_reaction(-1),
+            AppAction::ReactionNext => self.move_reaction(1),
+            AppAction::ConfirmReaction => self.confirm_reaction(),
+            AppAction::CancelReaction => {
+                self.reaction_picker = None;
+                self.action_notice = Some(ActionNotice::Cancelled);
+            }
+            _ => unreachable!("non-reaction-picker action dispatched to reaction picker"),
+        }
+    }
+
+    pub(crate) fn open_reaction_picker(&mut self) {
+        if self.selected_message().is_none() {
+            return self.unavailable("Reaction is not available");
+        }
+        self.reaction_picker = Some((
+            COMMON_REACTIONS
+                .iter()
+                .map(|reaction| (*reaction).into())
+                .collect(),
+            0,
+        ));
+    }
+
+    fn move_reaction(&mut self, delta: isize) {
+        if let Some((reactions, selected)) = &mut self.reaction_picker {
+            *selected = selected
+                .saturating_add_signed(delta)
+                .min(reactions.len() - 1);
+        }
+    }
+
+    fn confirm_reaction(&mut self) {
+        let Some((reactions, selected)) = self.reaction_picker.take() else {
+            return;
+        };
+        let Some(reaction) = reactions.get(selected).cloned() else {
+            return;
+        };
+        let Some(message) = self.selected_message().cloned() else {
+            return self.unavailable("Reaction is not available");
+        };
+        if self
+            .message_reactor
+            .react_to_message(
+                &message.info.chat,
+                &message.info.sender,
+                &message.info.id,
+                &reaction,
+            )
+            .is_ok()
+        {
+            self.action_notice = Some(ActionNotice::Reacted);
+        } else {
+            self.unavailable("Could not react to message");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::actions::ActionNotice;
+    use crate::app::test_support::{TestApp, message};
+    use whatsrust as wr;
+
+    fn selected_app() -> TestApp {
+        let mut app = TestApp::new();
+        let chat = wr::JID::from("chat@example.test".to_owned());
+        let selected = message(&chat, "message", 1);
+        app.add_message(selected);
+        app.message_list_state
+            .set_selected_message("message".into());
+        app
+    }
+
+    #[test]
+    fn opens_with_common_reactions_and_moves_within_bounds() {
+        let mut app = selected_app();
+
+        app.open_reaction_picker();
+        assert_eq!(
+            app.reaction_picker.as_ref().map(|(items, selected)| (
+                items.iter().map(String::as_str).collect::<Vec<_>>(),
+                *selected,
+            )),
+            Some((COMMON_REACTIONS.to_vec(), 0))
+        );
+
+        app.dispatch_reaction_picker_action(AppAction::ReactionNext);
+        app.dispatch_reaction_picker_action(AppAction::ReactionPrev);
+        app.dispatch_reaction_picker_action(AppAction::ReactionPrev);
+        assert_eq!(
+            app.reaction_picker.as_ref().map(|(_, selected)| *selected),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn cancel_clears_picker_and_reports_cancellation() {
+        let mut app = selected_app();
+        app.open_reaction_picker();
+
+        app.dispatch_reaction_picker_action(AppAction::CancelReaction);
+
+        assert!(app.reaction_picker.is_none());
+        assert_eq!(app.action_notice, Some(ActionNotice::Cancelled));
+    }
+
+    #[test]
+    fn opening_without_selection_reports_unavailable_action() {
+        let mut app = TestApp::new();
+
+        app.open_reaction_picker();
+
+        assert!(app.reaction_picker.is_none());
+        assert!(matches!(
+            app.action_notice,
+            Some(ActionNotice::Unavailable(_))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the complete message reaction-picker lifecycle from `src/app/inputs.rs` into a focused `reaction_picker` module.
- Preserve existing keyboard routing, common reactions, cancellation, selection bounds, and reaction dispatch behavior while reducing input-routing SRP pressure.
- Track the unit in #156.

## Changes

- Add `src/app/reaction_picker.rs` with reaction-picker action dispatch and lifecycle methods.
- Add focused tests for opening, bounded movement, cancellation, and unavailable selection behavior.
- Keep status reactions in `inputs.rs` because status reactions have a distinct direct-heart policy.

## Testing

- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test reaction_picker --lib`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo check`
- [ ] CI intentionally not run, per request.
- [ ] Manual UI testing not run; this is a behavior-preserving internal extraction.

Closes #156