### PR TITLE
refactor(bridge): extract self identity helper

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -98,7 +98,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 )
@@ -112,14 +111,6 @@ const (
 	forwardFailureInvalidDestination
 	forwardFailureSendFailed
 )
-
-// GetSelfId returns the current user's JID string for comparison (e.g. broadcast sender).
-func GetSelfId(client *whatsmeow.Client) string {
-	if client == nil || client.Store == nil || client.Store.ID == nil {
-		return ""
-	}
-	return StrFromJid(*client.Store.ID)
-}
 
 type messageCallbackMetadata struct {
 	id         string

--- a/whatsrust/lib/self_identity.go
+++ b/whatsrust/lib/self_identity.go
@@ -1,0 +1,11 @@
+package main
+
+import "go.mau.fi/whatsmeow"
+
+// GetSelfId returns the current user's JID string for comparison (e.g. broadcast sender).
+func GetSelfId(client *whatsmeow.Client) string {
+	if client == nil || client.Store == nil || client.Store.ID == nil {
+		return ""
+	}
+	return StrFromJid(*client.Store.ID)
+}

--- a/whatsrust/lib/self_identity_test.go
+++ b/whatsrust/lib/self_identity_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestGetSelfIdReturnsConfiguredIdentity(t *testing.T) {
+	client := &whatsmeow.Client{
+		Store: &store.Device{ID: pointerToJID(types.NewJID("15551234567", types.DefaultUserServer))},
+	}
+
+	if got := GetSelfId(client); got != "15551234567@s.whatsapp.net" {
+		t.Fatalf("GetSelfId() = %q, want %q", got, "15551234567@s.whatsapp.net")
+	}
+}
+
+func TestGetSelfIdReturnsEmptyForMissingIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *whatsmeow.Client
+	}{
+		{name: "nil client"},
+		{name: "nil store", client: &whatsmeow.Client{}},
+		{name: "nil device id", client: &whatsmeow.Client{Store: &store.Device{}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetSelfId(tt.client); got != "" {
+				t.Fatalf("GetSelfId() = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func pointerToJID(jid types.JID) *types.JID {
+	return &jid
+}


### PR DESCRIPTION
## Summary
- Extract the independent `GetSelfId` identity seam from `whatsrust/lib/main.go`.
- Preserve nil handling and the exact self-JID representation used by broadcast identity comparison.
- Repair the malformed branch reuse behind PR #216 without rewriting remote history.

## Changes
- Move self-identity lookup into `whatsrust/lib/self_identity.go`.
- Keep focused configured, missing-client, missing-store, and missing-device coverage in `self_identity_test.go`.
- Keep `HandleMessage` callback composition and unrelated action-kind naming unchanged.

## Chain context
- Exact base: `refactor/file-payload-construction` at `0eafbe6`.
- This PR contains exactly one responsibility commit: `3f35dd3` (replayed locally as `ba28c4e`).
- Follow-up action-kind naming PR will target this branch.

## Testing
- [x] `gofmt` check (`gofmt -d .` clean)
- [x] `git diff --check`
- [x] Focused Go tests
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cd whatsrust/lib && go test ./...`
- [x] No Cargo/Rust, race, merge, or CI work performed

Closes #215