### PR TITLE
refactor(app): extract log toggling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ pub mod file_picker_input;
 pub mod input_mapping;
 pub mod input_reader;
 pub mod inputs;
+pub mod log_toggle;
 pub mod logout;
 pub mod media_cache;
 pub mod media_support;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -1,4 +1,4 @@
-use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind};
 
 use crate::app::App;
 use crate::app::actions::{
@@ -11,6 +11,7 @@ use crate::app::input_mapping::{
     attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
     message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
 };
+use crate::app::log_toggle::is_toggle_logs_key;
 use crate::app::status_input::status_view_allows;
 use crate::key_handler::Key;
 
@@ -136,10 +137,7 @@ impl App<'_> {
                 self.should_quit = true;
             }
             AppAction::Logout => self.begin_logout_confirmation(),
-            AppAction::ToggleLogs => {
-                self.show_logs = !self.show_logs;
-                tui_logger::set_default_level(log_level_for_logs(self.show_logs));
-            }
+            AppAction::ToggleLogs => self.toggle_logs(),
             AppAction::ToggleSectionRail => {
                 self.pane_visibility.section_rail = !self.pane_visibility.section_rail;
                 self.focus_pane =
@@ -282,30 +280,5 @@ impl App<'_> {
         self.action_notice = Some(crate::app::actions::ActionNotice::Unavailable(
             action.into(),
         ));
-    }
-}
-
-fn is_toggle_logs_key(key: &Key) -> bool {
-    matches!(key.code, KeyCode::Char('l' | 'L'))
-        && key.modifiers == KeyModifiers::CONTROL | KeyModifiers::SHIFT
-}
-
-fn log_level_for_logs(show_logs: bool) -> tui_logger::LevelFilter {
-    if show_logs {
-        tui_logger::LevelFilter::Info
-    } else {
-        tui_logger::LevelFilter::Warn
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::log_level_for_logs;
-    use tui_logger::LevelFilter;
-
-    #[test]
-    fn log_panel_uses_info_and_restores_warn_when_closed() {
-        assert_eq!(log_level_for_logs(true), LevelFilter::Info);
-        assert_eq!(log_level_for_logs(false), LevelFilter::Warn);
     }
 }

--- a/src/app/log_toggle.rs
+++ b/src/app/log_toggle.rs
@@ -1,0 +1,49 @@
+use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+
+use crate::app::App;
+use crate::key_handler::Key;
+
+impl App<'_> {
+    pub(crate) fn toggle_logs(&mut self) {
+        self.show_logs = !self.show_logs;
+        tui_logger::set_default_level(log_level_for_logs(self.show_logs));
+    }
+}
+
+pub(crate) fn is_toggle_logs_key(key: &Key) -> bool {
+    matches!(key.code, KeyCode::Char('l' | 'L'))
+        && key.modifiers == KeyModifiers::CONTROL | KeyModifiers::SHIFT
+}
+
+fn log_level_for_logs(show_logs: bool) -> tui_logger::LevelFilter {
+    if show_logs {
+        tui_logger::LevelFilter::Info
+    } else {
+        tui_logger::LevelFilter::Warn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_toggle_logs_key, log_level_for_logs};
+    use crate::key_handler::Key;
+    use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+    use tui_logger::LevelFilter;
+
+    #[test]
+    fn recognizes_both_log_toggle_key_cases_only_with_ctrl_shift() {
+        for code in [KeyCode::Char('l'), KeyCode::Char('L')] {
+            assert!(is_toggle_logs_key(&Key {
+                code,
+                modifiers: KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            }));
+        }
+        assert!(!is_toggle_logs_key(&Key::c('l')));
+    }
+
+    #[test]
+    fn log_panel_uses_info_and_restores_warn_when_closed() {
+        assert_eq!(log_level_for_logs(true), LevelFilter::Info);
+        assert_eq!(log_level_for_logs(false), LevelFilter::Warn);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the complete log-toggle policy from `src/app/inputs.rs` into `src/app/log_toggle.rs`.
- Preserve Ctrl+Shift+L routing, visibility state changes, logger levels, and `AppAction` behavior.
- Leave `inputs.rs` as terminal routing, delegation, and central action coordination.

## Testing

- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --lib log_toggle -- --test-threads=1` (2 passed)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo check`
- [x] `git diff --check`
- [ ] CI intentionally not run, per request.

## SRP audit

After this extraction, every remaining branch in `src/app/inputs.rs` is terminal-event routing, action delegation, or central coordination for focus/status guards and `AppAction` state transitions. No independent policy seam remains.

Closes #182