### PR TITLE
refactor(bridge): extract chat settings FFI seam

### DIFF
--- a/whatsrust/lib/chat_settings_ffi.go
+++ b/whatsrust/lib/chat_settings_ffi.go
@@ -1,0 +1,46 @@
+package main
+
+/*
+#include <stdbool.h>
+#include <stdint.h>
+#include "callback_log_registration.h"
+
+typedef struct {
+	bool found;
+	int64_t muted_until;
+	bool pinned;
+	bool archived;
+} ChatSettings;
+*/
+import "C"
+
+import (
+	"context"
+)
+
+func chatSettingsPayloadToC(payload chatSettingsPayload) C.ChatSettings {
+	return C.ChatSettings{
+		found:       C.bool(payload.found),
+		muted_until: C.int64_t(payload.mutedUntil),
+		pinned:      C.bool(payload.pinned),
+		archived:    C.bool(payload.archived),
+	}
+}
+
+//export C_GetChatSettings
+func C_GetChatSettings(cjid C.JID) C.ChatSettings {
+	ctx := context.Background()
+	jid := cToJid(cjid).ToNonAD()
+	settings, err := lookupChatSettings(
+		ctx,
+		jid,
+		client.Store.ChatSettings.GetChatSettings,
+		client.Store.LIDs.GetLIDForPN,
+		client.Store.LIDs.GetPNForLID,
+	)
+	if err != nil {
+		LOG_WARN("failed to get chat settings for %s: %v", jid, err)
+		return C.ChatSettings{}
+	}
+	return chatSettingsPayloadToC(chatSettingsPayloadFrom(settings))
+}

--- a/whatsrust/lib/chat_settings_ffi_test.go
+++ b/whatsrust/lib/chat_settings_ffi_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestChatSettingsFFIOwnsChatSettingsExport(t *testing.T) {
+	seam, err := os.ReadFile("chat_settings_ffi.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seamSource := string(seam)
+	if !strings.Contains(seamSource, "//export C_GetChatSettings") ||
+		!strings.Contains(seamSource, "func C_GetChatSettings(cjid C.JID)") {
+		t.Fatal("chat settings FFI seam is missing C_GetChatSettings")
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mainSource), "func C_GetChatSettings") {
+		t.Fatal("chat settings FFI export remains in main.go")
+	}
+}
+
+func TestChatSettingsPayloadToCPreservesABIFields(t *testing.T) {
+	result := chatSettingsPayloadToC(chatSettingsPayload{
+		found:      true,
+		mutedUntil: 123,
+		pinned:     true,
+		archived:   true,
+	})
+	if !bool(result.found) || result.muted_until != 123 || !bool(result.pinned) || !bool(result.archived) {
+		t.Fatalf("C result = %#v, want all chat settings fields preserved", result)
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -17,13 +17,6 @@ typedef struct {
 } Contact;
 
 typedef struct {
-	bool found;
-	int64_t muted_until;
-	bool pinned;
-	bool archived;
-} ChatSettings;
-
-typedef struct {
 	char* text;
 } TextMessage;
 
@@ -618,30 +611,6 @@ func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, so
 		destinationStrings,
 		forwardingSourceBytes(forwardSource, forwardSourceLen),
 	).cResult()
-}
-
-//export C_GetChatSettings
-func C_GetChatSettings(cjid C.JID) C.ChatSettings {
-	ctx := context.Background()
-	jid := cToJid(cjid).ToNonAD()
-	settings, err := lookupChatSettings(
-		ctx,
-		jid,
-		client.Store.ChatSettings.GetChatSettings,
-		client.Store.LIDs.GetLIDForPN,
-		client.Store.LIDs.GetPNForLID,
-	)
-	if err != nil {
-		LOG_WARN("failed to get chat settings for %s: %v", jid, err)
-		return C.ChatSettings{}
-	}
-	payload := chatSettingsPayloadFrom(settings)
-	return C.ChatSettings{
-		found:       C.bool(payload.found),
-		muted_until: C.int64_t(payload.mutedUntil),
-		pinned:      C.bool(payload.pinned),
-		archived:    C.bool(payload.archived),
-	}
 }
 
 //export C_MarkAsRead


### PR DESCRIPTION
Closes #189

## Summary

- Extract `C_GetChatSettings` from `whatsrust/lib/main.go` into a focused chat settings FFI seam.
- Preserve the C ABI field mapping, JID normalization, lookup fallback, warning behavior, and error behavior.
- Add focused ownership and ABI-field coverage.

## Changes

| File | Change |
|------|--------|
| `whatsrust/lib/chat_settings_ffi.go` | Owns the chat settings C ABI type, conversion, and export. |
| `whatsrust/lib/chat_settings_ffi_test.go` | Verifies export ownership and ABI field preservation. |
| `whatsrust/lib/main.go` | Removes the extracted ChatSettings typedef and export. |

## Test Plan

- [x] `cd whatsrust/lib && go test -run "^(TestChatSettings|TestLookupChatSettings)" ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] `gofmt` applied to modified Go files
- [ ] Cargo/Rust checks — intentionally not run; this is a Go-only seam
- [ ] CI — intentionally not run

Authored diff: 116 lines, under the 400-line limit.

No race, merge, Rust, Cargo, or attribution changes.