### PR TITLE
refactor(bridge): extract profile picture FFI wrapper

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -30,14 +30,6 @@ typedef struct {
 } GroupInfoResult;
 
 typedef struct {
-	uint8_t status;
-	char* picture_id;
-	char* picture_type;
-	uint8_t* data;
-	uint32_t size;
-} ProfilePictureResult;
-
-typedef struct {
 	char* text;
 } TextMessage;
 
@@ -642,26 +634,6 @@ func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, so
 		destinationStrings,
 		forwardingSourceBytes(forwardSource, forwardSourceLen),
 	).cResult()
-}
-
-//export C_GetProfilePicture
-func C_GetProfilePicture(jid *C.char) C.ProfilePictureResult {
-	if jid == nil {
-		return C.ProfilePictureResult{status: C.uint8_t(profilePictureStatusInvalidJID)}
-	}
-	if client == nil {
-		return C.ProfilePictureResult{status: C.uint8_t(profilePictureStatusClientUnavailable)}
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), profilePictureTimeout)
-	defer cancel()
-	return profilePictureToC(fetchProfilePicture(ctx, C.GoString(jid), client.GetProfilePictureInfo, downloadProfilePicture))
-}
-
-//export C_FreeProfilePicture
-func C_FreeProfilePicture(result C.ProfilePictureResult) {
-	C.free(unsafe.Pointer(result.picture_id))
-	C.free(unsafe.Pointer(result.picture_type))
-	C.free(unsafe.Pointer(result.data))
 }
 
 //export C_GetChatSettings

--- a/whatsrust/lib/profile_picture.go
+++ b/whatsrust/lib/profile_picture.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"strings"
 	"time"
+	"unsafe"
 
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/types"
@@ -135,4 +136,24 @@ func profilePictureToC(outcome profilePictureOutcome) C.ProfilePictureResult {
 		result.size = C.uint32_t(len(outcome.data))
 	}
 	return result
+}
+
+//export C_GetProfilePicture
+func C_GetProfilePicture(jid *C.char) C.ProfilePictureResult {
+	if jid == nil {
+		return C.ProfilePictureResult{status: C.uint8_t(profilePictureStatusInvalidJID)}
+	}
+	if client == nil {
+		return C.ProfilePictureResult{status: C.uint8_t(profilePictureStatusClientUnavailable)}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), profilePictureTimeout)
+	defer cancel()
+	return profilePictureToC(fetchProfilePicture(ctx, C.GoString(jid), client.GetProfilePictureInfo, downloadProfilePicture))
+}
+
+//export C_FreeProfilePicture
+func C_FreeProfilePicture(result C.ProfilePictureResult) {
+	C.free(unsafe.Pointer(result.picture_id))
+	C.free(unsafe.Pointer(result.picture_type))
+	C.free(unsafe.Pointer(result.data))
 }

--- a/whatsrust/lib/profile_picture_ffi_test.go
+++ b/whatsrust/lib/profile_picture_ffi_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestProfilePictureFFIOwnsProfilePictureExports(t *testing.T) {
+	seam, err := os.ReadFile("profile_picture.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seamSource := string(seam)
+	for _, export := range []string{
+		"func C_GetProfilePicture(jid *C.char)",
+		"func C_FreeProfilePicture(result C.ProfilePictureResult)",
+	} {
+		if !strings.Contains(seamSource, export) {
+			t.Fatalf("profile picture FFI seam is missing %s", export)
+		}
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mainSource), "func C_GetProfilePicture") ||
+		strings.Contains(string(mainSource), "func C_FreeProfilePicture") {
+		t.Fatal("profile picture FFI exports remain in main.go")
+	}
+}


### PR DESCRIPTION
## Summary

- Move the profile-picture FFI wrapper and its release function out of `whatsrust/lib/main.go` into the existing profile-picture seam.
- Preserve the C ABI, invalid/client-unavailable statuses, timeout, result allocation, and release behavior.
- Add focused seam-ownership coverage.

## Changes

| File | Change |
| --- | --- |
| `whatsrust/lib/profile_picture.go` | Owns `C_GetProfilePicture` and `C_FreeProfilePicture` with profile-picture conversion. |
| `whatsrust/lib/profile_picture_ffi_test.go` | Verifies both exports are owned by the profile-picture seam. |
| `whatsrust/lib/main.go` | Removes the profile-picture C declaration and exports. |

## Testing

- [x] `gofmt -w profile_picture.go profile_picture_ffi_test.go main.go`
- [x] Focused: `go test ./... -run 'Test(ProfilePicture|FetchProfilePicture)'`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `git diff --check`
- [x] Authored diff: 53 additions, 28 deletions (81 authored lines), below 400.
- [x] No CI, Cargo/Rust, race, merge, privacy, or attribution work performed.

Closes #181