### PR TITLE
refactor(app): extract status actions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -46,6 +46,7 @@ pub mod runtime_loop;
 pub mod runtime_media_events;
 pub mod runtime_startup;
 pub mod share_picker;
+pub mod status_actions;
 pub mod status_input;
 pub mod status_projection;
 pub mod terminal_session;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -391,46 +391,6 @@ impl App<'_> {
         });
     }
 
-    /// Reply from a status: switches to the contact's private chat with
-    /// the status quoted, so the answer lands in the inbox (the same flow
-    /// as replying to a status in the WhatsApp mobile app).
-    fn reply_to_status(&mut self) {
-        let Some(message) = self.selected_message().cloned() else {
-            return self.unavailable("Reply is not available");
-        };
-        let contact = message.info.sender.clone();
-        self.selected_section = Section::Chats;
-        self.open_chat = Some(contact.clone());
-        self.sort_chat_messages(contact);
-        self.message_list_state.reset();
-        self.composer.quote = Some(message);
-        self.conversation_mode = ConversationMode::ComposerEditing;
-        self.focus_pane = FocusPane::Conversation;
-    }
-
-    /// Reacts to the selected status with a heart directly, skipping the
-    /// reaction picker (WhatsApp only allows the heart on statuses).
-    fn heart_selected_status(&mut self) {
-        let Some(message) = self.selected_message().cloned() else {
-            return self.unavailable("Reaction is not available");
-        };
-        if self
-            .message_reactor
-            .react_to_message_in_chat(
-                &message.info.chat,
-                &message.info.chat,
-                &message.info.sender,
-                &message.info.id,
-                crate::app::actions::STATUS_REACTION,
-            )
-            .is_ok()
-        {
-            self.action_notice = Some(crate::app::actions::ActionNotice::Reacted);
-        } else {
-            self.unavailable("Could not react to message");
-        }
-    }
-
     fn open_message_menu(&mut self) {
         if self.selected_message_is_deleted() {
             return self.unavailable("This message was deleted.");

--- a/src/app/status_actions.rs
+++ b/src/app/status_actions.rs
@@ -1,0 +1,103 @@
+use crate::app::App;
+use crate::app::actions::{ActionNotice, ConversationMode, FocusPane, STATUS_REACTION, Section};
+
+impl App<'_> {
+    /// Reply from a status: switches to the contact's private chat with
+    /// the status quoted, so the answer lands in the inbox.
+    pub(crate) fn reply_to_status(&mut self) {
+        let Some(message) = self.selected_message().cloned() else {
+            return self.unavailable("Reply is not available");
+        };
+        let contact = message.info.sender.clone();
+        self.selected_section = Section::Chats;
+        self.open_chat = Some(contact.clone());
+        self.sort_chat_messages(contact);
+        self.message_list_state.reset();
+        self.composer.quote = Some(message);
+        self.conversation_mode = ConversationMode::ComposerEditing;
+        self.focus_pane = FocusPane::Conversation;
+    }
+
+    /// Reacts to the selected status with a heart directly. Statuses do not
+    /// open the general reaction picker because WhatsApp only allows the heart.
+    pub(crate) fn heart_selected_status(&mut self) {
+        let Some(message) = self.selected_message().cloned() else {
+            return self.unavailable("Reaction is not available");
+        };
+        if self
+            .message_reactor
+            .react_to_message_in_chat(
+                &message.info.chat,
+                &message.info.chat,
+                &message.info.sender,
+                &message.info.id,
+                STATUS_REACTION,
+            )
+            .is_ok()
+        {
+            self.action_notice = Some(ActionNotice::Reacted);
+        } else {
+            self.unavailable("Could not react to message");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::actions::{ActionNotice, ConversationMode};
+    use crate::app::test_support::TestApp;
+    use whatsrust as wr;
+
+    fn status_message(id: &str) -> wr::Message {
+        wr::Message {
+            info: wr::MessageInfo {
+                id: id.into(),
+                chat: "status@broadcast".to_owned().into(),
+                sender: "alice@s.whatsapp.net".to_owned().into(),
+                timestamp: 100,
+                forwarding: Default::default(),
+                is_from_me: false,
+                quote_id: None,
+                read_by: 0,
+            },
+            message: wr::MessageContent::Text("status".into()),
+        }
+    }
+
+    #[test]
+    fn reply_moves_status_into_the_contact_chat_with_a_quote() {
+        let mut app = TestApp::new();
+        let message = status_message("status-1");
+        let sender = message.info.sender.clone();
+        app.add_message(message);
+        app.message_list_state
+            .set_selected_message("status-1".into());
+
+        app.reply_to_status();
+
+        assert_eq!(app.selected_section, Section::Chats);
+        assert_eq!(app.open_chat(), Some(sender));
+        assert_eq!(app.focus_pane, FocusPane::Conversation);
+        assert_eq!(app.conversation_mode, ConversationMode::ComposerEditing);
+        assert_eq!(
+            app.composer
+                .quote
+                .as_ref()
+                .map(|item| item.info.id.as_ref()),
+            Some("status-1")
+        );
+    }
+
+    #[test]
+    fn reaction_without_a_selected_status_reports_unavailability() {
+        let mut app = TestApp::new();
+
+        app.heart_selected_status();
+
+        assert!(matches!(
+            &app.action_notice,
+            Some(ActionNotice::Unavailable(message)) if message == "Reaction is not available"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the complete status-action seam from `src/app/inputs.rs` into `src/app/status_actions.rs`.
- Preserve status reply routing, quote setup, direct-heart reaction policy, notices, and dispatcher behavior.
- Continue the inputs modularization chain from PR #157 with a focused, 144-authored-line change.

## Changes

- Add `status_actions` as the single owner of status reply and status reaction lifecycle methods.
- Keep central action routing in `inputs.rs`; no message menu, composer, or chat-search behavior is included.
- Add focused tests for quoted status replies and unavailable status reactions.

## Testing

- [x] `CARGO_TARGET_DIR=<shared-target> cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=<shared-target> cargo test --lib -- --test-threads=1` (169 passed)
- [x] `CARGO_TARGET_DIR=<shared-target> cargo check`
- [x] `git diff --check`
- [ ] CI intentionally not run, per request.
- [ ] Manual UI testing not run; this is a behavior-preserving internal extraction.

Rollback boundary: revert commit `e4998ad` to remove this seam without touching PR #157 or unrelated input modules.

Closes #160