### PR TITLE
refactor(bridge): extract message action builders

### DIFF
--- a/whatsrust/lib/message_action_builders.go
+++ b/whatsrust/lib/message_action_builders.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// reactionRequest keeps the reaction target separate from the destination
+// chat. This is required for reactions to status messages.
+type reactionRequest struct {
+	target, destination, sender types.JID
+	id                          types.MessageID
+	reaction                    string
+}
+
+func newReactionRequest(target, destination, sender types.JID, id types.MessageID, reaction string) (reactionRequest, error) {
+	if target.IsEmpty() || destination.IsEmpty() || sender.IsEmpty() || id == "" || reaction == "" {
+		return reactionRequest{}, fmt.Errorf("reaction requires target, destination, sender, message ID, and text")
+	}
+	if target.Server == types.NewsletterServer || destination.Server == types.NewsletterServer {
+		return reactionRequest{}, fmt.Errorf("newsletter reactions are not ordinary message reactions")
+	}
+	return reactionRequest{target: target, destination: destination, sender: sender, id: id, reaction: reaction}, nil
+}
+
+func buildOrdinaryReaction(client *whatsmeow.Client, target, sender types.JID, id types.MessageID, reaction string) (*waE2E.Message, error) {
+	if client == nil {
+		return nil, fmt.Errorf("WhatsApp client is unavailable")
+	}
+	request, err := newReactionRequest(target, target, sender, id, reaction)
+	if err != nil {
+		return nil, err
+	}
+	return client.BuildReaction(request.target, request.sender, request.id, request.reaction), nil
+}
+
+func buildOrdinaryEdit(client *whatsmeow.Client, chat types.JID, id types.MessageID, replacement string) (*waE2E.Message, error) {
+	if client == nil {
+		return nil, fmt.Errorf("WhatsApp client is unavailable")
+	}
+	if chat.IsEmpty() || id == "" || strings.TrimSpace(replacement) == "" {
+		return nil, fmt.Errorf("edit requires chat, message ID, and replacement text")
+	}
+	if chat.Server == types.NewsletterServer {
+		return nil, fmt.Errorf("newsletter edits are not ordinary message edits")
+	}
+	return client.BuildEdit(chat, id, &waE2E.Message{Conversation: &replacement}), nil
+}
+
+func buildOrdinaryRevoke(client *whatsmeow.Client, chat, sender types.JID, id types.MessageID) (*waE2E.Message, error) {
+	if client == nil {
+		return nil, fmt.Errorf("WhatsApp client is unavailable")
+	}
+	if chat.IsEmpty() || sender.IsEmpty() || id == "" {
+		return nil, fmt.Errorf("revoke requires chat, sender, and message ID")
+	}
+	if chat.Server == types.NewsletterServer {
+		return nil, fmt.Errorf("newsletter revocations are not ordinary message revocations")
+	}
+	return client.BuildRevoke(chat, sender, id), nil
+}
+
+func parseActionJID(raw string) (types.JID, error) {
+	jid, err := types.ParseJID(raw)
+	if err != nil || jid.IsEmpty() {
+		return types.JID{}, fmt.Errorf("invalid JID")
+	}
+	return jid, nil
+}

--- a/whatsrust/lib/message_action_builders_test.go
+++ b/whatsrust/lib/message_action_builders_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestMessageActionBuildersOwnValidationAndBuilders(t *testing.T) {
+	source, err := os.ReadFile("message_action_builders.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(source)
+	for _, expected := range []string{
+		"func newReactionRequest(",
+		"func buildOrdinaryReaction(",
+		"func buildOrdinaryEdit(",
+		"func buildOrdinaryRevoke(",
+		"func parseActionJID(",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("action-builder seam missing %q", expected)
+		}
+	}
+
+	actionSource, err := os.ReadFile("message_actions.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, removed := range []string{
+		"func newReactionRequest(",
+		"func buildOrdinaryReaction(",
+		"func buildOrdinaryEdit(",
+		"func buildOrdinaryRevoke(",
+		"func parseActionJID(",
+	} {
+		if strings.Contains(string(actionSource), removed) {
+			t.Fatalf("action-builder helper remains in message_actions.go: %q", removed)
+		}
+	}
+}
+
+func TestParseActionJID(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want types.JID
+		ok   bool
+	}{
+		{name: "valid user", raw: "12345@s.whatsapp.net", want: types.NewJID("12345", types.DefaultUserServer), ok: true},
+		{name: "empty", raw: "", ok: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseActionJID(test.raw)
+			if (err == nil) != test.ok {
+				t.Fatalf("parseActionJID(%q) error = %v, want success = %v", test.raw, err, test.ok)
+			}
+			if test.ok && got != test.want {
+				t.Fatalf("parseActionJID(%q) = %v, want %v", test.raw, got, test.want)
+			}
+		})
+	}
+}

--- a/whatsrust/lib/message_actions.go
+++ b/whatsrust/lib/message_actions.go
@@ -9,76 +9,9 @@ import "C"
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
-	"go.mau.fi/whatsmeow"
-	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 )
-
-// reactionRequest keeps the reaction target separate from the destination
-// chat. This is required for reactions to status messages.
-type reactionRequest struct {
-	target, destination, sender types.JID
-	id                          types.MessageID
-	reaction                    string
-}
-
-func newReactionRequest(target, destination, sender types.JID, id types.MessageID, reaction string) (reactionRequest, error) {
-	if target.IsEmpty() || destination.IsEmpty() || sender.IsEmpty() || id == "" || reaction == "" {
-		return reactionRequest{}, fmt.Errorf("reaction requires target, destination, sender, message ID, and text")
-	}
-	if target.Server == types.NewsletterServer || destination.Server == types.NewsletterServer {
-		return reactionRequest{}, fmt.Errorf("newsletter reactions are not ordinary message reactions")
-	}
-	return reactionRequest{target: target, destination: destination, sender: sender, id: id, reaction: reaction}, nil
-}
-
-func buildOrdinaryReaction(client *whatsmeow.Client, target, sender types.JID, id types.MessageID, reaction string) (*waE2E.Message, error) {
-	if client == nil {
-		return nil, fmt.Errorf("WhatsApp client is unavailable")
-	}
-	request, err := newReactionRequest(target, target, sender, id, reaction)
-	if err != nil {
-		return nil, err
-	}
-	return client.BuildReaction(request.target, request.sender, request.id, request.reaction), nil
-}
-
-func buildOrdinaryEdit(client *whatsmeow.Client, chat types.JID, id types.MessageID, replacement string) (*waE2E.Message, error) {
-	if client == nil {
-		return nil, fmt.Errorf("WhatsApp client is unavailable")
-	}
-	if chat.IsEmpty() || id == "" || strings.TrimSpace(replacement) == "" {
-		return nil, fmt.Errorf("edit requires chat, message ID, and replacement text")
-	}
-	if chat.Server == types.NewsletterServer {
-		return nil, fmt.Errorf("newsletter edits are not ordinary message edits")
-	}
-	return client.BuildEdit(chat, id, &waE2E.Message{Conversation: &replacement}), nil
-}
-
-func buildOrdinaryRevoke(client *whatsmeow.Client, chat, sender types.JID, id types.MessageID) (*waE2E.Message, error) {
-	if client == nil {
-		return nil, fmt.Errorf("WhatsApp client is unavailable")
-	}
-	if chat.IsEmpty() || sender.IsEmpty() || id == "" {
-		return nil, fmt.Errorf("revoke requires chat, sender, and message ID")
-	}
-	if chat.Server == types.NewsletterServer {
-		return nil, fmt.Errorf("newsletter revocations are not ordinary message revocations")
-	}
-	return client.BuildRevoke(chat, sender, id), nil
-}
-
-func parseActionJID(raw string) (types.JID, error) {
-	jid, err := types.ParseJID(raw)
-	if err != nil || jid.IsEmpty() {
-		return types.JID{}, fmt.Errorf("invalid JID")
-	}
-	return jid, nil
-}
 
 //export C_ReactToMessage
 func C_ReactToMessage(targetJID C.JID, destinationJID C.JID, senderJID C.JID, messageID *C.char, reaction *C.char) C.uint8_t {


### PR DESCRIPTION
## Summary

- Extract the message-action validation and ordinary reaction/edit/revoke builders into a dedicated Go module.
- Preserve the existing C exports, ABI, call routing, errors, and behavior.
- Add focused seam ownership and action-JID validation tests.

## Changes

| File | Change |
| --- | --- |
| `whatsrust/lib/message_action_builders.go` | Owns action request validation and ordinary message builders. |
| `whatsrust/lib/message_action_builders_test.go` | Verifies seam ownership and parser behavior. |
| `whatsrust/lib/message_actions.go` | Retains only the C bridge action exports. |

## Verification

- [x] `gofmt -w whatsrust/lib/message_action_builders.go whatsrust/lib/message_action_builders_test.go whatsrust/lib/message_actions.go`
- [x] `cd whatsrust/lib && go test -run 'Test(MessageActionBuildersOwnValidationAndBuilders|ParseActionJID|OrdinaryActionBuildersRejectInvalidTargets)' .`\n- [x] `cd whatsrust/lib && go vet ./...`\n- [x] `cd whatsrust/lib && go test ./...`\n- [x] `git diff --check`\n- [x] Authored diff is 207 lines, below the 400-line limit.\n- [x] No CI, Cargo/Rust, race, merge, privacy, or attribution work performed.\n\nCloses #171