### PR TITLE
refactor(app): extract chat search input handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,7 @@ pub mod chat_navigation;
 pub mod chat_opening;
 pub mod chat_ordering;
 pub mod chat_projection;
+pub mod chat_search_input;
 pub mod chat_store;
 pub mod community_bridge;
 pub mod community_hierarchy;

--- a/src/app/chat_search_input.rs
+++ b/src/app/chat_search_input.rs
@@ -1,0 +1,54 @@
+use ratatui::crossterm::event::KeyCode;
+
+use super::App;
+use super::actions::{FocusPane, Section};
+use crate::key_handler::Key;
+
+impl App<'_> {
+    pub(crate) fn handle_chat_search_input(&mut self, key: Key) -> bool {
+        if self.focus_pane == FocusPane::ChatList && self.contact_search_active {
+            self.handle_chat_search_key(key);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn start_chat_search(&mut self, key: &Key) -> bool {
+        if self.focus_pane == FocusPane::ChatList
+            && self.selected_section == Section::Chats
+            && key.code == KeyCode::Char('/')
+        {
+            self.contact_search_active = true;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_support::TestApp;
+
+    #[test]
+    fn slash_starts_chat_search_only_in_the_chats_list() {
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::ChatList;
+        app.selected_section = Section::Chats;
+
+        assert!(app.start_chat_search(&Key::c('/')));
+        assert!(app.contact_search_active);
+    }
+
+    #[test]
+    fn active_chat_search_routes_characters_to_the_search_buffer() {
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::ChatList;
+        app.contact_search_active = true;
+
+        assert!(app.handle_chat_search_input(Key::c('a')));
+        assert_eq!(app.contact_search.input.to_string(), "a");
+    }
+}

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -94,8 +94,7 @@ impl App<'_> {
                         SequenceResolution::Cancelled => {}
                     }
                 }
-            } else if self.focus_pane == FocusPane::ChatList && self.contact_search_active {
-                self.handle_chat_search_key(key);
+            } else if self.handle_chat_search_input(key.clone()) {
             } else if self.focus_pane == FocusPane::ChatList && key == Key::k(KeyCode::Enter) {
                 self.dispatch_action(AppAction::OpenChat);
             } else if self.focus_pane == FocusPane::SectionRail
@@ -116,12 +115,7 @@ impl App<'_> {
     fn handle_unbound_key(&mut self, key: Key) {
         // Chat search is a Chats-section feature; the status list has its
         // own single-pane navigation.
-        if self.focus_pane == FocusPane::ChatList
-            && self.selected_section == Section::Chats
-            && key.code == KeyCode::Char('/')
-        {
-            self.contact_search_active = true;
-        }
+        self.start_chat_search(&key);
     }
 
     pub fn dispatch_action(&mut self, action: AppAction) {


### PR DESCRIPTION
## Summary

- Extract chat-search activation and active-search keyboard routing from `src/app/inputs.rs` into a focused app module.
- Preserve existing chat selection, filtering, and `AppAction` behavior.

## Changes

- Add `src/app/chat_search_input.rs` with delegated routing and focused tests.
- Keep `inputs.rs` as the central terminal-event and action-routing boundary.

## Testing

- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --lib chat_search_input -- --test-threads=1` (2 passed)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --test composer_behavior -- --test-threads=1` (13 passed)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo check`
- [x] `git diff --check`
- [ ] CI intentionally not run, per request.
- [ ] Manual UI testing not run; this is a behavior-preserving internal extraction.

## SRP audit

`inputs.rs` now contains terminal-event coordination, central action dispatch, and delegation to focused modules. Remaining inline policy/lifecycle includes log toggling, status-view action rejection, share-picker construction/confirmation, and generic action dispatch; these are separate future seams rather than chat-search behavior.

Authored diff: 65 lines (57 additions, 8 deletions).

Closes #175