### PR TITLE
refactor(bridge): extract media message conversion

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -187,9 +187,7 @@ import "C"
 import (
 	"context"
 	"fmt"
-	"mime"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -200,7 +198,6 @@ import (
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
-	"google.golang.org/protobuf/proto"
 )
 
 var logHandler C.LogHandler
@@ -352,113 +349,6 @@ const (
 	FileTypeDocument
 	FileTypeSticker
 )
-
-type uploadMediaFunc func(context.Context, []byte, whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
-
-// buildFileMessage maps one FFI file payload into its WhatsApp message without
-// requiring a connected client. Keeping upload injectable lets the mapping stay
-// deterministic and testable with fake upload responses.
-func buildFileMessage(ctx context.Context, kind uint8, filePath string, caption *string, contextInfo *waE2E.ContextInfo, upload uploadMediaFunc) (*waE2E.Message, error) {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("read file %s: %w", filePath, err)
-	}
-	mimetype := mime.TypeByExtension(filepath.Ext(filePath))
-
-	uploadedMessage := func(mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
-		uploaded, uploadErr := upload(ctx, data, mediaType)
-		if uploadErr != nil {
-			return whatsmeow.UploadResponse{}, fmt.Errorf("upload file: %w", uploadErr)
-		}
-		return uploaded, nil
-	}
-
-	switch kind {
-	case FileTypeImage:
-		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaImage)
-		if uploadErr != nil {
-			return nil, uploadErr
-		}
-		return &waE2E.Message{ImageMessage: &waE2E.ImageMessage{
-			Caption:       caption,
-			URL:           proto.String(uploaded.URL),
-			DirectPath:    proto.String(uploaded.DirectPath),
-			MediaKey:      uploaded.MediaKey,
-			Mimetype:      proto.String(mimetype),
-			FileEncSHA256: uploaded.FileEncSHA256,
-			FileSHA256:    uploaded.FileSHA256,
-			FileLength:    proto.Uint64(uint64(len(data))),
-			ContextInfo:   contextInfo,
-		}}, nil
-	case FileTypeVideo:
-		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaVideo)
-		if uploadErr != nil {
-			return nil, uploadErr
-		}
-		return &waE2E.Message{VideoMessage: &waE2E.VideoMessage{
-			Caption:       caption,
-			URL:           proto.String(uploaded.URL),
-			DirectPath:    proto.String(uploaded.DirectPath),
-			MediaKey:      uploaded.MediaKey,
-			Mimetype:      proto.String(mimetype),
-			FileEncSHA256: uploaded.FileEncSHA256,
-			FileSHA256:    uploaded.FileSHA256,
-			FileLength:    proto.Uint64(uint64(len(data))),
-			ContextInfo:   contextInfo,
-		}}, nil
-	case FileTypeAudio:
-		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaAudio)
-		if uploadErr != nil {
-			return nil, uploadErr
-		}
-		return &waE2E.Message{AudioMessage: &waE2E.AudioMessage{
-			URL:           proto.String(uploaded.URL),
-			DirectPath:    proto.String(uploaded.DirectPath),
-			MediaKey:      uploaded.MediaKey,
-			Mimetype:      proto.String(mimetype),
-			FileEncSHA256: uploaded.FileEncSHA256,
-			FileSHA256:    uploaded.FileSHA256,
-			FileLength:    proto.Uint64(uint64(len(data))),
-			ContextInfo:   contextInfo,
-		}}, nil
-	case FileTypeDocument:
-		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaDocument)
-		if uploadErr != nil {
-			return nil, uploadErr
-		}
-		fileName := filepath.Base(filePath)
-		return &waE2E.Message{DocumentMessage: &waE2E.DocumentMessage{
-			Caption:       caption,
-			URL:           proto.String(uploaded.URL),
-			DirectPath:    proto.String(uploaded.DirectPath),
-			MediaKey:      uploaded.MediaKey,
-			Mimetype:      proto.String(mimetype),
-			FileEncSHA256: uploaded.FileEncSHA256,
-			FileSHA256:    uploaded.FileSHA256,
-			FileLength:    proto.Uint64(uint64(len(data))),
-			FileName:      proto.String(fileName),
-			ContextInfo:   contextInfo,
-		}}, nil
-	case FileTypeSticker:
-		// WhatsApp stickers use the image media encryption keys.
-		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaImage)
-		if uploadErr != nil {
-			return nil, uploadErr
-		}
-		return &waE2E.Message{StickerMessage: &waE2E.StickerMessage{
-			URL:           proto.String(uploaded.URL),
-			DirectPath:    proto.String(uploaded.DirectPath),
-			MediaKey:      uploaded.MediaKey,
-			Mimetype:      proto.String(mimetype),
-			FileEncSHA256: uploaded.FileEncSHA256,
-			FileSHA256:    uploaded.FileSHA256,
-			FileLength:    proto.Uint64(uint64(len(data))),
-			ContextInfo:   contextInfo,
-		}}, nil
-	default:
-		return nil, fmt.Errorf("unsupported file type: %v", kind)
-	}
-}
 
 func isStatusProtocolContext(context *waE2E.ContextInfo) bool {
 	return context.GetRemoteJID() == "status@broadcast" ||

--- a/whatsrust/lib/media_message_conversion.go
+++ b/whatsrust/lib/media_message_conversion.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
+)
+
+type uploadMediaFunc func(context.Context, []byte, whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
+
+// buildFileMessage maps one FFI file payload into its WhatsApp message without
+// requiring a connected client. Keeping upload injectable lets the mapping stay
+// deterministic and testable with fake upload responses.
+func buildFileMessage(ctx context.Context, kind uint8, filePath string, caption *string, contextInfo *waE2E.ContextInfo, upload uploadMediaFunc) (*waE2E.Message, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("read file %s: %w", filePath, err)
+	}
+	mimetype := mime.TypeByExtension(filepath.Ext(filePath))
+
+	uploadedMessage := func(mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
+		uploaded, uploadErr := upload(ctx, data, mediaType)
+		if uploadErr != nil {
+			return whatsmeow.UploadResponse{}, fmt.Errorf("upload file: %w", uploadErr)
+		}
+		return uploaded, nil
+	}
+
+	switch kind {
+	case FileTypeImage:
+		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaImage)
+		if uploadErr != nil {
+			return nil, uploadErr
+		}
+		return &waE2E.Message{ImageMessage: &waE2E.ImageMessage{
+			Caption:       caption,
+			URL:           proto.String(uploaded.URL),
+			DirectPath:    proto.String(uploaded.DirectPath),
+			MediaKey:      uploaded.MediaKey,
+			Mimetype:      proto.String(mimetype),
+			FileEncSHA256: uploaded.FileEncSHA256,
+			FileSHA256:    uploaded.FileSHA256,
+			FileLength:    proto.Uint64(uint64(len(data))),
+			ContextInfo:   contextInfo,
+		}}, nil
+	case FileTypeVideo:
+		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaVideo)
+		if uploadErr != nil {
+			return nil, uploadErr
+		}
+		return &waE2E.Message{VideoMessage: &waE2E.VideoMessage{
+			Caption:       caption,
+			URL:           proto.String(uploaded.URL),
+			DirectPath:    proto.String(uploaded.DirectPath),
+			MediaKey:      uploaded.MediaKey,
+			Mimetype:      proto.String(mimetype),
+			FileEncSHA256: uploaded.FileEncSHA256,
+			FileSHA256:    uploaded.FileSHA256,
+			FileLength:    proto.Uint64(uint64(len(data))),
+			ContextInfo:   contextInfo,
+		}}, nil
+	case FileTypeAudio:
+		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaAudio)
+		if uploadErr != nil {
+			return nil, uploadErr
+		}
+		return &waE2E.Message{AudioMessage: &waE2E.AudioMessage{
+			URL:           proto.String(uploaded.URL),
+			DirectPath:    proto.String(uploaded.DirectPath),
+			MediaKey:      uploaded.MediaKey,
+			Mimetype:      proto.String(mimetype),
+			FileEncSHA256: uploaded.FileEncSHA256,
+			FileSHA256:    uploaded.FileSHA256,
+			FileLength:    proto.Uint64(uint64(len(data))),
+			ContextInfo:   contextInfo,
+		}}, nil
+	case FileTypeDocument:
+		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaDocument)
+		if uploadErr != nil {
+			return nil, uploadErr
+		}
+		return &waE2E.Message{DocumentMessage: &waE2E.DocumentMessage{
+			Caption:       caption,
+			URL:           proto.String(uploaded.URL),
+			DirectPath:    proto.String(uploaded.DirectPath),
+			MediaKey:      uploaded.MediaKey,
+			Mimetype:      proto.String(mimetype),
+			FileEncSHA256: uploaded.FileEncSHA256,
+			FileSHA256:    uploaded.FileSHA256,
+			FileLength:    proto.Uint64(uint64(len(data))),
+			FileName:      proto.String(filepath.Base(filePath)),
+			ContextInfo:   contextInfo,
+		}}, nil
+	case FileTypeSticker:
+		// WhatsApp stickers use the image media encryption keys.
+		uploaded, uploadErr := uploadedMessage(whatsmeow.MediaImage)
+		if uploadErr != nil {
+			return nil, uploadErr
+		}
+		return &waE2E.Message{StickerMessage: &waE2E.StickerMessage{
+			URL:           proto.String(uploaded.URL),
+			DirectPath:    proto.String(uploaded.DirectPath),
+			MediaKey:      uploaded.MediaKey,
+			Mimetype:      proto.String(mimetype),
+			FileEncSHA256: uploaded.FileEncSHA256,
+			FileSHA256:    uploaded.FileSHA256,
+			FileLength:    proto.Uint64(uint64(len(data))),
+			ContextInfo:   contextInfo,
+		}}, nil
+	default:
+		return nil, fmt.Errorf("unsupported file type: %v", kind)
+	}
+}

--- a/whatsrust/lib/media_message_conversion_test.go
+++ b/whatsrust/lib/media_message_conversion_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestBuildFileMessageReportsReadFailure(t *testing.T) {
+	_, err := buildFileMessage(context.Background(), FileTypeImage, "missing.bin", nil, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "read file") {
+		t.Fatalf("error = %v, want file-read error", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract the file-payload-to-WhatsApp-message conversion from `whatsrust/lib/main.go` into `media_message_conversion.go`.
- Preserve upload selection, media fields, captions, filenames, errors, and the existing C ABI/behavior.
- Add focused read-failure coverage while retaining the existing media-kind coverage.

## Changes

| File | Change |
|------|--------|
| `whatsrust/lib/main.go` | Remove the media conversion implementation and its imports from the bridge composition file. |
| `whatsrust/lib/media_message_conversion.go` | Own file media conversion and injectable upload mapping. |
| `whatsrust/lib/media_message_conversion_test.go` | Cover conversion read-failure behavior. |

## Verification

- [x] `gofmt`
- [x] Focused Go tests
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] Authored diff: 243 lines, below the 400-line limit.
- [x] No CI checks queried or awaited.
- [x] No Cargo/Rust, race, merge, or ABI changes.

Closes #155