### PR TITLE
refactor(bridge): extract DM resolution FFI seam

### DIFF
--- a/whatsrust/lib/dm_resolution.go
+++ b/whatsrust/lib/dm_resolution.go
@@ -1,0 +1,50 @@
+package main
+
+/*
+#include <stdlib.h>
+#include "callback_log_registration.h"
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type dmChatIDResolver func(types.JID) string
+
+func resolveDMChatID(client *whatsmeow.Client, jidText string, resolve dmChatIDResolver) (string, bool) {
+	if client == nil {
+		return "", false
+	}
+	jid, err := types.ParseJID(jidText)
+	if err != nil || jid.IsEmpty() {
+		return "", false
+	}
+	return resolve(jid), true
+}
+
+// Resolve a user JID (typically a group participant) to its canonical
+// direct-conversation id. Direct chats are stored under the phone number
+// (PN); a group participant may be a LID, so we map LID→PN when known so the
+// private reply opens the real chat instead of an empty LID-keyed thread.
+// Non-LID personal JIDs pass through unchanged. Returns NULL when the
+// client is not ready or the JID cannot be parsed.
+//
+//export C_ResolveDmChatId
+func C_ResolveDmChatId(cjid C.JID) *C.char {
+	value, ok := resolveDMChatID(client, C.GoString(cjid), func(jid types.JID) string {
+		return GetChatId(client, &jid, nil)
+	})
+	if !ok {
+		return nil
+	}
+	return C.CString(value)
+}
+
+//export C_FreeResolveDmChatId
+func C_FreeResolveDmChatId(value *C.char) {
+	C.free(unsafe.Pointer(value))
+}

--- a/whatsrust/lib/dm_resolution_test.go
+++ b/whatsrust/lib/dm_resolution_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestResolveDMChatID(t *testing.T) {
+	client := &whatsmeow.Client{}
+	cases := []struct {
+		name       string
+		jidText    string
+		want       string
+		wantOK     bool
+		wantLookup bool
+	}{
+		{name: "personal JID", jidText: "12345@s.whatsapp.net", want: "12345@s.whatsapp.net", wantOK: true, wantLookup: true},
+		{name: "empty JID", jidText: "", wantOK: false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			lookupCalled := false
+			got, ok := resolveDMChatID(client, testCase.jidText, func(jid types.JID) string {
+				lookupCalled = true
+				return jid.String()
+			})
+			if got != testCase.want || ok != testCase.wantOK || lookupCalled != testCase.wantLookup {
+				t.Fatalf("resolveDMChatID(%q) = (%q, %v), lookup called %v; want (%q, %v), lookup called %v", testCase.jidText, got, ok, lookupCalled, testCase.want, testCase.wantOK, testCase.wantLookup)
+			}
+		})
+	}
+}
+
+func TestResolveDMChatIDRequiresClient(t *testing.T) {
+	lookupCalled := false
+	if got, ok := resolveDMChatID(nil, "12345@s.whatsapp.net", func(types.JID) string {
+		lookupCalled = true
+		return "unexpected"
+	}); got != "" || ok || lookupCalled {
+		t.Fatalf("nil client resolved DM chat as (%q, %v), lookup called %v", got, ok, lookupCalled)
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -644,30 +644,6 @@ func C_GetChatSettings(cjid C.JID) C.ChatSettings {
 	}
 }
 
-// Resolve a user JID (typically a group participant) to its canonical
-// direct-conversation id. Direct chats are stored under the phone number
-// (PN); a group participant may be a LID, so we map LID→PN when known so the
-// private reply opens the real chat instead of an empty LID-keyed thread.
-// Non-LID personal JIDs pass through unchanged. Returns NULL when the
-// client is not ready or the JID cannot be parsed.
-//
-//export C_ResolveDmChatId
-func C_ResolveDmChatId(cjid C.JID) *C.char {
-	if client == nil {
-		return nil
-	}
-	jid, err := types.ParseJID(C.GoString(cjid))
-	if err != nil || jid.IsEmpty() {
-		return nil
-	}
-	return C.CString(GetChatId(client, &jid, nil))
-}
-
-//export C_FreeResolveDmChatId
-func C_FreeResolveDmChatId(value *C.char) {
-	C.free(unsafe.Pointer(value))
-}
-
 //export C_MarkAsRead
 func C_MarkAsRead(msg_id *C.char, chat_jid C.JID, sender_jid C.JID) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Extract the DM chat ID resolution and matching C free function from `whatsrust/lib/main.go`.
- Keep the C ABI and runtime behavior unchanged while giving the seam focused Go coverage.
- Addresses #187.

## Changes

- Added `whatsrust/lib/dm_resolution.go` for client readiness, JID parsing, canonical DM resolution, and C allocation ownership.
- Added table-driven tests for valid and empty JIDs, resolver routing, and unavailable clients.
- Removed only the extracted exports from `whatsrust/lib/main.go`.

## Testing

- [x] `cd whatsrust/lib && go test -run "^TestResolveDMChatID" ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `gofmt` applied to modified Go files
- [ ] Cargo/Rust checks — intentionally not run; this is a Go-only seam
- [ ] CI — intentionally not run

Diff is 95 authored lines, scoped to the Go FFI seam.

Closes #187