### PR TITLE
refactor(bridge): extract forwarding source payload

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -158,20 +158,9 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	if dispatchMessageEvent(info, msg) {
 		return
 	}
-	if !viewOnceUnavailable {
-		cacheForwardSource(info, msg)
-	}
+	rawSource := forwardingSourcePayload(info, msg, viewOnceUnavailable)
 	messageCallbackMu.Lock()
 	defer messageCallbackMu.Unlock()
-	var rawSource []byte
-	if !viewOnceUnavailable {
-		var err error
-		rawSource, err = marshalForwardSource(msg)
-		if err != nil {
-			LOG_WARN("forward source serialization failed: %v", err)
-			rawSource = nil
-		}
-	}
 	var cForwardSource unsafe.Pointer
 	if len(rawSource) > 0 {
 		cForwardSource = C.CBytes(rawSource)

--- a/whatsrust/lib/message_forwarding.go
+++ b/whatsrust/lib/message_forwarding.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func forwardingSourcePayload(info types.MessageInfo, message *waE2E.Message, unavailable bool) []byte {
+	if unavailable {
+		return nil
+	}
+
+	cacheForwardSource(info, message)
+	rawSource, err := marshalForwardSource(message)
+	if err != nil {
+		LOG_WARN("forward source serialization failed: %v", err)
+		return nil
+	}
+	return rawSource
+}

--- a/whatsrust/lib/message_forwarding_test.go
+++ b/whatsrust/lib/message_forwarding_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestForwardingSourcePayloadCachesAndSerializesMessage(t *testing.T) {
+	resetForwardedSourcesForTest()
+	t.Cleanup(resetForwardedSourcesForTest)
+	chat := types.NewJID("chat", types.DefaultUserServer)
+	info := types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: chat}, ID: "message"}
+	message := &waE2E.Message{Conversation: stringPointer("payload")}
+
+	raw := forwardingSourcePayload(info, message, false)
+	decoded, err := proto.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != string(decoded) {
+		t.Fatalf("serialized source = %x, want %x", raw, decoded)
+	}
+	key := forwardSourceKey(chat, chat, info.ID)
+	if _, ok := forwardedSources.entries[key]; !ok {
+		t.Fatal("forwarding source was not cached")
+	}
+}
+
+func TestForwardingSourcePayloadSkipsUnavailableViewOnceMessage(t *testing.T) {
+	resetForwardedSourcesForTest()
+	t.Cleanup(resetForwardedSourcesForTest)
+	chat := types.NewJID("chat", types.DefaultUserServer)
+	info := types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: chat}, ID: "view-once"}
+	message := &waE2E.Message{ImageMessage: &waE2E.ImageMessage{}}
+
+	if raw := forwardingSourcePayload(info, message, true); raw != nil {
+		t.Fatalf("unavailable source bytes = %x, want nil", raw)
+	}
+	if len(forwardedSources.entries) != 0 {
+		t.Fatal("unavailable view-once message must not be cached")
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts the second `HandleMessage` seam: forwarding-source cache population and protobuf serialization.
- Keeps callback metadata, synchronization, and text/file/multimedia payload construction in `HandleMessage`.
- Continues directly from the published PR #204 head.

## Changes

- Adds `forwardingSourcePayload` with the existing view-once guard, cache behavior, and serialization warning behavior.
- Adds focused tests for cache-plus-serialization and unavailable view-once forwarding sources.
- Removes only the extracted forwarding preparation block from `main.go`; ABI and callback wiring are unchanged.

## Testing

- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` and `git diff --check`
- [x] Authored diff: 78 lines (<400).
- [x] No Cargo/Rust, race, merge, or CI work performed.
- [x] No callback metadata/synchronization or text/file/multimedia payload changes.
- [x] No privacy, scope, or attribution changes.

## Remaining seams

- Callback metadata construction and callback synchronization.
- Text, file, and multimedia payload construction.

Closes #205