### PR TITLE
refactor(bridge): extract callback metadata synchronization

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -123,6 +123,61 @@ func GetSelfId(client *whatsmeow.Client) string {
 	return StrFromJid(*client.Store.ID)
 }
 
+type messageCallbackMetadata struct {
+	id         string
+	chat       types.JID
+	sender     types.JID
+	timestamp  int64
+	isFromMe   bool
+	forwarding forwardingState
+}
+
+func messageCallbackMetadataFrom(info types.MessageInfo, msg *waE2E.Message) messageCallbackMetadata {
+	return messageCallbackMetadata{
+		id:         info.ID,
+		chat:       info.Chat,
+		sender:     info.Sender,
+		timestamp:  info.Timestamp.Unix(),
+		isFromMe:   info.IsFromMe,
+		forwarding: forwardingStateFromMessage(msg),
+	}
+}
+
+type messageCallback struct {
+	info        C.MessageInfo
+	forwardData unsafe.Pointer
+}
+
+func beginMessageCallback(info types.MessageInfo, msg *waE2E.Message, rawSource []byte) *messageCallback {
+	messageCallbackMu.Lock()
+	callback := &messageCallback{}
+	if len(rawSource) > 0 {
+		callback.forwardData = C.CBytes(rawSource)
+	}
+	C.setActiveForwardSource((*C.uint8_t)(callback.forwardData), C.size_t(len(rawSource)))
+	metadata := messageCallbackMetadataFrom(info, msg)
+	callback.info = C.MessageInfo{
+		id:              C.CString(metadata.id),
+		chat:            jidToC(metadata.chat),
+		sender:          jidToC(metadata.sender),
+		timestamp:       C.int64_t(metadata.timestamp),
+		isFromMe:        C.bool(metadata.isFromMe),
+		quoteID:         nil,
+		readBy:          C.uint16_t(0),
+		isForwarded:     C.bool(metadata.forwarding.isForwarded),
+		forwardingScore: C.uint32_t(metadata.forwarding.score),
+	}
+	return callback
+}
+
+func (callback *messageCallback) close() {
+	C.setActiveForwardSource(nil, 0)
+	if callback.forwardData != nil {
+		C.free(callback.forwardData)
+	}
+	messageCallbackMu.Unlock()
+}
+
 const (
 	EventTypeSyncProgress         = 0
 	EventTypeAppStateSyncComplete = 1
@@ -153,35 +208,13 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 
 	info = normalizeMessageInfo(info)
 
-	chat := info.Chat
-	sender := info.Sender
 	if dispatchMessageEvent(info, msg) {
 		return
 	}
 	rawSource := forwardingSourcePayload(info, msg, viewOnceUnavailable)
-	messageCallbackMu.Lock()
-	defer messageCallbackMu.Unlock()
-	var cForwardSource unsafe.Pointer
-	if len(rawSource) > 0 {
-		cForwardSource = C.CBytes(rawSource)
-		defer C.free(cForwardSource)
-	}
-	C.setActiveForwardSource((*C.uint8_t)(cForwardSource), C.size_t(len(rawSource)))
-	defer C.setActiveForwardSource(nil, 0)
-	timestamp := info.Timestamp.Unix()
-	forwarding := forwardingStateFromMessage(msg)
-
-	cinfo := C.MessageInfo{
-		id:              C.CString(info.ID),
-		chat:            jidToC(chat),
-		sender:          jidToC(sender),
-		timestamp:       C.int64_t(timestamp),
-		isFromMe:        C.bool(info.IsFromMe),
-		quoteID:         nil,
-		readBy:          C.uint16_t(0),
-		isForwarded:     C.bool(forwarding.isForwarded),
-		forwardingScore: C.uint32_t(forwarding.score),
-	}
+	callback := beginMessageCallback(info, msg, rawSource)
+	defer callback.close()
+	cinfo := callback.info
 
 	if msg.Conversation != nil {
 		ctext := C.CString(msg.GetConversation())

--- a/whatsrust/lib/message_callback_test.go
+++ b/whatsrust/lib/message_callback_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestMessageCallbackMetadataFromPreservesCallbackFields(t *testing.T) {
+	info := types.MessageInfo{
+		MessageSource: types.MessageSource{
+			Chat:     types.NewJID("chat", "example.test"),
+			Sender:   types.NewJID("sender", "example.test"),
+			IsFromMe: true,
+		},
+		ID:        "message-id",
+		Timestamp: time.Unix(123, 456),
+	}
+	forwarded := true
+	message := &waE2E.Message{
+		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+			ContextInfo: &waE2E.ContextInfo{IsForwarded: &forwarded, ForwardingScore: proto.Uint32(4)},
+		},
+	}
+
+	metadata := messageCallbackMetadataFrom(info, message)
+	if metadata.id != info.ID || metadata.chat != info.Chat || metadata.sender != info.Sender {
+		t.Fatalf("callback identity metadata changed: %#v", metadata)
+	}
+	if metadata.timestamp != 123 || !metadata.isFromMe {
+		t.Fatalf("callback scalar metadata changed: %#v", metadata)
+	}
+	if metadata.forwarding != (forwardingState{isForwarded: true, score: 4}) {
+		t.Fatalf("callback forwarding metadata changed: %#v", metadata.forwarding)
+	}
+}
+
+func TestBeginMessageCallbackSerializesCallbacks(t *testing.T) {
+	info := types.MessageInfo{Timestamp: time.Unix(1, 0)}
+	first := beginMessageCallback(info, &waE2E.Message{}, []byte("source"))
+	acquired := make(chan struct{})
+	done := make(chan *messageCallback)
+	go func() {
+		callback := beginMessageCallback(info, &waE2E.Message{}, nil)
+		close(acquired)
+		done <- callback
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second callback acquired the callback lock early")
+	case <-time.After(10 * time.Millisecond):
+	}
+	first.close()
+
+	select {
+	case second := <-done:
+		second.close()
+	case <-time.After(time.Second):
+		t.Fatal("second callback did not acquire the callback lock")
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts exactly the C ABI callback metadata construction and callback synchronization from `HandleMessage`.
- Keeps text, file, and multimedia payload construction in `HandleMessage`.

## Changes

- Adds a callback metadata helper preserving identity, timestamp, sender flags, and forwarding state.
- Adds a callback guard preserving active forward-source lifetime and serialized callback delivery.
- Adds focused tests for metadata preservation and callback serialization.

## Testing

- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` and `git diff --check`
- [x] Authored diff: 123 lines (<400).
- [x] No Cargo/Rust, race, merge, or CI work performed.
- [x] ABI and behavior preserved; no payload text/file/multimedia extraction.
- [x] No privacy, scope, or attribution changes.

## Remaining seams

- Text, file, and multimedia payload construction.

Closes #207