### PR TITLE
refactor(bridge): extract test-only presence emitters

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -83,10 +83,6 @@ static void callMessageHandler(MessageHandler hdl, bool isSync, const Message* d
     hdl.callback(&copy, isSync, hdl.user_data);
 }
 
-static void callPresenceHandler(PresenceHandler hdl, JID from, bool unavailable, int64_t lastSeen) {
-	hdl.callback(from, unavailable, lastSeen, hdl.user_data);
-}
-
 typedef void (*HistorySyncCallback)(uint32_t, void*);
 typedef struct {
 	HistorySyncCallback callback;
@@ -562,24 +558,6 @@ func messageActionKindName(kind uint8) string {
 		return "edit"
 	}
 	return "delete"
-}
-
-//export C_TestEmitPresenceEvent
-func C_TestEmitPresenceEvent(from *C.char, unavailable C.bool, lastSeen C.int64_t) {
-	C.callPresenceHandler(presenceHandler, from, unavailable, lastSeen)
-}
-
-//export C_TestEmitPresenceEventsConcurrently
-func C_TestEmitPresenceEventsConcurrently(from *C.char, count C.uint32_t) {
-	var wait sync.WaitGroup
-	for index := uint32(0); index < uint32(count); index++ {
-		wait.Add(1)
-		go func(lastSeen uint32) {
-			defer wait.Done()
-			C.callPresenceHandler(presenceHandler, from, C.bool(false), C.int64_t(lastSeen))
-		}(index)
-	}
-	wait.Wait()
 }
 
 func main() {} // Required for CGO

--- a/whatsrust/lib/presence_ffi.go
+++ b/whatsrust/lib/presence_ffi.go
@@ -1,0 +1,32 @@
+package main
+
+/*
+#include <stdbool.h>
+#include <stdint.h>
+#include "callback_log_registration.h"
+
+static void callPresenceTestHandler(PresenceHandler hdl, JID from, bool unavailable, int64_t lastSeen) {
+	hdl.callback(from, unavailable, lastSeen, hdl.user_data);
+}
+*/
+import "C"
+
+import "sync"
+
+//export C_TestEmitPresenceEvent
+func C_TestEmitPresenceEvent(from *C.char, unavailable C.bool, lastSeen C.int64_t) {
+	C.callPresenceTestHandler(presenceHandler, from, unavailable, lastSeen)
+}
+
+//export C_TestEmitPresenceEventsConcurrently
+func C_TestEmitPresenceEventsConcurrently(from *C.char, count C.uint32_t) {
+	var wait sync.WaitGroup
+	for index := uint32(0); index < uint32(count); index++ {
+		wait.Add(1)
+		go func(lastSeen uint32) {
+			defer wait.Done()
+			C.callPresenceTestHandler(presenceHandler, from, C.bool(false), C.int64_t(lastSeen))
+		}(index)
+	}
+	wait.Wait()
+}

--- a/whatsrust/lib/presence_ffi_test.go
+++ b/whatsrust/lib/presence_ffi_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPresenceFFIOwnsTestPresenceEmitters(t *testing.T) {
+	seam, err := os.ReadFile("presence_ffi.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, export := range []string{
+		"//export C_TestEmitPresenceEvent",
+		"//export C_TestEmitPresenceEventsConcurrently",
+		"callPresenceTestHandler",
+	} {
+		if !strings.Contains(string(seam), export) {
+			t.Fatalf("presence FFI seam is missing %s", export)
+		}
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, export := range []string{
+		"func C_TestEmitPresenceEvent",
+		"func C_TestEmitPresenceEventsConcurrently",
+		"callPresenceTestHandler",
+	} {
+		if strings.Contains(string(mainSource), export) {
+			t.Fatalf("presence FFI export remains in main.go: %s", export)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Extract `C_TestEmitPresenceEvent` and `C_TestEmitPresenceEventsConcurrently` from `whatsrust/lib/main.go` into `presence_ffi.go`.
- Move their inseparable C callback helper and add an ownership test proving the seam is no longer in `main.go`.
- Preserve the C ABI and concurrent callback behavior.

## Changes
| File | Change |
|------|--------|
| `whatsrust/lib/presence_ffi.go` | Owns the two test-only presence emitters and their C callback helper. |
| `whatsrust/lib/presence_ffi_test.go` | Verifies emitter/helper ownership. |
| `whatsrust/lib/main.go` | Removes only the presence test FFI seam. |

## Testing
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` and `git diff --check`
- [x] Authored diff is 91 lines (<400).
- [x] No Cargo, Rust, race, merge, or CI work performed.

## Full `main.go` SRP audit
MORE_EXTRACTIONS_NEEDED

Remaining responsibilities with independent reasons for change:
- `HandleMessage`: translates whatsmeow message events into the C message ABI, including normalization, reaction/action routing, forwarding-source lifecycle, and per-message-type payload construction.
- `messageActionEventFromIncomingMessage`: classifies incoming edit/delete protocol messages and applies diagnostic fallback policy.
- `isStatusProtocolContext` plus `forwardSourceKey`: independent domain helpers for status detection and forwarding-source identity.

The cgo preamble, ABI constants/types, `main()`, `GetSelfId`, and `messageActionKindName` remain cohesive bridge composition/ABI/entrypoint support. This PR intentionally extracts only the requested presence emitters.

Closes #195