### PR TITLE
refactor(bridge): move group info FFI export

### DIFF
--- a/whatsrust/lib/group_info.go
+++ b/whatsrust/lib/group_info.go
@@ -3,6 +3,7 @@ package main
 /*
 #include <stdbool.h>
 #include <stdint.h>
+#include "callback_log_registration.h"
 
 typedef struct {
 	uint8_t status;
@@ -73,6 +74,16 @@ func fetchGroupInfoWith(ctx context.Context, jid types.JID, lookup groupInfoLook
 		}
 	}
 	return result
+}
+
+//export C_GetGroupInfo
+func C_GetGroupInfo(cjid C.JID) C.GroupInfoResult {
+	if cjid == nil {
+		return groupInfoResultToC(groupInfoClientUnavailable)
+	}
+	return groupInfoResultToC(fetchGroupInfo(client, cToJid(cjid).ToNonAD(), func(participant types.GroupParticipant) bool {
+		return participantMatchesSelf(client, participant)
+	}))
 }
 
 func groupInfoResultToC(result groupInfoResult) C.GroupInfoResult {

--- a/whatsrust/lib/group_info_test.go
+++ b/whatsrust/lib/group_info_test.go
@@ -3,10 +3,31 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 
 	"go.mau.fi/whatsmeow/types"
 )
+
+func TestGroupInfoFFIOwnsGroupInfoExport(t *testing.T) {
+	seam, err := os.ReadFile("group_info.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(seam), "//export C_GetGroupInfo") ||
+		!strings.Contains(string(seam), "func C_GetGroupInfo(cjid C.JID)") {
+		t.Fatal("group info FFI seam is missing C_GetGroupInfo")
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mainSource), "func C_GetGroupInfo") {
+		t.Fatal("group info FFI export remains in main.go")
+	}
+}
 
 func TestFetchGroupInfoPreservesStatusesAndGroupFields(t *testing.T) {
 	wantErr := errors.New("group request failed")

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -24,12 +24,6 @@ typedef struct {
 } ChatSettings;
 
 typedef struct {
-	uint8_t status;
-	bool is_announce;
-	bool is_admin;
-} GroupInfoResult;
-
-typedef struct {
 	char* text;
 } TextMessage;
 
@@ -150,16 +144,6 @@ func GetSelfId(client *whatsmeow.Client) string {
 		return ""
 	}
 	return StrFromJid(*client.Store.ID)
-}
-
-//export C_GetGroupInfo
-func C_GetGroupInfo(cjid C.JID) C.GroupInfoResult {
-	if cjid == nil {
-		return groupInfoResultToC(groupInfoClientUnavailable)
-	}
-	return groupInfoResultToC(fetchGroupInfo(client, cToJid(cjid).ToNonAD(), func(participant types.GroupParticipant) bool {
-		return participantMatchesSelf(client, participant)
-	}))
 }
 
 const (


### PR DESCRIPTION
## Summary

- Move `C_GetGroupInfo` and its C type declaration from `main.go` into the existing `group_info.go` seam.
- Preserve the exported ABI and all group-info status, announce, admin, and unavailable behavior.
- Follow-up child unit for #181 / PR #184; implementation issue: #185.

## Changes

- `whatsrust/lib/group_info.go`: owns the group-info C export and shared C header dependency.
- `whatsrust/lib/group_info_test.go`: verifies export ownership and keeps focused group-info behavior coverage.
- `whatsrust/lib/main.go`: no longer owns group-info C declarations or export.

## Testing

- [x] `gofmt -w group_info.go group_info_test.go main.go`
- [x] Focused: `go test ./... -run 'Test(GroupInfo|FetchGroupInfo)'`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `git diff --check`
- [x] Authored diff: 48 lines, below 400.
- [x] Cargo/Rust, CI, race, merge, privacy, and attribution checks intentionally not run.

Closes #185