### PR TITLE
refactor(bridge): extract contacts FFI wrapper

### DIFF
--- a/whatsrust/lib/contacts.go
+++ b/whatsrust/lib/contacts.go
@@ -69,6 +69,25 @@ func lookupContactEntries(ctx context.Context, bridgeClient *whatsmeow.Client) [
 	return entries
 }
 
+//export C_GetContacts
+func C_GetContacts() C.GetContactsResult {
+	if client == nil || client.Store == nil {
+		return contactEntriesToC(nil)
+	}
+	ctx := context.Background()
+	entries := lookupContactEntries(ctx, client)
+
+	// Groups remain in this bridge wrapper; contacts.go owns only contact lookup.
+	groups, err := client.GetJoinedGroups(ctx)
+	if err != nil {
+		panic(err)
+	}
+	for _, group := range groups {
+		entries = append(entries, contactEntry{jid: group.JID, name: group.GroupName.Name})
+	}
+	return contactEntriesToC(entries)
+}
+
 func contactEntriesToC(entries []contactEntry) C.GetContactsResult {
 	if len(entries) == 0 {
 		return C.GetContactsResult{}

--- a/whatsrust/lib/contacts_ffi_test.go
+++ b/whatsrust/lib/contacts_ffi_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestContactsFFIOwnsContactsExport(t *testing.T) {
+	seam, err := os.ReadFile("contacts.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(seam), "func C_GetContacts()") {
+		t.Fatal("contacts FFI seam is missing C_GetContacts")
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mainSource), "func C_GetContacts()") {
+		t.Fatal("contacts FFI export remains in main.go")
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -17,11 +17,6 @@ typedef struct {
 } Contact;
 
 typedef struct {
-	JID jid;
-	const char* name;
-} ContactEntry;
-
-typedef struct {
 	bool found;
 	int64_t muted_until;
 	bool pinned;
@@ -33,11 +28,6 @@ typedef struct {
 	bool is_announce;
 	bool is_admin;
 } GroupInfoResult;
-
-typedef struct {
-	ContactEntry* entries;
-	uint32_t size;
-} GetContactsResult;
 
 typedef struct {
 	uint8_t status;
@@ -652,25 +642,6 @@ func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, so
 		destinationStrings,
 		forwardingSourceBytes(forwardSource, forwardSourceLen),
 	).cResult()
-}
-
-//export C_GetContacts
-func C_GetContacts() C.GetContactsResult {
-	if client == nil || client.Store == nil {
-		return contactEntriesToC(nil)
-	}
-	ctx := context.Background()
-	entries := lookupContactEntries(ctx, client)
-
-	// Groups remain in this bridge wrapper; contacts.go owns only contact lookup.
-	groups, err := client.GetJoinedGroups(ctx)
-	if err != nil {
-		panic(err)
-	}
-	for _, group := range groups {
-		entries = append(entries, contactEntry{jid: group.JID, name: group.GroupName.Name})
-	}
-	return contactEntriesToC(entries)
 }
 
 //export C_GetProfilePicture


### PR DESCRIPTION
## Summary

- Move the `C_GetContacts` FFI wrapper out of `whatsrust/lib/main.go` into the contacts seam.
- Preserve contact and joined-group retrieval, ordering, error behavior, and the existing C ABI.
- Link the focused extraction to issue #177.

## Changes

| File | Change |
| --- | --- |
| `whatsrust/lib/contacts.go` | Owns the `C_GetContacts` export alongside contact lookup and C conversion. |
| `whatsrust/lib/contacts_ffi_test.go` | Verifies contacts FFI ownership and removal from `main.go`. |
| `whatsrust/lib/main.go` | Removes the contacts FFI export and its now-unused C declarations. |

## Testing

- [x] `gofmt -w contacts.go contacts_ffi_test.go main.go`
- [x] Focused: `go test ./... -run 'Test(Contact|ContactsFFI)'`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `git diff --check`
- [x] Authored diff: 44 additions, 29 deletions (73 authored lines), below 400.
- [x] No CI, Cargo/Rust, race, merge, privacy, or attribution work performed.

Closes #177