### PR TITLE
refactor(bridge): extract message event dispatch

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -151,35 +151,11 @@ const (
 func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	msg, viewOnceUnavailable := unavailableViewOnceMessage(msg)
 
-	// Normalize chat and sender ids (LID→PN, broadcast→per-sender) so Rust sees canonical ids.
-	if normalizedChat := GetChatId(client, &info.Chat, &info.Sender); normalizedChat != "" {
-		if jid, err := types.ParseJID(normalizedChat); err == nil {
-			info.Chat = jid
-		}
-	}
-	if normalizedSender := GetUserId(client, &info.Chat, &info.Sender); normalizedSender != "" {
-		if jid, err := types.ParseJID(normalizedSender); err == nil {
-			info.Sender = jid
-		}
-	}
+	info = normalizeMessageInfo(info)
 
 	chat := info.Chat
 	sender := info.Sender
-	if line, ok := statusProtocolReactionDiagnostic(info, msg); ok {
-		emitStatusProtocolDiagnostic(messageActionDiagnostic, line)
-	}
-	for _, line := range statusProtocolContextDiagnostics(info, msg) {
-		emitStatusProtocolDiagnostic(messageActionDiagnostic, line)
-	}
-	if reaction, ok := reactionEventFromMessage(info, msg); ok {
-		dispatchReactionEvent(reaction)
-		return
-	}
-	if action, ok := messageActionEventFromMessage(info, msg); ok {
-		if action.kind == messageActionDelete {
-			removeForwardSources(action.chat, action.targetMessageID)
-		}
-		dispatchMessageActionEvent(action)
+	if dispatchMessageEvent(info, msg) {
 		return
 	}
 	if !viewOnceUnavailable {

--- a/whatsrust/lib/message_event_dispatch.go
+++ b/whatsrust/lib/message_event_dispatch.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func normalizeMessageInfo(info types.MessageInfo) types.MessageInfo {
+	// Normalize chat and sender ids (LID→PN, broadcast→per-sender) so Rust sees canonical ids.
+	if normalizedChat := GetChatId(client, &info.Chat, &info.Sender); normalizedChat != "" {
+		if jid, err := types.ParseJID(normalizedChat); err == nil {
+			info.Chat = jid
+		}
+	}
+	if normalizedSender := GetUserId(client, &info.Chat, &info.Sender); normalizedSender != "" {
+		if jid, err := types.ParseJID(normalizedSender); err == nil {
+			info.Sender = jid
+		}
+	}
+	return info
+}
+
+func dispatchMessageEvent(info types.MessageInfo, msg *waE2E.Message) bool {
+	if line, ok := statusProtocolReactionDiagnostic(info, msg); ok {
+		emitStatusProtocolDiagnostic(messageActionDiagnostic, line)
+	}
+	for _, line := range statusProtocolContextDiagnostics(info, msg) {
+		emitStatusProtocolDiagnostic(messageActionDiagnostic, line)
+	}
+	if reaction, ok := reactionEventFromMessage(info, msg); ok {
+		dispatchReactionEvent(reaction)
+		return true
+	}
+	if action, ok := messageActionEventFromMessage(info, msg); ok {
+		if action.kind == messageActionDelete {
+			removeForwardSources(action.chat, action.targetMessageID)
+		}
+		dispatchMessageActionEvent(action)
+		return true
+	}
+	return false
+}

--- a/whatsrust/lib/message_event_dispatch_test.go
+++ b/whatsrust/lib/message_event_dispatch_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestNormalizeMessageInfoKeepsCanonicalIDs(t *testing.T) {
+	info := types.MessageInfo{MessageSource: types.MessageSource{
+		Chat:   types.NewJID("chat", types.DefaultUserServer),
+		Sender: types.NewJID("sender", types.DefaultUserServer),
+	}}
+
+	normalized := normalizeMessageInfo(info)
+	if normalized.Chat != info.Chat || normalized.Sender != info.Sender {
+		t.Fatalf("normalization changed canonical IDs: got chat=%s sender=%s", normalized.Chat, normalized.Sender)
+	}
+}
+
+func TestDispatchMessageEventRecognizesReactionsAndActions(t *testing.T) {
+	info := types.MessageInfo{MessageSource: types.MessageSource{
+		Chat:   types.NewJID("chat", types.DefaultUserServer),
+		Sender: types.NewJID("sender", types.DefaultUserServer),
+	}, ID: "action"}
+	cases := []struct {
+		name string
+		msg  *waE2E.Message
+	}{
+		{
+			name: "reaction",
+			msg: &waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{
+				Key:  &waCommon.MessageKey{ID: stringPointer("target")},
+				Text: stringPointer("👍"),
+			}},
+		},
+		{
+			name: "revoke action",
+			msg: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
+				Key:  &waCommon.MessageKey{ID: stringPointer("target")},
+				Type: waE2E.ProtocolMessage_REVOKE.Enum(),
+			}},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if !dispatchMessageEvent(info, testCase.msg) {
+				t.Fatal("message event was not dispatched")
+			}
+		})
+	}
+}
+
+func TestDispatchMessageEventLeavesOrdinaryMessagesForCallback(t *testing.T) {
+	info := types.MessageInfo{MessageSource: types.MessageSource{
+		Chat:   types.NewJID("chat", types.DefaultUserServer),
+		Sender: types.NewJID("sender", types.DefaultUserServer),
+	}}
+	if dispatchMessageEvent(info, &waE2E.Message{Conversation: stringPointer("ordinary")}) {
+		t.Fatal("ordinary message was dispatched as an action")
+	}
+}


### PR DESCRIPTION
## Summary
- Extract message-info normalization from `HandleMessage`.
- Extract reaction/action diagnostics and dispatch into a focused Go seam.
- Preserve callback behavior, ABI, and ordinary-message fallthrough.

## Changes
| File | Change |
|------|--------|
| `whatsrust/lib/main.go` | Delegates normalization and reaction/action dispatch. |
| `whatsrust/lib/message_event_dispatch.go` | Owns normalization and reaction/action dispatch helpers. |
| `whatsrust/lib/message_event_dispatch_test.go` | Covers canonical IDs, reaction/action dispatch, and ordinary-message fallthrough. |

## Verification
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` and `git diff --check`
- [x] Authored diff: 135 lines (<400).
- [x] ABI and behavior preserved.
- [x] No Cargo/Rust, race, merge, or CI work performed.
- [x] No forwarding cache, callback metadata/synchronization, or multimedia payload changes.
- [x] No attribution or privacy/scope changes.

## Remaining seams
- Forwarding cache and source serialization.
- Callback metadata construction and callback synchronization.
- Text, file, and multimedia payload construction.

Closes #203