### PR TITLE
refactor(bridge): extract forward-message FFI seam

### DIFF
--- a/whatsrust/lib/forward_message_ffi.go
+++ b/whatsrust/lib/forward_message_ffi.go
@@ -1,0 +1,40 @@
+package main
+
+/*
+#include <stdint.h>
+#include <stddef.h>
+#include "callback_log_registration.h"
+
+typedef struct {
+	uint32_t succeeded;
+	uint32_t failed;
+	uint8_t failure;
+} ForwardResult;
+*/
+import "C"
+
+import "unsafe"
+
+//export C_ForwardMessage
+func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, sourceIsFromMe C.bool, destinations **C.char, destinationCount C.size_t, forwardSource *C.uint8_t, forwardSourceLen C.size_t) C.ForwardResult {
+	if sourceID == nil || sourceChat == nil || sourceSender == nil || destinations == nil || destinationCount == 0 {
+		return C.ForwardResult{}
+	}
+	rawDestinations := unsafe.Slice(destinations, int(destinationCount))
+	destinationStrings := make([]string, 0, len(rawDestinations))
+	for _, destination := range rawDestinations {
+		if destination == nil {
+			return C.ForwardResult{failed: C.uint32_t(destinationCount)}
+		}
+		destinationStrings = append(destinationStrings, C.GoString(destination))
+	}
+	report := forwardMessages(
+		C.GoString(sourceID),
+		C.GoString(sourceChat),
+		C.GoString(sourceSender),
+		bool(sourceIsFromMe),
+		destinationStrings,
+		forwardingSourceBytes(forwardSource, forwardSourceLen),
+	).cResult()
+	return report
+}

--- a/whatsrust/lib/forward_message_ffi_test.go
+++ b/whatsrust/lib/forward_message_ffi_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestForwardMessageFFIOwnsForwardMessageExport(t *testing.T) {
+	seam, err := os.ReadFile("forward_message_ffi.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(seam), "//export C_ForwardMessage") {
+		t.Fatal("forward-message FFI seam is missing C_ForwardMessage")
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mainSource), "func C_ForwardMessage") {
+		t.Fatal("forward-message FFI export remains in main.go")
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -28,12 +28,6 @@ typedef struct {
 } FileMessage;
 
 typedef struct {
-	uint32_t succeeded;
-	uint32_t failed;
-	uint8_t failure;
-} ForwardResult;
-
-typedef struct {
 	uint8_t kind;
 	JID id;
 	char* const* messageIDs;
@@ -586,29 +580,6 @@ func C_TestEmitPresenceEventsConcurrently(from *C.char, count C.uint32_t) {
 		}(index)
 	}
 	wait.Wait()
-}
-
-//export C_ForwardMessage
-func C_ForwardMessage(sourceID *C.char, sourceChat C.JID, sourceSender C.JID, sourceIsFromMe C.bool, destinations **C.char, destinationCount C.size_t, forwardSource *C.uint8_t, forwardSourceLen C.size_t) C.ForwardResult {
-	if sourceID == nil || sourceChat == nil || sourceSender == nil || destinations == nil || destinationCount == 0 {
-		return C.ForwardResult{}
-	}
-	rawDestinations := unsafe.Slice(destinations, int(destinationCount))
-	destinationStrings := make([]string, 0, len(rawDestinations))
-	for _, destination := range rawDestinations {
-		if destination == nil {
-			return C.ForwardResult{failed: C.uint32_t(destinationCount)}
-		}
-		destinationStrings = append(destinationStrings, C.GoString(destination))
-	}
-	return forwardMessages(
-		C.GoString(sourceID),
-		C.GoString(sourceChat),
-		C.GoString(sourceSender),
-		bool(sourceIsFromMe),
-		destinationStrings,
-		forwardingSourceBytes(forwardSource, forwardSourceLen),
-	).cResult()
 }
 
 func main() {} // Required for CGO


### PR DESCRIPTION
## Summary
- Extract `C_ForwardMessage` into a focused Go FFI seam.
- Preserve the existing C ABI, validation, destination conversion, forwarding call, and result composition.
- Keep forwarding internals unchanged.

## Changes
- Added `whatsrust/lib/forward_message_ffi.go`.
- Added an ownership test proving the export moved out of `main.go`.
- Removed the entrypoint and its ABI result typedef from `main.go`.

## Testing
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` and `git diff --check`
- [x] No Cargo, Rust, race, merge, or CI work performed.

## Audit
- Remaining `C_TestEmitPresenceEvent` and `C_TestEmitPresenceEventsConcurrently` exports are test-only emitters.
- `forwardingReport.cResult` remains legitimate ABI composition; forwarding orchestration remains intact.

Closes #193