### PR TITLE
refactor(app): extract composer integration

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,7 @@ pub mod community_hierarchy;
 pub mod composer;
 pub mod composer_input_mapping;
 pub mod composer_input_paste;
+pub mod composer_integration;
 pub mod contact_avatars;
 pub mod download_worker;
 pub mod events;

--- a/src/app/composer_integration.rs
+++ b/src/app/composer_integration.rs
@@ -1,0 +1,102 @@
+use ratatui::crossterm::event::KeyCode;
+
+use crate::app::App;
+use crate::app::actions::{AppAction, ComposerAction, ConversationMode, FocusPane, Section};
+use crate::app::composer_input_mapping::composer_action_for_editing_key;
+use crate::app::composer_input_paste::apply_clipboard_paste;
+use crate::key_handler::Key;
+use whatsrust as wr;
+
+impl App<'_> {
+    /// Handles the composer-owned part of terminal input.
+    ///
+    /// Returns `true` when the composer owns the current input context.
+    pub(crate) fn handle_composer_input(&mut self, key: Key) -> bool {
+        if self.focus_pane != FocusPane::Conversation
+            || self.selected_section != Section::Chats
+            || !matches!(
+                self.conversation_mode,
+                ConversationMode::ComposerEditing | ConversationMode::EditingMessage
+            )
+        {
+            return false;
+        }
+
+        if key == Key::k(KeyCode::Esc) {
+            if self.conversation_mode == ConversationMode::EditingMessage {
+                self.cancel_message_edit();
+            } else {
+                self.composer.apply(ComposerAction::CancelReply);
+                self.composer.pending.clear();
+                self.conversation_mode = ConversationMode::MessageNavigation;
+            }
+        } else if key == Key::ctrl('o') {
+            self.dispatch_action(AppAction::AttachFile);
+        } else if !self.composer_blocked() {
+            self.dispatch_composer_action(composer_action_for_editing_key(&key));
+        }
+
+        true
+    }
+
+    pub(crate) fn dispatch_composer_action(&mut self, action: ComposerAction) {
+        if self.composer_blocked() {
+            return;
+        }
+        if self.conversation_mode == ConversationMode::EditingMessage
+            && matches!(action, ComposerAction::Submit)
+        {
+            return self.submit_message_edit();
+        }
+        match action {
+            ComposerAction::StartEdit => {
+                // InsertMode is now the canonical way; StartEdit is unused.
+            }
+            ComposerAction::Paste => {
+                let paste = self.clipboard_reader.read_paste();
+                if let Err(error) =
+                    apply_clipboard_paste(&mut self.composer, &self.media_path, paste)
+                {
+                    self.unavailable(&format!("Could not paste clipboard content: {error:?}"));
+                }
+            }
+            action => match self.composer.apply(action) {
+                crate::app::composer::ComposerOutcome::Idle => {}
+                crate::app::composer::ComposerOutcome::Submit { messages, quote } => {
+                    if let Some(chat) = self.open_chat() {
+                        for message in messages {
+                            wr::send_message(&chat, &message, quote.as_ref());
+                        }
+                    }
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_support::TestApp;
+
+    #[test]
+    fn non_composer_context_is_left_for_the_central_router() {
+        let mut app = TestApp::new();
+        assert!(!app.handle_composer_input(Key::c('x')));
+
+        assert_eq!(app.conversation_mode, ConversationMode::MessageNavigation);
+        assert!(app.composer.text().is_empty());
+    }
+
+    #[test]
+    fn composer_context_consumes_blocked_input_without_mutation() {
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::Conversation;
+        app.selected_section = Section::Chats;
+        app.conversation_mode = ConversationMode::ComposerEditing;
+        app.composer.set_blocked(true);
+
+        assert!(app.handle_composer_input(Key::c('x')));
+        assert!(app.composer.text().is_empty());
+    }
+}

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -2,10 +2,9 @@ use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 
 use crate::app::App;
 use crate::app::actions::{
-    AppAction, ComposerAction, ConversationMode, FocusPane, Section, SequenceResolution,
-    focus_after, focus_after_visibility_change,
+    AppAction, ConversationMode, FocusPane, Section, SequenceResolution, focus_after,
+    focus_after_visibility_change,
 };
-use crate::app::composer::ComposerOutcome;
 pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
 pub use crate::app::composer_input_paste::apply_clipboard_paste;
 use crate::app::input_mapping::{
@@ -15,7 +14,6 @@ use crate::app::input_mapping::{
 use crate::app::share_picker::is_forwardable_recipient;
 use crate::app::status_input::status_view_allows;
 use crate::key_handler::Key;
-use whatsrust as wr;
 
 impl App<'_> {
     pub fn on_terminal_event(&mut self, event: Event) {
@@ -39,28 +37,7 @@ impl App<'_> {
 
             if is_toggle_logs_key(&key) {
                 self.dispatch_action(AppAction::ToggleLogs);
-            } else if self.focus_pane == FocusPane::Conversation
-                && self.selected_section == Section::Chats
-                && matches!(
-                    self.conversation_mode,
-                    ConversationMode::ComposerEditing | ConversationMode::EditingMessage
-                )
-            {
-                if key == Key::k(KeyCode::Esc) {
-                    if self.conversation_mode == ConversationMode::EditingMessage {
-                        self.cancel_message_edit();
-                    } else {
-                        self.composer.apply(ComposerAction::CancelReply);
-                        self.composer.pending.clear();
-                        self.conversation_mode = ConversationMode::MessageNavigation;
-                    }
-                } else if is_attach_file_key(&key) {
-                    self.dispatch_action(AppAction::AttachFile);
-                } else if self.composer_blocked() {
-                    return;
-                } else {
-                    self.dispatch_composer_action(composer_action_for_editing_key(&key));
-                }
+            } else if self.handle_composer_input(key.clone()) {
             } else if self.attachment_viewer.is_some() {
                 let Some(action) = attachment_viewer_action(&key) else {
                     return;
@@ -390,49 +367,11 @@ impl App<'_> {
             failure: report.failure,
         });
     }
-
-    fn dispatch_composer_action(&mut self, action: ComposerAction) {
-        if self.composer_blocked() {
-            return;
-        }
-        if self.conversation_mode == ConversationMode::EditingMessage
-            && matches!(action, ComposerAction::Submit)
-        {
-            return self.submit_message_edit();
-        }
-        match action {
-            ComposerAction::StartEdit => {
-                // InsertMode is now the canonical way; StartEdit is unused.
-            }
-            ComposerAction::Paste => {
-                let paste = self.clipboard_reader.read_paste();
-                if let Err(error) =
-                    apply_clipboard_paste(&mut self.composer, &self.media_path, paste)
-                {
-                    self.unavailable(&format!("Could not paste clipboard content: {error:?}"));
-                }
-            }
-            action => match self.composer.apply(action) {
-                ComposerOutcome::Idle => {}
-                ComposerOutcome::Submit { messages, quote } => {
-                    if let Some(chat) = self.open_chat() {
-                        for message in messages {
-                            wr::send_message(&chat, &message, quote.as_ref());
-                        }
-                    }
-                }
-            },
-        }
-    }
 }
 
 fn is_toggle_logs_key(key: &Key) -> bool {
     matches!(key.code, KeyCode::Char('l' | 'L'))
         && key.modifiers == KeyModifiers::CONTROL | KeyModifiers::SHIFT
-}
-
-fn is_attach_file_key(key: &Key) -> bool {
-    key == &Key::ctrl('o')
 }
 
 fn log_level_for_logs(show_logs: bool) -> tui_logger::LevelFilter {


### PR DESCRIPTION
## Summary

- Extract the complete composer integration seam from src/app/inputs.rs into src/app/composer_integration.rs.
- Preserve composer editing, attachment, paste, message-edit, submission, and blocked-composer behavior.
- Keep central action routing and chat-search routing in inputs.rs.

## Changes

- Move composer-context terminal handling and composer action dispatch into the new module.
- Keep the dispatcher action arm and unrelated input routing in inputs.rs.
- Add focused tests for composer-context ownership and blocked input.

## Testing

- [x] CARGO_TARGET_DIR=/home/samael/.cache/cargo-target cargo fmt --all -- --check
- [x] CARGO_TARGET_DIR=/home/samael/.cache/cargo-target cargo test --lib -- --test-threads=1 (171 passed)
- [x] CARGO_TARGET_DIR=/home/samael/.cache/cargo-target cargo test --test composer_behavior -- --test-threads=1 (13 passed)
- [x] CARGO_TARGET_DIR=/home/samael/.cache/cargo-target cargo check
- [x] git diff --check
- [ ] CI intentionally not run, per request.
- [ ] Manual UI testing not run; this is a behavior-preserving internal extraction.

Authored diff: 170 lines (106 additions, 64 deletions).

Rollback boundary: revert commit 833cf5f to remove only this composer integration seam.

Closes #167