### PR TITLE
refactor(bridge): extract file payload emission

### DIFF
--- a/whatsrust/lib/file_message_payload.go
+++ b/whatsrust/lib/file_message_payload.go
@@ -1,0 +1,128 @@
+package main
+
+/*
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "callback_log_registration.h"
+
+typedef struct {
+	uint8_t kind;
+	char* path;
+	char* fileID;
+	char* caption;
+} FileMessage;
+
+extern void callMessageHandler(MessageHandler hdl, bool isSync, const Message* data);
+*/
+import "C"
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+)
+
+func emitFileMessage(cinfo C.MessageInfo, kind uint8, filePath, fileID, caption string, isSync bool) {
+	cfileID := C.CString(fileID)
+	defer C.free(unsafe.Pointer(cfileID))
+
+	cpath := C.CString(filePath)
+	defer C.free(unsafe.Pointer(cpath))
+
+	ccaption := C.CString(caption)
+	if caption == "" {
+		ccaption = nil
+	}
+	defer C.free(unsafe.Pointer(ccaption))
+
+	content := (*C.FileMessage)(C.malloc(C.sizeof_FileMessage))
+	content.kind = C.uint8_t(kind)
+	content.path = cpath
+	content.fileID = cfileID
+	content.caption = ccaption
+	defer C.free(unsafe.Pointer(content))
+
+	message := C.Message{
+		info:        cinfo,
+		messageType: C.uint8_t(MessageTypeFile),
+		message:     unsafe.Pointer(content),
+	}
+	C.callMessageHandler(messageHandler, C.bool(isSync), &message)
+}
+
+func emitImageMessage(cinfo C.MessageInfo, messageID string, image *waE2E.ImageMessage, isSync bool) bool {
+	if image == nil {
+		LOG_ERROR("ImageMessage is nil")
+		return false
+	}
+	setMessageQuoteID(&cinfo, image.GetContextInfo())
+	ext := ExtensionByType(image.GetMimetype(), ".jpg")
+	filePath := fmt.Sprintf("imgs/%s%s", messageID, ext)
+	fileID := DownloadableMessageToFileId(client, image, filePath)
+	emitFileMessage(cinfo, FileTypeImage, filePath, fileID, image.GetCaption(), isSync)
+	return true
+}
+
+func emitVideoMessage(cinfo C.MessageInfo, messageID string, video *waE2E.VideoMessage, isSync bool) bool {
+	if video == nil {
+		LOG_ERROR("VideoMessage is nil")
+		return false
+	}
+	setMessageQuoteID(&cinfo, video.GetContextInfo())
+	ext := ExtensionByType(video.GetMimetype(), ".mp4")
+	filePath := fmt.Sprintf("videos/%s%s", messageID, ext)
+	fileID := DownloadableMessageToFileId(client, video, filePath)
+	if thumbnail := video.GetJPEGThumbnail(); len(thumbnail) > 0 {
+		thumbPath := strings.TrimSuffix(filePath, ext) + ".jpg"
+		fileID = AddThumbnailToFileId(fileID, thumbnail, thumbPath)
+	}
+	emitFileMessage(cinfo, FileTypeVideo, filePath, fileID, video.GetCaption(), isSync)
+	return true
+}
+
+func emitAudioMessage(cinfo C.MessageInfo, messageID string, audio *waE2E.AudioMessage, isSync bool) bool {
+	if audio == nil {
+		LOG_ERROR("AudioMessage is nil")
+		return false
+	}
+	setMessageQuoteID(&cinfo, audio.GetContextInfo())
+	ext := ExtensionByType(audio.GetMimetype(), ".ogg")
+	filePath := fmt.Sprintf("audios/%s%s", messageID, ext)
+	fileID := DownloadableMessageToFileId(client, audio, filePath)
+	emitFileMessage(cinfo, FileTypeAudio, filePath, fileID, "", isSync)
+	return true
+}
+
+func emitDocumentMessage(cinfo C.MessageInfo, messageID string, document *waE2E.DocumentMessage, isSync bool) bool {
+	if document == nil {
+		LOG_ERROR("DocumentMessage is nil")
+		return false
+	}
+	setMessageQuoteID(&cinfo, document.GetContextInfo())
+	filePath := fmt.Sprintf("docs/%s-%s", messageID, *document.FileName)
+	fileID := DownloadableMessageToFileId(client, document, filePath)
+	emitFileMessage(cinfo, FileTypeDocument, filePath, fileID, document.GetCaption(), isSync)
+	return true
+}
+
+func emitStickerMessage(cinfo C.MessageInfo, messageID string, sticker *waE2E.StickerMessage, isSync bool) bool {
+	if sticker == nil {
+		LOG_ERROR("StickerMessage is nil")
+		return false
+	}
+	setMessageQuoteID(&cinfo, sticker.GetContextInfo())
+	ext := ExtensionByType(sticker.GetMimetype(), ".webp")
+	filePath := fmt.Sprintf("stickers/%s%s", messageID, ext)
+	fileID := DownloadableMessageToFileId(client, sticker, filePath)
+	emitFileMessage(cinfo, FileTypeSticker, filePath, fileID, "", isSync)
+	return true
+}
+
+func setMessageQuoteID(cinfo *C.MessageInfo, contextInfo *waE2E.ContextInfo) {
+	if contextInfo != nil && contextInfo.GetStanzaID() != "" {
+		cinfo.quoteID = C.CString(contextInfo.GetStanzaID())
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -76,7 +76,7 @@ static void setActiveForwardSource(uint8_t* source, size_t length) {
     activeForwardSource = source;
     activeForwardSourceLen = length;
 }
-static void callMessageHandler(MessageHandler hdl, bool isSync, const Message* data) {
+void callMessageHandler(MessageHandler hdl, bool isSync, const Message* data) {
     Message copy = *data;
     copy.forwardSource = activeForwardSource;
     copy.forwardSourceLen = activeForwardSourceLen;
@@ -95,8 +95,6 @@ static void callHistorySync(HistorySyncHandler hdl, uint32_t percent) {
 */
 import "C"
 import (
-	"fmt"
-	"strings"
 	"sync"
 	"unsafe"
 
@@ -250,228 +248,29 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 		emitTextMessage(cinfo, ext_msg.GetText(), isSync)
 	}
 	if msg.ImageMessage != nil {
-		img := msg.GetImageMessage()
-		if img == nil {
-			LOG_ERROR("ImageMessage is nil")
+		if !emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync) {
 			return
 		}
-
-		ext := ExtensionByType(img.GetMimetype(), ".jpg")
-		caption := img.GetCaption()
-
-		context_info := img.GetContextInfo()
-		if context_info != nil {
-			id := context_info.GetStanzaID()
-			if id != "" {
-				cinfo.quoteID = C.CString(id)
-			}
-		}
-
-		filePath := fmt.Sprintf("imgs/%s%s", info.ID, ext)
-
-		fileId := DownloadableMessageToFileId(client, img, filePath)
-		cfileId := C.CString(fileId)
-		defer C.free(unsafe.Pointer(cfileId))
-
-		cpath := C.CString(filePath)
-		defer C.free(unsafe.Pointer(cpath))
-
-		// set caption or nil
-		ccaption := C.CString(caption)
-		if caption == "" {
-			ccaption = nil
-		}
-		defer C.free(unsafe.Pointer(ccaption))
-
-		content := (*C.FileMessage)(C.malloc(C.sizeof_FileMessage))
-		content.kind = C.uint8_t(FileTypeImage)
-		content.path = cpath
-		content.fileID = cfileId
-		content.caption = ccaption
-		defer C.free(unsafe.Pointer(content))
-
-		message := C.Message{
-			info:        cinfo,
-			messageType: C.uint8_t(MessageTypeFile),
-			message:     unsafe.Pointer(content),
-		}
-		C.callMessageHandler(messageHandler, C.bool(isSync), &message)
 	}
 	if msg.VideoMessage != nil {
-		vid := msg.GetVideoMessage()
-		if vid == nil {
-			LOG_ERROR("VideoMessage is nil")
+		if !emitVideoMessage(cinfo, info.ID, msg.GetVideoMessage(), isSync) {
 			return
 		}
-
-		ext := ExtensionByType(vid.GetMimetype(), ".mp4")
-		caption := vid.GetCaption()
-
-		context_info := vid.GetContextInfo()
-		if context_info != nil {
-			id := context_info.GetStanzaID()
-			if id != "" {
-				cinfo.quoteID = C.CString(id)
-			}
-		}
-
-		filePath := fmt.Sprintf("videos/%s%s", info.ID, ext)
-		fileId := DownloadableMessageToFileId(client, vid, filePath)
-
-		// Embed JPEG thumbnail into the fileId so DownloadFromFileId
-		// saves it as a sidecar file (videos/<id>.jpg) alongside the video.
-		if thumbnail := vid.GetJPEGThumbnail(); len(thumbnail) > 0 {
-			thumbPath := strings.TrimSuffix(filePath, ext) + ".jpg"
-			fileId = AddThumbnailToFileId(fileId, thumbnail, thumbPath)
-		}
-
-		cfileId := C.CString(fileId)
-		defer C.free(unsafe.Pointer(cfileId))
-
-		cpath := C.CString(filePath)
-		defer C.free(unsafe.Pointer(cpath))
-
-		ccaption := C.CString(caption)
-		if caption == "" {
-			ccaption = nil
-		}
-		defer C.free(unsafe.Pointer(ccaption))
-
-		content := (*C.FileMessage)(C.malloc(C.sizeof_FileMessage))
-		content.kind = C.uint8_t(FileTypeVideo)
-		content.path = cpath
-		content.fileID = cfileId
-		content.caption = ccaption
-		defer C.free(unsafe.Pointer(content))
-		message := C.Message{
-			info:        cinfo,
-			messageType: C.uint8_t(MessageTypeFile),
-			message:     unsafe.Pointer(content),
-		}
-		C.callMessageHandler(messageHandler, C.bool(isSync), &message)
 	}
 	if msg.AudioMessage != nil {
-		audio := msg.GetAudioMessage()
-		if audio == nil {
-			LOG_ERROR("AudioMessage is nil")
+		if !emitAudioMessage(cinfo, info.ID, msg.GetAudioMessage(), isSync) {
 			return
 		}
-
-		ext := ExtensionByType(audio.GetMimetype(), ".ogg")
-
-		context_info := audio.GetContextInfo()
-		if context_info != nil {
-			id := context_info.GetStanzaID()
-			if id != "" {
-				cinfo.quoteID = C.CString(id)
-			}
-		}
-
-		filePath := fmt.Sprintf("audios/%s%s", info.ID, ext)
-		fileId := DownloadableMessageToFileId(client, audio, filePath)
-		cfileId := C.CString(fileId)
-		defer C.free(unsafe.Pointer(cfileId))
-
-		cpath := C.CString(filePath)
-		defer C.free(unsafe.Pointer(cpath))
-
-		content := (*C.FileMessage)(C.malloc(C.sizeof_FileMessage))
-		content.kind = C.uint8_t(FileTypeAudio)
-		content.path = cpath
-		content.fileID = cfileId
-		content.caption = nil
-		defer C.free(unsafe.Pointer(content))
-
-		message := C.Message{
-			info:        cinfo,
-			messageType: C.uint8_t(MessageTypeFile),
-			message:     unsafe.Pointer(content),
-		}
-		C.callMessageHandler(messageHandler, C.bool(isSync), &message)
 	}
 	if msg.DocumentMessage != nil {
-		doc := msg.GetDocumentMessage()
-		if doc == nil {
-			LOG_ERROR("DocumentMessage is nil")
+		if !emitDocumentMessage(cinfo, info.ID, msg.GetDocumentMessage(), isSync) {
 			return
 		}
-
-		caption := doc.GetCaption()
-
-		context_info := doc.GetContextInfo()
-		if context_info != nil {
-			id := context_info.GetStanzaID()
-			if id != "" {
-				cinfo.quoteID = C.CString(id)
-			}
-		}
-
-		filePath := fmt.Sprintf("docs/%s-%s", info.ID, *doc.FileName)
-		fileId := DownloadableMessageToFileId(client, doc, filePath)
-		cfileId := C.CString(fileId)
-		defer C.free(unsafe.Pointer(cfileId))
-
-		cpath := C.CString(filePath)
-		defer C.free(unsafe.Pointer(cpath))
-
-		ccaption := C.CString(caption)
-		if caption == "" {
-			ccaption = nil
-		}
-		defer C.free(unsafe.Pointer(ccaption))
-
-		content := (*C.FileMessage)(C.malloc(C.sizeof_FileMessage))
-		content.kind = C.uint8_t(FileTypeDocument)
-		content.path = cpath
-		content.fileID = cfileId
-		content.caption = ccaption
-		defer C.free(unsafe.Pointer(content))
-
-		message := C.Message{
-			info:        cinfo,
-			messageType: C.uint8_t(MessageTypeFile),
-			message:     unsafe.Pointer(content),
-		}
-		C.callMessageHandler(messageHandler, C.bool(isSync), &message)
 	}
 	if msg.StickerMessage != nil {
-		sticker := msg.GetStickerMessage()
-		if sticker == nil {
-			LOG_ERROR("StickerMessage is nil")
+		if !emitStickerMessage(cinfo, info.ID, msg.GetStickerMessage(), isSync) {
 			return
 		}
-
-		ext := ExtensionByType(sticker.GetMimetype(), ".webp")
-
-		context_info := sticker.GetContextInfo()
-		if context_info != nil {
-			id := context_info.GetStanzaID()
-			if id != "" {
-				cinfo.quoteID = C.CString(id)
-			}
-		}
-
-		filePath := fmt.Sprintf("stickers/%s%s", info.ID, ext)
-		fileId := DownloadableMessageToFileId(client, sticker, filePath)
-		cfileId := C.CString(fileId)
-		defer C.free(unsafe.Pointer(cfileId))
-
-		cpath := C.CString(filePath)
-		defer C.free(unsafe.Pointer(cpath))
-
-		content := (*C.FileMessage)(C.malloc(C.sizeof_FileMessage))
-		content.kind = C.uint8_t(FileTypeSticker)
-		content.path = cpath
-		content.fileID = cfileId
-		content.caption = nil
-		defer C.free(unsafe.Pointer(content))
-
-		message := C.Message{
-			info:        cinfo,
-			messageType: C.uint8_t(MessageTypeFile),
-			message:     unsafe.Pointer(content),
-		}
-		C.callMessageHandler(messageHandler, C.bool(isSync), &message)
 	}
 }
 

--- a/whatsrust/lib/message_payload_test.go
+++ b/whatsrust/lib/message_payload_test.go
@@ -19,15 +19,32 @@ func TestHandleMessageOwnsTextPayloadEmission(t *testing.T) {
 	if strings.Count(mainSource, "emitTextMessage(cinfo,") != 2 {
 		t.Fatal("conversation and extended-text payloads must use the text seam")
 	}
+}
+
+func TestHandleMessageDelegatesFilePayloadEmission(t *testing.T) {
+	if strings.Contains(string(mustRead(t, "main.go")), "func emitFileMessage(") {
+		t.Fatal("file payload emission must remain outside HandleMessage's composition file")
+	}
+	source := string(mustRead(t, "file_message_payload.go"))
 	for _, fragment := range []string{
-		"if msg.ImageMessage != nil",
-		"if msg.VideoMessage != nil",
-		"if msg.AudioMessage != nil",
-		"if msg.DocumentMessage != nil",
-		"if msg.StickerMessage != nil",
+		"func emitFileMessage(",
+		"func emitImageMessage(",
+		"func emitVideoMessage(",
+		"func emitAudioMessage(",
+		"func emitDocumentMessage(",
+		"func emitStickerMessage(",
 	} {
-		if !strings.Contains(mainSource, fragment) {
-			t.Fatalf("remaining media payload responsibility changed: %q", fragment)
+		if !strings.Contains(source, fragment) {
+			t.Fatalf("file payload seam is missing: %q", fragment)
 		}
 	}
+}
+
+func mustRead(t *testing.T, name string) []byte {
+	t.Helper()
+	source, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return source
 }


### PR DESCRIPTION
## Summary
- Extract file and multimedia callback payload conversion and C emission from `HandleMessage`.
- Preserve media ordering, quote metadata, thumbnail sidecars, nil handling, ownership, callback order, and sync propagation.
- Keep the authored diff under 400 lines.

## Changes
| File | Change |
|------|--------|
| `whatsrust/lib/file_message_payload.go` | Own shared file payload allocation/emission and image, video, audio, document, and sticker adapters. |
| `whatsrust/lib/main.go` | Keep `HandleMessage` as composition and retain the existing cgo callback bridge. |
| `whatsrust/lib/message_payload_test.go` | Verify text ownership remains intact and media ownership is delegated. |

## Testing
- [x] `gofmt`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `git diff --check`
- [x] Authored diff: 372 lines (<400)
- [x] No Cargo/Rust, race, merge, or CI work performed

## Main.go audit
`main.go` still contains the cgo bridge and callback composition plus pre-existing seams: self identity lookup (`GetSelfId`), callback metadata/synchronization (`messageCallbackMetadataFrom`, `beginMessageCallback`), text payload emission (`emitTextMessage`), and action-kind naming (`messageActionKindName`). This scoped change does not extract those responsibilities.

Closes #212