### PR TITLE
refactor(app): extract share picker lifecycle

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -49,6 +49,7 @@ pub mod runtime_loop;
 pub mod runtime_media_events;
 pub mod runtime_startup;
 pub mod share_picker;
+pub mod share_picker_input;
 pub mod status_actions;
 pub mod status_input;
 pub mod status_projection;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -11,7 +11,6 @@ use crate::app::input_mapping::{
     attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
     message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
 };
-use crate::app::share_picker::is_forwardable_recipient;
 use crate::app::status_input::status_view_allows;
 use crate::key_handler::Key;
 
@@ -283,83 +282,6 @@ impl App<'_> {
         self.action_notice = Some(crate::app::actions::ActionNotice::Unavailable(
             action.into(),
         ));
-    }
-
-    fn open_share_picker(&mut self) {
-        if self.selected_message_is_deleted() {
-            return self.unavailable("This message was deleted.");
-        }
-        let Some(message) = self.selected_message() else {
-            return self.unavailable("Forward is not available");
-        };
-        if !is_forwardable_recipient(&message.info.chat) {
-            return self.unavailable("Forward is not available");
-        }
-        let contacts = self
-            .contacts
-            .keys()
-            .filter(|jid| is_forwardable_recipient(jid))
-            .cloned()
-            .collect();
-        let labels = self
-            .contacts
-            .iter()
-            .map(|(jid, name)| (jid.clone(), name.to_string()))
-            .collect();
-        let recency = self
-            .chats
-            .iter()
-            .filter_map(|(jid, chat)| chat.last_message_time.map(|time| (jid.clone(), time)))
-            .collect();
-        self.share_picker = Some(crate::app::SharePicker::new(contacts, labels, recency));
-    }
-
-    fn move_share_picker(&mut self, delta: isize) {
-        if let Some(picker) = self.share_picker.as_mut() {
-            picker.move_selection(delta);
-        }
-    }
-
-    fn toggle_share_recipient(&mut self) {
-        let Some(picker) = self.share_picker.as_mut() else {
-            return;
-        };
-        picker.toggle_selected();
-    }
-
-    fn share_search_backspace(&mut self) {
-        if let Some(picker) = self.share_picker.as_mut() {
-            picker.search_backspace();
-        }
-    }
-
-    fn share_search_character(&mut self, character: char) {
-        if let Some(picker) = self.share_picker.as_mut() {
-            picker.search_character(character);
-        }
-    }
-
-    fn confirm_share(&mut self) {
-        let Some(picker) = self.share_picker.as_ref() else {
-            return;
-        };
-        let destinations = picker.destinations();
-        if destinations.is_empty() {
-            return self.unavailable("Select at least one contact");
-        }
-        let Some(message) = self.selected_message().cloned() else {
-            self.share_picker = None;
-            return self.unavailable("Forward is not available");
-        };
-        self.share_picker = None;
-        let report = self
-            .message_forwarder
-            .forward_message(&message, &destinations);
-        self.action_notice = Some(crate::app::actions::ActionNotice::Forwarded {
-            succeeded: report.succeeded,
-            failed: report.failed,
-            failure: report.failure,
-        });
     }
 }
 

--- a/src/app/share_picker_input.rs
+++ b/src/app/share_picker_input.rs
@@ -1,0 +1,81 @@
+use crate::app::App;
+use crate::app::share_picker::{SharePicker, is_forwardable_recipient};
+
+impl App<'_> {
+    pub(crate) fn open_share_picker(&mut self) {
+        if self.selected_message_is_deleted() {
+            return self.unavailable("This message was deleted.");
+        }
+        let Some(message) = self.selected_message() else {
+            return self.unavailable("Forward is not available");
+        };
+        if !is_forwardable_recipient(&message.info.chat) {
+            return self.unavailable("Forward is not available");
+        }
+        let contacts = self
+            .contacts
+            .keys()
+            .filter(|jid| is_forwardable_recipient(jid))
+            .cloned()
+            .collect();
+        let labels = self
+            .contacts
+            .iter()
+            .map(|(jid, name)| (jid.clone(), name.to_string()))
+            .collect();
+        let recency = self
+            .chats
+            .iter()
+            .filter_map(|(jid, chat)| chat.last_message_time.map(|time| (jid.clone(), time)))
+            .collect();
+        self.share_picker = Some(SharePicker::new(contacts, labels, recency));
+    }
+
+    pub(crate) fn move_share_picker(&mut self, delta: isize) {
+        if let Some(picker) = self.share_picker.as_mut() {
+            picker.move_selection(delta);
+        }
+    }
+
+    pub(crate) fn toggle_share_recipient(&mut self) {
+        let Some(picker) = self.share_picker.as_mut() else {
+            return;
+        };
+        picker.toggle_selected();
+    }
+
+    pub(crate) fn share_search_backspace(&mut self) {
+        if let Some(picker) = self.share_picker.as_mut() {
+            picker.search_backspace();
+        }
+    }
+
+    pub(crate) fn share_search_character(&mut self, character: char) {
+        if let Some(picker) = self.share_picker.as_mut() {
+            picker.search_character(character);
+        }
+    }
+
+    pub(crate) fn confirm_share(&mut self) {
+        let Some(picker) = self.share_picker.as_ref() else {
+            return;
+        };
+        let destinations = picker.destinations();
+        if destinations.is_empty() {
+            return self.unavailable("Select at least one contact");
+        }
+        let Some(message) = self.selected_message().cloned() else {
+            self.share_picker = None;
+            return self.unavailable("Forward is not available");
+        };
+        self.share_picker = None;
+        let report = self
+            .message_forwarder
+            .forward_message(&message, &destinations);
+        self.action_notice = Some(crate::app::actions::ActionNotice::Forwarded {
+            succeeded: report.succeeded,
+            failed: report.failed,
+            failure: report.failure,
+        });
+    }
+}


### PR DESCRIPTION
Closes #178

## Summary

- Extract share-picker construction, navigation, search, cancellation, and confirmation lifecycle from `src/app/inputs.rs`.
- Keep central `dispatch_action` as coordination and preserve all `AppAction` behavior.

## Changes

| File | Change |
|------|--------|
| `src/app/share_picker_input.rs` | Own share-picker lifecycle policies and forwarding confirmation. |
| `src/app/inputs.rs` | Retain action routing; remove inline share-picker lifecycle implementation. |
| `src/app.rs` | Register the focused module. |

## Verification

- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --lib share_picker -- --test-threads=1` (5 passed)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo check`
- [x] `git diff --check`
- [ ] CI intentionally not run, per request.

## Checklist

- [x] Linked issue
- [x] Exactly one `type:*` label
- [x] Conventional commit
- [x] No behavior or `AppAction` changes
- [x] No attribution trailers
