### PR TITLE
refactor(bridge): extract JID conversion

### DIFF
--- a/whatsrust/lib/jid_conversion.go
+++ b/whatsrust/lib/jid_conversion.go
@@ -1,0 +1,23 @@
+package main
+
+/*
+#include "callback_log_registration.h"
+*/
+import "C"
+
+import "go.mau.fi/whatsmeow/types"
+
+// jidToC converts canonical Go JIDs to the stable C bridge representation.
+func jidToC(jid types.JID) C.JID {
+	return C.CString(jid.ToNonAD().String())
+}
+
+// cToJid parses a C bridge JID and preserves the existing panic contract for
+// malformed values.
+func cToJid(cjid C.JID) types.JID {
+	jid, err := types.ParseJID(C.GoString(cjid))
+	if err != nil {
+		panic(err)
+	}
+	return jid
+}

--- a/whatsrust/lib/jid_conversion_test.go
+++ b/whatsrust/lib/jid_conversion_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestJIDConversionOwnsBridgeHelpers(t *testing.T) {
+	source, err := os.ReadFile("jid_conversion.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(source)
+	for _, expected := range []string{
+		"func jidToC(jid types.JID) C.JID",
+		"func cToJid(cjid C.JID) types.JID",
+		"jid.ToNonAD().String()",
+		"types.ParseJID(C.GoString(cjid))",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("JID conversion seam missing %q", expected)
+		}
+	}
+}
+
+func TestJIDConversionLeavesMainFreeOfHelpers(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(source)
+	for _, removed := range []string{
+		"func jidToC(jid types.JID) C.JID",
+		"func cToJid(cjid C.JID) types.JID",
+	} {
+		if strings.Contains(body, removed) {
+			t.Fatalf("JID conversion helper remains in main.go: %q", removed)
+		}
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -195,21 +195,6 @@ func C_GetGroupInfo(cjid C.JID) C.GroupInfoResult {
 	}))
 }
 
-// Convert Go JID to C JID
-func jidToC(jid types.JID) C.JID {
-	return C.CString(jid.ToNonAD().String())
-	// return C.CString(jid.User + "@" + jid.Server)
-}
-
-// Convert C JID to Go JID
-func cToJid(cjid C.JID) types.JID {
-	jid, err := types.ParseJID(C.GoString(cjid))
-	if err != nil {
-		panic(err)
-	}
-	return jid
-}
-
 const (
 	EventTypeSyncProgress         = 0
 	EventTypeAppStateSyncComplete = 1


### PR DESCRIPTION
## Summary

- Extract the cohesive Go↔C JID conversion helpers from `whatsrust/lib/main.go`.
- Preserve canonical non-AD serialization, malformed-input panic behavior, C ABI, and all callers.
- This is the next single SRP seam after PR #165.

## Changes

- Add `whatsrust/lib/jid_conversion.go` for `jidToC` and `cToJid`.
- Add seam-ownership tests proving the helpers are dedicated and absent from `main.go`.
- Remove only the two helper definitions from `main.go`; no wrapper or behavior changes.

## Testing

- [x] `gofmt -w whatsrust/lib/jid_conversion.go whatsrust/lib/jid_conversion_test.go whatsrust/lib/main.go`
- [x] `cd whatsrust/lib && go test -run 'TestJIDConversion' .`\n- [x] `cd whatsrust/lib && go test ./...`\n- [x] `cd whatsrust/lib && go vet ./...`\n- [x] `git diff --check`\n- [x] Authored diff is 64 lines, below the 400-line limit\n- [x] No Cargo/Rust, race, merge, CI, or attribution work performed\n- [x] No manual runtime harness applies; this is an internal pure bridge-helper relocation\n\nCloses #168