### PR TITLE
refactor(bridge): extract event wiring

### DIFF
--- a/whatsrust/lib/callback_log_registration_test.go
+++ b/whatsrust/lib/callback_log_registration_test.go
@@ -15,6 +15,10 @@ func TestCallbackAndLogRegistrationStaysDedicated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	wiringSource, err := os.ReadFile("event_wiring.go")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, expected := range []string{
 		"func LOG_LEVEL",
@@ -34,7 +38,10 @@ func TestCallbackAndLogRegistrationStaysDedicated(t *testing.T) {
 	if strings.Contains(string(mainSource), "func C_SetEventHandler") {
 		t.Fatal("event callback registration remains in main.go")
 	}
-	if !strings.Contains(string(mainSource), "func AddEventHandlers") {
-		t.Fatal("event wiring was moved with callback registration")
+	if strings.Contains(string(mainSource), "func AddEventHandlers") {
+		t.Fatal("event wiring remains in main.go")
+	}
+	if !strings.Contains(string(wiringSource), "func AddEventHandlers") {
+		t.Fatal("event wiring is not dedicated")
 	}
 }

--- a/whatsrust/lib/connection_events_test.go
+++ b/whatsrust/lib/connection_events_test.go
@@ -27,15 +27,15 @@ func TestConnectionEventDispatchKeepsCallbackGuardAndKinds(t *testing.T) {
 }
 
 func TestConnectionEventDispatchLeavesMainHandlerAsRouter(t *testing.T) {
-	source, err := os.ReadFile("main.go")
+	source, err := os.ReadFile("event_wiring.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	body := string(source)
-	if !strings.Contains(body, "dispatchConnectedEvent,") {
-		t.Fatal("main handler does not delegate connected events")
+	if !strings.Contains(body, "dispatchConnectedEvent") {
+		t.Fatal("event wiring does not delegate connected events")
 	}
 	if strings.Contains(body, "func emitLogoutResult(status uint8)") {
-		t.Fatal("logout result conversion remains in main.go")
+		t.Fatal("logout result conversion remains in event wiring")
 	}
 }

--- a/whatsrust/lib/event_wiring.go
+++ b/whatsrust/lib/event_wiring.go
@@ -1,0 +1,54 @@
+package main
+
+/*
+#include <stdlib.h>
+#include "callback_log_registration.h"
+
+static void callPresenceWiringHandler(PresenceHandler hdl, JID from, bool unavailable, int64_t lastSeen) {
+	hdl.callback(from, unavailable, lastSeen, hdl.user_data);
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func dispatchPresenceCallback(from string, unavailable bool, lastSeen int64) {
+	cFrom := C.CString(from)
+	defer C.free(unsafe.Pointer(cFrom))
+	C.callPresenceWiringHandler(presenceHandler, cFrom, C.bool(unavailable), C.int64_t(lastSeen))
+}
+
+func AddEventHandlers() {
+	client.AddEventHandler(func(rawEvt any) {
+		messageActionCensusDiagnostic(rawEvt)
+		switch evt := rawEvt.(type) {
+		case *events.Connected:
+			handleConnected(client.SendPresence, dispatchConnectedEvent, LOG_WARN)
+		case *events.Presence:
+			dispatchPresenceEvent(evt, client.Store.LIDs.GetPNForLID, rawPresenceProbe.record, rawPresenceProbe.update, dispatchPresenceCallback)
+		case *events.MarkChatAsRead:
+			LOG_DEBUG("MarkChatAsRead %v", evt.JID)
+		case *events.AppStateSyncComplete:
+			dispatchAppStateSyncComplete(evt)
+		case *events.Message:
+			dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage)
+		case *events.Receipt:
+			if receipt, ok := receiptEventFromEvent(evt); ok {
+				LOG_DEBUG("%#v was read by %s at %s", evt.MessageIDs, evt.SourceString(), evt.Timestamp)
+				dispatchReceiptEvent(receipt)
+			}
+		case *events.HistorySync:
+			dispatchHistorySync(evt, client.DangerousInternals().StoreHistoricalMessageSecrets, client.ParseWebMessage, func(parsed *events.Message) {
+				dispatchIncomingMessage(parsed, dispatchMessageActionEvent, func(info types.MessageInfo, message *waE2E.Message, _ bool) {
+					HandleMessage(info, message, true)
+				})
+			})
+		}
+	})
+}

--- a/whatsrust/lib/event_wiring_test.go
+++ b/whatsrust/lib/event_wiring_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEventWiringOwnsRegistrationAndDispatchCases(t *testing.T) {
+	source, err := os.ReadFile("event_wiring.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(source)
+	for _, expected := range []string{
+		"func AddEventHandlers()",
+		"client.AddEventHandler(func(rawEvt any)",
+		"case *events.Connected:",
+		"case *events.Presence:",
+		"case *events.AppStateSyncComplete:",
+		"case *events.Message:",
+		"case *events.Receipt:",
+		"case *events.HistorySync:",
+		"dispatchHistorySync(",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("event wiring missing %q", expected)
+		}
+	}
+}
+
+func TestEventWiringLeavesMainFreeOfRegistration(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(source), "func AddEventHandlers()") {
+		t.Fatal("event registration remains in main.go")
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -643,54 +643,6 @@ func messageActionKindName(kind uint8) string {
 	return "delete"
 }
 
-func AddEventHandlers() {
-	client.AddEventHandler(func(rawEvt any) {
-		messageActionCensusDiagnostic(rawEvt)
-		switch evt := rawEvt.(type) {
-		case *events.Connected:
-			handleConnected(
-				client.SendPresence,
-				dispatchConnectedEvent,
-				LOG_WARN,
-			)
-
-		case *events.Presence:
-			dispatchPresenceEvent(evt, client.Store.LIDs.GetPNForLID, rawPresenceProbe.record, rawPresenceProbe.update, func(from string, unavailable bool, lastSeen int64) {
-				cFrom := C.CString(from)
-				defer C.free(unsafe.Pointer(cFrom))
-				C.callPresenceHandler(presenceHandler, cFrom, C.bool(unavailable), C.int64_t(lastSeen))
-			})
-
-		case *events.MarkChatAsRead:
-			LOG_DEBUG("MarkChatAsRead %v", evt.JID)
-
-		case *events.AppStateSyncComplete:
-			dispatchAppStateSyncComplete(evt)
-
-		case *events.Message:
-			dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage)
-
-		case *events.Receipt:
-			if receipt, ok := receiptEventFromEvent(evt); ok {
-				LOG_DEBUG("%#v was read by %s at %s", evt.MessageIDs, evt.SourceString(), evt.Timestamp)
-				dispatchReceiptEvent(receipt)
-			}
-
-		case *events.HistorySync:
-			dispatchHistorySync(
-				evt,
-				client.DangerousInternals().StoreHistoricalMessageSecrets,
-				client.ParseWebMessage,
-				func(parsed *events.Message) {
-					dispatchIncomingMessage(parsed, dispatchMessageActionEvent, func(info types.MessageInfo, message *waE2E.Message, _ bool) {
-						HandleMessage(info, message, true)
-					})
-				},
-			)
-		}
-	})
-}
-
 //export C_TestEmitPresenceEvent
 func C_TestEmitPresenceEvent(from *C.char, unavailable C.bool, lastSeen C.int64_t) {
 	C.callPresenceHandler(presenceHandler, from, unavailable, lastSeen)

--- a/whatsrust/lib/message_action_dispatch_test.go
+++ b/whatsrust/lib/message_action_dispatch_test.go
@@ -35,15 +35,15 @@ func TestMessageActionDispatchOwnsPayloadInCUntilSynchronousCallbackReturns(t *t
 }
 
 func TestMessageActionDispatchLeavesMessageRouterInMain(t *testing.T) {
-	source, err := os.ReadFile("main.go")
+	source, err := os.ReadFile("event_wiring.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	body := string(source)
 	if !strings.Contains(body, "dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage)") {
-		t.Fatal("incoming message router no longer delegates message action dispatch")
+		t.Fatal("event wiring no longer delegates message action dispatch")
 	}
 	if strings.Contains(body, "func dispatchMessageActionEvent(action messageActionEvent)") {
-		t.Fatal("message action dispatch remains in main.go")
+		t.Fatal("message action dispatch remains in event_wiring.go")
 	}
 }


### PR DESCRIPTION
## Summary
- Extract `AddEventHandlers` and the inseparable presence callback adapter from `whatsrust/lib/main.go`.
- Preserve event ordering, callback routing, C payload ownership, ABI, privacy boundaries, and runtime behavior.
- Keep unrelated bridge operations untouched.

## Changes
| File | Change |
|------|--------|
| `whatsrust/lib/event_wiring.go` | Own event registration and dispatch routing, plus the presence callback adapter. |
| `whatsrust/lib/event_wiring_test.go` | Add focused seam-ownership coverage. |
| `whatsrust/lib/*_test.go` | Keep existing routing-ownership assertions aligned with the extracted seam. |
| `whatsrust/lib/main.go` | Remove only `AddEventHandlers`. |

## Testing
- [x] `gofmt`
- [x] Focused event-wiring tests
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] Authored diff: 110 lines, below the 400-line publication limit
- [x] No CI checks queried or awaited
- [x] No Cargo/Rust, race, merge, or attribution changes

Closes #164