### PR TITLE
refactor(bridge): extract action diagnostics

### DIFF
--- a/whatsrust/lib/action_diagnostics.go
+++ b/whatsrust/lib/action_diagnostics.go
@@ -1,0 +1,17 @@
+package main
+
+import "os"
+
+func messageActionDiagnostic(msg string, args ...any) {
+	if os.Getenv("WPTUI_MESSAGE_ACTION_DEBUG") != "1" {
+		return
+	}
+	LOG_WARN("MESSAGE_ACTION_DIAG "+msg, args...)
+}
+
+func emitStatusProtocolDiagnostic(emit func(string, ...any), entry string) {
+	if os.Getenv("WPTUI_MESSAGE_ACTION_DEBUG") != "1" {
+		return
+	}
+	emit("%s", entry)
+}

--- a/whatsrust/lib/action_diagnostics_test.go
+++ b/whatsrust/lib/action_diagnostics_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestActionDiagnosticsOwnDebugEmission(t *testing.T) {
+	source, err := os.ReadFile("action_diagnostics.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(source)
+	for _, expected := range []string{
+		"func messageActionDiagnostic(",
+		"func emitStatusProtocolDiagnostic(",
+		"WPTUI_MESSAGE_ACTION_DEBUG",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("action-diagnostics seam missing %q", expected)
+		}
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, removed := range []string{
+		"func messageActionDiagnostic(",
+		"func emitStatusProtocolDiagnostic(",
+	} {
+		if strings.Contains(string(mainSource), removed) {
+			t.Fatalf("action-diagnostics helper remains in main.go: %q", removed)
+		}
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -138,7 +138,6 @@ import "C"
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -162,20 +161,6 @@ const (
 	forwardFailureInvalidDestination
 	forwardFailureSendFailed
 )
-
-func messageActionDiagnostic(msg string, args ...any) {
-	if os.Getenv("WPTUI_MESSAGE_ACTION_DEBUG") != "1" {
-		return
-	}
-	LOG_WARN("MESSAGE_ACTION_DIAG "+msg, args...)
-}
-
-func emitStatusProtocolDiagnostic(emit func(string, ...any), entry string) {
-	if os.Getenv("WPTUI_MESSAGE_ACTION_DEBUG") != "1" {
-		return
-	}
-	emit("%s", entry)
-}
 
 // GetSelfId returns the current user's JID string for comparison (e.g. broadcast sender).
 func GetSelfId(client *whatsmeow.Client) string {


### PR DESCRIPTION
## Summary

- Extract the action-diagnostics debug gate and status-protocol emitter from `whatsrust/lib/main.go`.
- Preserve the existing environment gate, log prefix, formatting, and call routing.
- Add focused seam-ownership coverage.

## Changes

| File | Change |
| --- | --- |
| `whatsrust/lib/action_diagnostics.go` | Owns action diagnostic emission and debug gating. |
| `whatsrust/lib/action_diagnostics_test.go` | Verifies ownership and removal from `main.go`. |
| `whatsrust/lib/main.go` | Retains callers and removes the extracted helpers/import. |

## Verification

- [x] `gofmt -w action_diagnostics.go action_diagnostics_test.go main.go`
- [x] Focused Go tests passed.
- [x] `go vet ./...` passed.
- [x] `go test ./...` passed.
- [x] `git diff --check` passed.
- [x] Authored diff is 54 additions/deletions, below the 400-line limit.
- [x] No CI, Cargo/Rust, race, merge, privacy, or attribution work performed.

Closes #173