### PR TITLE
refactor(bridge): extract mark-as-read FFI seam

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -105,12 +105,10 @@ static void callHistorySync(HistorySyncHandler hdl, uint32_t percent) {
 */
 import "C"
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 	"unsafe"
 
 	"go.mau.fi/whatsmeow"
@@ -611,24 +609,6 @@ func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, so
 		destinationStrings,
 		forwardingSourceBytes(forwardSource, forwardSourceLen),
 	).cResult()
-}
-
-//export C_MarkAsRead
-func C_MarkAsRead(msg_id *C.char, chat_jid C.JID, sender_jid C.JID) {
-	ctx := context.Background()
-	timeRead := time.Now()
-
-	msgIds := []types.MessageID{
-		C.GoString(msg_id),
-	}
-
-	client.MarkRead(
-		ctx,
-		msgIds,
-		timeRead,
-		cToJid(chat_jid),
-		cToJid(sender_jid),
-	)
 }
 
 func main() {} // Required for CGO

--- a/whatsrust/lib/mark_as_read_ffi.go
+++ b/whatsrust/lib/mark_as_read_ffi.go
@@ -1,0 +1,24 @@
+package main
+
+/*
+#include "callback_log_registration.h"
+*/
+import "C"
+
+import (
+	"context"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+type markAsReadFunc func(context.Context, []types.MessageID, time.Time, types.JID, types.JID, ...types.ReceiptType) error
+
+func markMessageAsRead(msgID string, chat, sender types.JID, markRead markAsReadFunc) {
+	_ = markRead(context.Background(), []types.MessageID{types.MessageID(msgID)}, time.Now(), chat, sender)
+}
+
+//export C_MarkAsRead
+func C_MarkAsRead(msgID *C.char, chatJID C.JID, senderJID C.JID) {
+	markMessageAsRead(C.GoString(msgID), cToJid(chatJID), cToJid(senderJID), client.MarkRead)
+}

--- a/whatsrust/lib/mark_as_read_ffi_test.go
+++ b/whatsrust/lib/mark_as_read_ffi_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestMarkAsReadFFIOwnsMarkAsReadExport(t *testing.T) {
+	seam, err := os.ReadFile("mark_as_read_ffi.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(seam), "//export C_MarkAsRead") {
+		t.Fatal("mark-as-read FFI seam is missing C_MarkAsRead")
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mainSource), "func C_MarkAsRead") {
+		t.Fatal("mark-as-read FFI export remains in main.go")
+	}
+}
+
+func TestMarkMessageAsReadPreservesRequest(t *testing.T) {
+	wantMessageID := types.MessageID("message-42")
+	wantChat := types.NewJID("chat-42", types.DefaultUserServer)
+	wantSender := types.NewJID("sender-42", types.DefaultUserServer)
+	before := time.Now()
+	called := false
+
+	markMessageAsRead(string(wantMessageID), wantChat, wantSender, func(ctx context.Context, messageIDs []types.MessageID, readAt time.Time, chat, sender types.JID, _ ...types.ReceiptType) error {
+		called = true
+		if ctx == nil || len(messageIDs) != 1 || messageIDs[0] != wantMessageID || chat != wantChat || sender != wantSender {
+			t.Fatalf("mark-read request = (%v, %v, %v, %v), want preserved request", ctx, messageIDs, chat, sender)
+		}
+		if readAt.Before(before) || readAt.After(time.Now()) {
+			t.Fatalf("read timestamp = %v, want current time", readAt)
+		}
+		return nil
+	})
+
+	if !called {
+		t.Fatal("mark-read callback was not called")
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `C_MarkAsRead` from `whatsrust/lib/main.go` into a focused Go-only FFI seam.
- Preserve the existing ABI, current timestamp behavior, JID conversion, message-ID conversion, and `client.MarkRead` call.
- Addresses #191.

## Changes

| File | Change |
|------|--------|
| `whatsrust/lib/mark_as_read_ffi.go` | Owns the mark-as-read C export and request forwarding helper. |
| `whatsrust/lib/mark_as_read_ffi_test.go` | Verifies export ownership and request payload preservation. |
| `whatsrust/lib/main.go` | Removes the extracted export and now-unused imports. |

## Testing

- [x] `cd whatsrust/lib && go test -run "^(TestMarkAsRead|TestMarkMessageAsRead)" ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `git diff --check`
- [x] `gofmt` applied to modified Go files
- [ ] Cargo/Rust checks — intentionally not run; this is a Go-only seam
- [ ] CI — intentionally not run

Authored diff: 76 lines, under the 400-line limit.

No race, merge, Rust, Cargo, or attribution changes.

Closes #191