### PR TITLE
refactor(bridge): move text payload ownership to its module

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -17,10 +17,6 @@ typedef struct {
 } Contact;
 
 typedef struct {
-	char* text;
-} TextMessage;
-
-typedef struct {
 	uint8_t kind;
 	char* path;
 	char* fileID;
@@ -84,8 +80,6 @@ static void callHistorySync(HistorySyncHandler hdl, uint32_t percent) {
 */
 import "C"
 import (
-	"unsafe"
-
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 )
@@ -122,22 +116,6 @@ const (
 	FileTypeDocument
 	FileTypeSticker
 )
-
-func emitTextMessage(cinfo C.MessageInfo, text string, isSync bool) {
-	ctext := C.CString(text)
-	defer C.free(unsafe.Pointer(ctext))
-
-	content := (*C.TextMessage)(C.malloc(C.sizeof_TextMessage))
-	content.text = ctext
-	defer C.free(unsafe.Pointer(content))
-
-	message := C.Message{
-		info:        cinfo,
-		messageType: C.uint8_t(MessageTypeText),
-		message:     unsafe.Pointer(content),
-	}
-	C.callMessageHandler(messageHandler, C.bool(isSync), &message)
-}
 
 func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 	msg, viewOnceUnavailable := unavailableViewOnceMessage(msg)

--- a/whatsrust/lib/message_payload_test.go
+++ b/whatsrust/lib/message_payload_test.go
@@ -6,21 +6,6 @@ import (
 	"testing"
 )
 
-func TestHandleMessageOwnsTextPayloadEmission(t *testing.T) {
-	source, err := os.ReadFile("main.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	mainSource := string(source)
-
-	if !strings.Contains(mainSource, "func emitTextMessage(") {
-		t.Fatal("text payload emission seam is missing")
-	}
-	if strings.Count(mainSource, "emitTextMessage(cinfo,") != 2 {
-		t.Fatal("conversation and extended-text payloads must use the text seam")
-	}
-}
-
 func TestHandleMessageDelegatesFilePayloadEmission(t *testing.T) {
 	if strings.Contains(string(mustRead(t, "main.go")), "func emitFileMessage(") {
 		t.Fatal("file payload emission must remain outside HandleMessage's composition file")

--- a/whatsrust/lib/text_message_payload.go
+++ b/whatsrust/lib/text_message_payload.go
@@ -1,0 +1,33 @@
+package main
+
+/*
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "callback_log_registration.h"
+
+typedef struct {
+	char* text;
+} TextMessage;
+
+extern void callMessageHandler(MessageHandler hdl, bool isSync, const Message* data);
+*/
+import "C"
+
+import "unsafe"
+
+func emitTextMessage(cinfo C.MessageInfo, text string, isSync bool) {
+	ctext := C.CString(text)
+	defer C.free(unsafe.Pointer(ctext))
+
+	content := (*C.TextMessage)(C.malloc(C.sizeof_TextMessage))
+	content.text = ctext
+	defer C.free(unsafe.Pointer(content))
+
+	message := C.Message{
+		info:        cinfo,
+		messageType: C.uint8_t(MessageTypeText),
+		message:     unsafe.Pointer(content),
+	}
+	C.callMessageHandler(messageHandler, C.bool(isSync), &message)
+}

--- a/whatsrust/lib/text_message_payload_test.go
+++ b/whatsrust/lib/text_message_payload_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTextPayloadOwnershipIsKeptWithEmitter(t *testing.T) {
+	mainSource := string(mustRead(t, "main.go"))
+	source, err := os.ReadFile("text_message_payload.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	textSource := string(source)
+
+	if strings.Contains(mainSource, "func emitTextMessage(") {
+		t.Fatal("text payload emission must not remain in HandleMessage's composition file")
+	}
+	for _, fragment := range []string{
+		"typedef struct {\n\tchar* text;\n} TextMessage;",
+		"func emitTextMessage(",
+		"C.sizeof_TextMessage",
+		"defer C.free(unsafe.Pointer(ctext))",
+		"defer C.free(unsafe.Pointer(content))",
+	} {
+		if !strings.Contains(textSource, fragment) {
+			t.Fatalf("text payload ownership is missing: %q", fragment)
+		}
+	}
+	if strings.Count(mainSource, "emitTextMessage(cinfo,") != 2 {
+		t.Fatal("conversation and extended-text payloads must use the text seam")
+	}
+}


### PR DESCRIPTION
## Summary
- Move direct text callback payload emission out of `main.go` into `text_message_payload.go`.
- Keep the C `TextMessage` declaration, allocation/free ownership, callback routing, and focused ownership tests with the emitter.
- Leave `HandleMessage` orchestration and already-delegated file/multimedia emitters untouched.

## Chain context
- Exact base: `refactor/go-callback-metadata` / PR #225.
- The prior broad issue #209 is already linked to open PR #210, so this corrected chain uses dedicated issue #228.
- Child commit: `ec531b3`.

## Changes
- `whatsrust/lib/text_message_payload.go` owns `TextMessage` and `emitTextMessage`.
- `whatsrust/lib/main.go` retains only the two text call sites and orchestration.
- `whatsrust/lib/text_message_payload_test.go` verifies ownership, declarations, allocation cleanup, and both call sites.
- File/multimedia payload emission remains owned by `file_message_payload.go`.

## Testing
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt -d .`
- [x] `git diff --check`
- [x] Authored diff: 104 lines (<400).
- [x] No Cargo/Rust, race, merge, or CI work performed.
- [x] ABI and behavior preserved; no privacy, scope, or attribution changes.

Closes #228