### PR TITLE
refactor(bridge): move message action kind naming

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -265,11 +265,4 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	}
 }
 
-func messageActionKindName(kind uint8) string {
-	if kind == messageActionEdit {
-		return "edit"
-	}
-	return "delete"
-}
-
 func main() {} // Required for CGO

--- a/whatsrust/lib/message_action_classifier.go
+++ b/whatsrust/lib/message_action_classifier.go
@@ -12,6 +12,13 @@ const (
 	messageActionDelete
 )
 
+func messageActionKindName(kind uint8) string {
+	if kind == messageActionEdit {
+		return "edit"
+	}
+	return "delete"
+}
+
 type messageActionEvent struct {
 	actionID, chat, sender, targetMessageID, replacement string
 	occurredAt                                           int64

--- a/whatsrust/lib/message_action_classifier_test.go
+++ b/whatsrust/lib/message_action_classifier_test.go
@@ -9,6 +9,25 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+func TestMessageActionKindName(t *testing.T) {
+	tests := []struct {
+		name string
+		kind uint8
+		want string
+	}{
+		{name: "edit", kind: messageActionEdit, want: "edit"},
+		{name: "delete", kind: messageActionDelete, want: "delete"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := messageActionKindName(tt.kind); got != tt.want {
+				t.Fatalf("messageActionKindName(%d) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMessageActionEventFromMessage(t *testing.T) {
 	baseInfo := types.MessageInfo{
 		MessageSource: types.MessageSource{Chat: types.NewJID("chat", types.DefaultUserServer), Sender: types.NewJID("sender", types.DefaultUserServer)},


### PR DESCRIPTION
## Summary
- Move the residual `messageActionKindName` helper beside the message-action classifier.
- Preserve the existing edit/delete mapping and cgo ABI.
- Repair the malformed branch reuse behind PR #220 without rewriting remote history.

## Changes
- Remove action-kind naming from `whatsrust/lib/main.go`.
- Keep action-kind naming beside `messageActionEdit` and `messageActionDelete`.
- Add table-driven coverage for both action kinds.

## Chain context
- Exact base: `refactor/go-self-identity` at `ba28c4e2acc23d19bc92c3cdfd2f62567102cb2d` (replacement PR #223).
- This PR contains exactly one responsibility commit: `ce18aa7` (replayed locally as `b0a35a3`).
- It is intentionally dependent on the self-identity replacement PR.

## Testing
- [x] `gofmt` check (`gofmt -d .` clean)
- [x] `git diff --check`
- [x] Focused Go tests
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cd whatsrust/lib && go test ./...`
- [x] No Cargo/Rust, race, merge, or CI work performed

Closes #219