### PR TITLE
refactor(bridge): extract text payload emission

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -203,6 +203,22 @@ const (
 	FileTypeSticker
 )
 
+func emitTextMessage(cinfo C.MessageInfo, text string, isSync bool) {
+	ctext := C.CString(text)
+	defer C.free(unsafe.Pointer(ctext))
+
+	content := (*C.TextMessage)(C.malloc(C.sizeof_TextMessage))
+	content.text = ctext
+	defer C.free(unsafe.Pointer(content))
+
+	message := C.Message{
+		info:        cinfo,
+		messageType: C.uint8_t(MessageTypeText),
+		message:     unsafe.Pointer(content),
+	}
+	C.callMessageHandler(messageHandler, C.bool(isSync), &message)
+}
+
 func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	msg, viewOnceUnavailable := unavailableViewOnceMessage(msg)
 
@@ -217,27 +233,10 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	cinfo := callback.info
 
 	if msg.Conversation != nil {
-		ctext := C.CString(msg.GetConversation())
-		defer C.free(unsafe.Pointer(ctext))
-
-		content := (*C.TextMessage)(C.malloc(C.sizeof_TextMessage))
-		content.text = ctext
-		defer C.free(unsafe.Pointer(content))
-
-		message := C.Message{
-			info:        cinfo,
-			messageType: C.uint8_t(MessageTypeText),
-			message:     unsafe.Pointer(content),
-		}
-
-		C.callMessageHandler(messageHandler, C.bool(isSync), &message)
+		emitTextMessage(cinfo, msg.GetConversation(), isSync)
 	}
 	if msg.ExtendedTextMessage != nil {
 		ext_msg := msg.GetExtendedTextMessage()
-
-		text := ext_msg.GetText()
-		ctext := C.CString(text)
-		defer C.free(unsafe.Pointer(ctext))
 
 		context_info := ext_msg.GetContextInfo()
 		if context_info != nil {
@@ -248,16 +247,7 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 			}
 		}
 
-		content := (*C.TextMessage)(C.malloc(C.sizeof_TextMessage))
-		content.text = ctext
-		defer C.free(unsafe.Pointer(content))
-
-		message := C.Message{
-			info:        cinfo,
-			messageType: C.uint8_t(MessageTypeText),
-			message:     unsafe.Pointer(content),
-		}
-		C.callMessageHandler(messageHandler, C.bool(isSync), &message)
+		emitTextMessage(cinfo, ext_msg.GetText(), isSync)
 	}
 	if msg.ImageMessage != nil {
 		img := msg.GetImageMessage()

--- a/whatsrust/lib/message_payload_test.go
+++ b/whatsrust/lib/message_payload_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHandleMessageOwnsTextPayloadEmission(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainSource := string(source)
+
+	if !strings.Contains(mainSource, "func emitTextMessage(") {
+		t.Fatal("text payload emission seam is missing")
+	}
+	if strings.Count(mainSource, "emitTextMessage(cinfo,") != 2 {
+		t.Fatal("conversation and extended-text payloads must use the text seam")
+	}
+	for _, fragment := range []string{
+		"if msg.ImageMessage != nil",
+		"if msg.VideoMessage != nil",
+		"if msg.AudioMessage != nil",
+		"if msg.DocumentMessage != nil",
+		"if msg.StickerMessage != nil",
+	} {
+		if !strings.Contains(mainSource, fragment) {
+			t.Fatalf("remaining media payload responsibility changed: %q", fragment)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Extract text callback payload construction into `emitTextMessage`.
- Preserve the existing C ABI, allocation ownership, callback ordering, and sync flag.
- Keep file and multimedia payload construction listed as the remaining responsibility because it has distinct downloadable-media conversion concerns.

## Changes

| File | Change |
|------|--------|
| `whatsrust/lib/main.go` | Centralize conversation and extended-text C payload emission. |
| `whatsrust/lib/message_payload_test.go` | Add ownership coverage for the extracted text seam and remaining media branches. |

## Testing

- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` and `git diff --check`
- [x] Authored diff: 79 lines (<400).
- [x] No Cargo/Rust, race, merge, or CI work performed.
- [x] ABI and behavior preserved; no privacy, scope, or attribution changes.

## Remaining audit

- File/multimedia payload construction remains in `HandleMessage`. It performs downloadable-media conversion, path/extension selection, captions, thumbnail sidecar embedding, and media-kind mapping; those are a separate responsibility from direct text C-string emission.

Closes #209