### PR TITLE
refactor(ui): extract message-list layout cache integration

### DIFF
--- a/src/ui/message_layout_integration.rs
+++ b/src/ui/message_layout_integration.rs
@@ -1,0 +1,53 @@
+use whatsrust as wr;
+
+use crate::app::{App, FileMeta, Metadata};
+
+use super::message_helpers::forwarding_label;
+use super::message_layout::{self, LayoutInput, file_kind};
+use super::{AuthorGroupContext, status_label};
+
+pub fn message_height(
+    message: &wr::Message,
+    width: usize,
+    is_selected: bool,
+    author_group: AuthorGroupContext,
+    app: &mut App,
+) -> usize {
+    let input = LayoutInput {
+        width,
+        is_selected,
+        has_quote: message.info.quote_id.is_some(),
+        has_reactions: app.reactions.contains_key(&message.info.id),
+        author_group,
+        content: match &message.message {
+            wr::MessageContent::Text(text) => message_layout::HeightContent::Text {
+                body: text,
+                forwarding: forwarding_label(message),
+                status: status_label(app, &message.info.id),
+            },
+            wr::MessageContent::File(file) => message_layout::HeightContent::File {
+                kind: file_kind(file.kind.clone()),
+                caption: file.caption.as_deref(),
+                forwarding: forwarding_label(message),
+                preview_loaded: matches!(
+                    app.metadata.get(&message.info.id),
+                    Some(Metadata::File(FileMeta::Loaded))
+                ),
+                status: status_label(app, &message.info.id),
+            },
+        },
+    };
+    message_layout::height(&mut app.message_height_cache, &message.info.id, &input)
+}
+
+pub(crate) fn retain_message_heights(app: &mut App, items: &[wr::Message]) {
+    let item_ids = items
+        .iter()
+        .map(|message| message.info.id.clone())
+        .collect::<Vec<_>>();
+    app.message_height_cache.retain_messages(&item_ids);
+}
+
+pub(crate) fn height_generation(app: &App) -> u64 {
+    app.message_height_cache.generation()
+}

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -9,7 +9,7 @@ use ratatui::{
 };
 use whatsrust as wr;
 
-use crate::app::{App, FileMeta, Metadata};
+use crate::app::App;
 
 #[path = "message_formatting.rs"]
 mod message_formatting;
@@ -17,6 +17,8 @@ mod message_formatting;
 mod message_helpers;
 #[path = "message_layout.rs"]
 mod message_layout;
+#[path = "message_layout_integration.rs"]
+mod message_layout_integration;
 #[path = "message_list_state.rs"]
 mod message_list_state;
 #[path = "message_media.rs"]
@@ -37,7 +39,6 @@ pub use message_layout::{
     IMAGE_HEIGHT, IMAGE_WIDTH, MESSAGE_HEIGHT_CACHE_CAPACITY, MessageHeightCache, VIDEO_HEIGHT,
     VIDEO_WIDTH,
 };
-use message_layout::{LayoutInput, file_kind};
 pub use message_list_state::MessageListState;
 pub use message_media::preview_height;
 use message_media::render_file;
@@ -59,39 +60,7 @@ mod layout_contract_tests {
     }
 }
 
-pub fn message_height(
-    message: &wr::Message,
-    width: usize,
-    is_selected: bool,
-    author_group: AuthorGroupContext,
-    app: &mut App,
-) -> usize {
-    let input = LayoutInput {
-        width,
-        is_selected,
-        has_quote: message.info.quote_id.is_some(),
-        has_reactions: app.reactions.contains_key(&message.info.id),
-        author_group,
-        content: match &message.message {
-            wr::MessageContent::Text(text) => message_layout::HeightContent::Text {
-                body: text,
-                forwarding: forwarding_label(message),
-                status: status_label(app, &message.info.id),
-            },
-            wr::MessageContent::File(file) => message_layout::HeightContent::File {
-                kind: file_kind(file.kind.clone()),
-                caption: file.caption.as_deref(),
-                forwarding: forwarding_label(message),
-                preview_loaded: matches!(
-                    app.metadata.get(&message.info.id),
-                    Some(Metadata::File(FileMeta::Loaded))
-                ),
-                status: status_label(app, &message.info.id),
-            },
-        },
-    };
-    message_layout::height(&mut app.message_height_cache, &message.info.id, &input)
-}
+pub use message_layout_integration::message_height;
 
 fn spacing_after_message(
     index: usize,
@@ -341,11 +310,7 @@ fn render_message_items(
         })
         .collect::<Vec<_>>();
 
-    let item_ids = items
-        .iter()
-        .map(|message| message.info.id.clone())
-        .collect::<Vec<_>>();
-    app.message_height_cache.retain_messages(&item_ids);
+    message_layout_integration::retain_message_heights(app, &items);
 
     if items.is_empty() {
         app.message_list_state.select(None);
@@ -384,7 +349,7 @@ fn render_message_items(
         .filter(|anchor| {
             anchor.width == width as usize
                 && anchor.offset == app.message_list_state.offset
-                && anchor.generation == app.message_height_cache.generation()
+                && anchor.generation == message_layout_integration::height_generation(app)
                 && app
                     .message_list_state
                     .selected

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -26,9 +26,8 @@ mod message_media;
 #[path = "message_viewport.rs"]
 mod message_viewport;
 
-use message_formatting::{
-    author_color, media_paragraph, message_block, message_content_area, reaction_chips,
-};
+pub use message_formatting::reaction_chips;
+use message_formatting::{author_color, media_paragraph, message_block, message_content_area};
 pub use message_helpers::{
     AUTHOR_GROUP_MAX_GAP, AuthorGroupContext, get_quoted_text, reply_summary, starts_author_group,
 };


### PR DESCRIPTION
## Summary

- Extract the cohesive layout/height-cache integration seam from `src/ui/message_list.rs`.
- Preserve height inputs, cache retention, generation checks, rendering, and public `message_height` behavior.
- Leave selection, media, viewport, and formatting responsibilities untouched.

## Changes

| File | Change |
|------|--------|
| `src/ui/message_layout_integration.rs` | Owns message-height input construction, cache measurement delegation, retained-message pruning, and generation access. |
| `src/ui/message_list.rs` | Registers and delegates to the integration seam while retaining orchestration and rendering. |

## Testing

- [x] `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all`
- [x] `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --lib message_list -- --test-threads=1` (8 passed)
- [x] `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo check`
- [x] `git diff --check`
- [x] Authored diff: 100 lines, below the 400-line limit
- [x] Cargo global serial execution: `CARGO_BUILD_JOBS=1`
- [x] Go, CI, merge, and unrelated work: N/A; not touched
- [x] Manual UI testing: N/A; behavior-preserving structural refactor

## Remaining audit

- `message_list.rs` still owns selection reconciliation, viewport-anchor adjustment, spacing policy, and final viewport rendering coordination. These are separate responsibilities and are intentionally not extracted here.
- `message_layout.rs` remains the owner of height calculation and cache storage/invalidation contracts; this change extracts only the message-list integration boundary.

## Chain

- Exact base: `refactor/message-list-formatting` / PR #227
- Child issue: #230
- Rollback boundary: revert commit `9ea3917` to remove only this integration seam.

Closes #230