### PR TITLE
refactor(bridge): extract incoming action classifier

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -98,16 +98,12 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"unsafe"
 
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
-	"go.mau.fi/whatsmeow/types/events"
 )
-
-var messageActionArrivalOrder uint64
 
 var messageCallbackMu sync.Mutex
 
@@ -503,54 +499,6 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 		}
 		C.callMessageHandler(messageHandler, C.bool(isSync), &message)
 	}
-}
-
-// messageActionEventFromIncomingMessage also supports whatsmeow's normalized edit
-// event: UnwrapRaw has already replaced Message with the edited body and Info.ID
-// with the target ID. IsEdit is the library's explicit discriminator, so normal
-// messages with matching text cannot be mistaken for edits.
-func messageActionEventFromIncomingMessage(evt *events.Message) (messageActionEvent, bool) {
-	if evt == nil {
-		return messageActionEvent{}, false
-	}
-	rawProbe := messageActionProbeFromMessage(evt.RawMessage, "raw")
-	if action, ok, reason := messageActionEventFromProbe(evt.Info, rawProbe); ok {
-		if sourceID := evt.SourceWebMsg.GetKey().GetID(); sourceID != "" {
-			action.actionID = sourceID
-		}
-		messageActionStructuralDiagnostic(evt, "raw_classified", "")
-		return action, true
-	} else if rawProbe.hasActionProtocol() {
-		messageActionStructuralDiagnostic(evt, "raw_miss", reason)
-		return messageActionEvent{}, false
-	}
-	if !evt.IsEdit {
-		messageActionStructuralDiagnostic(evt, "signal_miss", "protocol_absent")
-		return messageActionEvent{}, false
-	}
-	// Only ParseWebMessage rewrites Info.ID to the target. Live edit envelopes keep
-	// Info.ID as the action ID, so never use this fallback without history source data.
-	if evt.SourceWebMsg == nil || evt.SourceWebMsg.GetKey().GetID() == "" || evt.Info.ID == "" {
-		messageActionStructuralDiagnostic(evt, "normalized_miss", "unproven_target")
-		return messageActionEvent{}, false
-	}
-	replacement, ok := replacementText(evt.Message)
-	if !ok {
-		messageActionStructuralDiagnostic(evt, "normalized_miss", "missing_replacement")
-		return messageActionEvent{}, false
-	}
-	action := messageActionEvent{
-		actionID:        evt.SourceWebMsg.GetKey().GetID(),
-		chat:            evt.Info.Chat.String(),
-		sender:          evt.Info.Sender.String(),
-		targetMessageID: evt.Info.ID,
-		replacement:     replacement,
-		occurredAt:      evt.Info.Timestamp.Unix(),
-		arrivalOrder:    atomic.AddUint64(&messageActionArrivalOrder, 1),
-		kind:            messageActionEdit,
-	}
-	messageActionStructuralDiagnostic(evt, "normalized_classified", "")
-	return action, true
 }
 
 func messageActionKindName(kind uint8) string {

--- a/whatsrust/lib/message_action_incoming.go
+++ b/whatsrust/lib/message_action_incoming.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"sync/atomic"
+
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+var messageActionArrivalOrder uint64
+
+// messageActionEventFromIncomingMessage also supports whatsmeow's normalized edit
+// event: UnwrapRaw has already replaced Message with the edited body and Info.ID
+// with the target ID. IsEdit is the library's explicit discriminator, so normal
+// messages with matching text cannot be mistaken for edits.
+func messageActionEventFromIncomingMessage(evt *events.Message) (messageActionEvent, bool) {
+	if evt == nil {
+		return messageActionEvent{}, false
+	}
+	rawProbe := messageActionProbeFromMessage(evt.RawMessage, "raw")
+	if action, ok, reason := messageActionEventFromProbe(evt.Info, rawProbe); ok {
+		if sourceID := evt.SourceWebMsg.GetKey().GetID(); sourceID != "" {
+			action.actionID = sourceID
+		}
+		messageActionStructuralDiagnostic(evt, "raw_classified", "")
+		return action, true
+	} else if rawProbe.hasActionProtocol() {
+		messageActionStructuralDiagnostic(evt, "raw_miss", reason)
+		return messageActionEvent{}, false
+	}
+	if !evt.IsEdit {
+		messageActionStructuralDiagnostic(evt, "signal_miss", "protocol_absent")
+		return messageActionEvent{}, false
+	}
+	// Only ParseWebMessage rewrites Info.ID to the target. Live edit envelopes keep
+	// Info.ID as the action ID, so never use this fallback without history source data.
+	if evt.SourceWebMsg == nil || evt.SourceWebMsg.GetKey().GetID() == "" || evt.Info.ID == "" {
+		messageActionStructuralDiagnostic(evt, "normalized_miss", "unproven_target")
+		return messageActionEvent{}, false
+	}
+	replacement, ok := replacementText(evt.Message)
+	if !ok {
+		messageActionStructuralDiagnostic(evt, "normalized_miss", "missing_replacement")
+		return messageActionEvent{}, false
+	}
+	action := messageActionEvent{
+		actionID:        evt.SourceWebMsg.GetKey().GetID(),
+		chat:            evt.Info.Chat.String(),
+		sender:          evt.Info.Sender.String(),
+		targetMessageID: evt.Info.ID,
+		replacement:     replacement,
+		occurredAt:      evt.Info.Timestamp.Unix(),
+		arrivalOrder:    atomic.AddUint64(&messageActionArrivalOrder, 1),
+		kind:            messageActionEdit,
+	}
+	messageActionStructuralDiagnostic(evt, "normalized_classified", "")
+	return action, true
+}

--- a/whatsrust/lib/message_action_incoming_test.go
+++ b/whatsrust/lib/message_action_incoming_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIncomingMessageActionClassifierOwnsNormalizedEditSeam(t *testing.T) {
+	seam, err := os.ReadFile("message_action_incoming.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(seam), "func messageActionEventFromIncomingMessage") {
+		t.Fatal("incoming message action seam is missing its classifier")
+	}
+
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mainSource), "func messageActionEventFromIncomingMessage") {
+		t.Fatal("incoming message action classifier remains in main.go")
+	}
+}


### PR DESCRIPTION
## Summary
- Extract `messageActionEventFromIncomingMessage` and its arrival-order state from `whatsrust/lib/main.go`.
- Preserve normalized edit classification, protocol fallback diagnostics, and behavior.
- Add an ownership test for the new seam.

## Changes
| File | Change |
|------|--------|
| `whatsrust/lib/message_action_incoming.go` | Owns incoming message action classification and arrival ordering. |
| `whatsrust/lib/message_action_incoming_test.go` | Verifies classifier ownership. |
| `whatsrust/lib/main.go` | Removes only the extracted classifier seam and unused imports. |

## Testing
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` and `git diff --check`
- [x] Authored diff is 134 lines (<400).
- [x] No CI command, Cargo, Rust, race, merge, privacy, scoped-attribution, or unrelated work performed.

## Remaining seams
- `HandleMessage`: message-to-C ABI translation, normalization, reaction/action routing, forwarding-source lifecycle, and per-message payload construction.
- `isStatusProtocolContext` plus `forwardSourceKey`: independent status detection and forwarding-source identity helpers.

The cgo preamble, ABI constants/types, `main()`, `GetSelfId`, and `messageActionKindName` remain cohesive bridge composition/ABI/entrypoint support.

Parent: #196
Closes #197