### PR TITLE
refactor(bridge): extract HandleMessage orchestration

### DIFF
--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -79,10 +79,6 @@ static void callHistorySync(HistorySyncHandler hdl, uint32_t percent) {
 
 */
 import "C"
-import (
-	"go.mau.fi/whatsmeow/proto/waE2E"
-	"go.mau.fi/whatsmeow/types"
-)
 
 const (
 	forwardFailureNone uint8 = iota
@@ -116,62 +112,5 @@ const (
 	FileTypeDocument
 	FileTypeSticker
 )
-
-func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
-	msg, viewOnceUnavailable := unavailableViewOnceMessage(msg)
-
-	info = normalizeMessageInfo(info)
-
-	if dispatchMessageEvent(info, msg) {
-		return
-	}
-	rawSource := forwardingSourcePayload(info, msg, viewOnceUnavailable)
-	callback := beginMessageCallback(info, msg, rawSource)
-	defer callback.close()
-	cinfo := callback.info
-
-	if msg.Conversation != nil {
-		emitTextMessage(cinfo, msg.GetConversation(), isSync)
-	}
-	if msg.ExtendedTextMessage != nil {
-		ext_msg := msg.GetExtendedTextMessage()
-
-		context_info := ext_msg.GetContextInfo()
-		if context_info != nil {
-			id := context_info.GetStanzaID()
-			// LOG_ERROR("asdfasdf %s", co)
-			if id != "" {
-				cinfo.quoteID = C.CString(id)
-			}
-		}
-
-		emitTextMessage(cinfo, ext_msg.GetText(), isSync)
-	}
-	if msg.ImageMessage != nil {
-		if !emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync) {
-			return
-		}
-	}
-	if msg.VideoMessage != nil {
-		if !emitVideoMessage(cinfo, info.ID, msg.GetVideoMessage(), isSync) {
-			return
-		}
-	}
-	if msg.AudioMessage != nil {
-		if !emitAudioMessage(cinfo, info.ID, msg.GetAudioMessage(), isSync) {
-			return
-		}
-	}
-	if msg.DocumentMessage != nil {
-		if !emitDocumentMessage(cinfo, info.ID, msg.GetDocumentMessage(), isSync) {
-			return
-		}
-	}
-	if msg.StickerMessage != nil {
-		if !emitStickerMessage(cinfo, info.ID, msg.GetStickerMessage(), isSync) {
-			return
-		}
-	}
-}
 
 func main() {} // Required for CGO

--- a/whatsrust/lib/message_handling.go
+++ b/whatsrust/lib/message_handling.go
@@ -27,17 +27,18 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 		emitTextMessage(cinfo, msg.GetConversation(), isSync)
 	}
 	if msg.ExtendedTextMessage != nil {
-		extMsg := msg.GetExtendedTextMessage()
+		ext_msg := msg.GetExtendedTextMessage()
 
-		contextInfo := extMsg.GetContextInfo()
-		if contextInfo != nil {
-			id := contextInfo.GetStanzaID()
+		context_info := ext_msg.GetContextInfo()
+		if context_info != nil {
+			id := context_info.GetStanzaID()
+			// LOG_ERROR("asdfasdf %s", co)
 			if id != "" {
 				cinfo.quoteID = C.CString(id)
 			}
 		}
 
-		emitTextMessage(cinfo, extMsg.GetText(), isSync)
+		emitTextMessage(cinfo, ext_msg.GetText(), isSync)
 	}
 	if msg.ImageMessage != nil {
 		if !emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync) {

--- a/whatsrust/lib/message_handling.go
+++ b/whatsrust/lib/message_handling.go
@@ -1,0 +1,67 @@
+package main
+
+/*
+#include "callback_log_registration.h"
+*/
+import "C"
+
+import (
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
+	msg, viewOnceUnavailable := unavailableViewOnceMessage(msg)
+
+	info = normalizeMessageInfo(info)
+
+	if dispatchMessageEvent(info, msg) {
+		return
+	}
+	rawSource := forwardingSourcePayload(info, msg, viewOnceUnavailable)
+	callback := beginMessageCallback(info, msg, rawSource)
+	defer callback.close()
+	cinfo := callback.info
+
+	if msg.Conversation != nil {
+		emitTextMessage(cinfo, msg.GetConversation(), isSync)
+	}
+	if msg.ExtendedTextMessage != nil {
+		extMsg := msg.GetExtendedTextMessage()
+
+		contextInfo := extMsg.GetContextInfo()
+		if contextInfo != nil {
+			id := contextInfo.GetStanzaID()
+			if id != "" {
+				cinfo.quoteID = C.CString(id)
+			}
+		}
+
+		emitTextMessage(cinfo, extMsg.GetText(), isSync)
+	}
+	if msg.ImageMessage != nil {
+		if !emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync) {
+			return
+		}
+	}
+	if msg.VideoMessage != nil {
+		if !emitVideoMessage(cinfo, info.ID, msg.GetVideoMessage(), isSync) {
+			return
+		}
+	}
+	if msg.AudioMessage != nil {
+		if !emitAudioMessage(cinfo, info.ID, msg.GetAudioMessage(), isSync) {
+			return
+		}
+	}
+	if msg.DocumentMessage != nil {
+		if !emitDocumentMessage(cinfo, info.ID, msg.GetDocumentMessage(), isSync) {
+			return
+		}
+	}
+	if msg.StickerMessage != nil {
+		if !emitStickerMessage(cinfo, info.ID, msg.GetStickerMessage(), isSync) {
+			return
+		}
+	}
+}

--- a/whatsrust/lib/message_handling_test.go
+++ b/whatsrust/lib/message_handling_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHandleMessageOrchestrationOwnership(t *testing.T) {
+	mainSource := string(mustRead(t, "main.go"))
+	source := string(mustRead(t, "message_handling.go"))
+
+	if strings.Contains(mainSource, "func HandleMessage(") {
+		t.Fatal("HandleMessage orchestration must not remain in the CGO ABI root")
+	}
+	for _, fragment := range []string{
+		"#include \"callback_log_registration.h\"",
+		"func HandleMessage(",
+		"msg, viewOnceUnavailable := unavailableViewOnceMessage(msg)",
+		"info = normalizeMessageInfo(info)",
+		"if dispatchMessageEvent(info, msg)",
+		"rawSource := forwardingSourcePayload(info, msg, viewOnceUnavailable)",
+		"callback := beginMessageCallback(info, msg, rawSource)",
+		"defer callback.close()",
+	} {
+		if !strings.Contains(source, fragment) {
+			t.Fatalf("message orchestration ownership is missing: %q", fragment)
+		}
+	}
+	for _, fragment := range []string{
+		"emitTextMessage(cinfo, msg.GetConversation(), isSync)",
+		"emitTextMessage(cinfo, extMsg.GetText(), isSync)",
+		"emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync)",
+		"emitVideoMessage(cinfo, info.ID, msg.GetVideoMessage(), isSync)",
+		"emitAudioMessage(cinfo, info.ID, msg.GetAudioMessage(), isSync)",
+		"emitDocumentMessage(cinfo, info.ID, msg.GetDocumentMessage(), isSync)",
+		"emitStickerMessage(cinfo, info.ID, msg.GetStickerMessage(), isSync)",
+	} {
+		if !strings.Contains(source, fragment) {
+			t.Fatalf("message orchestration call is missing: %q", fragment)
+		}
+	}
+}

--- a/whatsrust/lib/message_handling_test.go
+++ b/whatsrust/lib/message_handling_test.go
@@ -28,7 +28,7 @@ func TestHandleMessageOrchestrationOwnership(t *testing.T) {
 	}
 	for _, fragment := range []string{
 		"emitTextMessage(cinfo, msg.GetConversation(), isSync)",
-		"emitTextMessage(cinfo, extMsg.GetText(), isSync)",
+		"emitTextMessage(cinfo, ext_msg.GetText(), isSync)",
 		"emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync)",
 		"emitVideoMessage(cinfo, info.ID, msg.GetVideoMessage(), isSync)",
 		"emitAudioMessage(cinfo, info.ID, msg.GetAudioMessage(), isSync)",

--- a/whatsrust/lib/text_message_payload_test.go
+++ b/whatsrust/lib/text_message_payload_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestTextPayloadOwnershipIsKeptWithEmitter(t *testing.T) {
-	mainSource := string(mustRead(t, "main.go"))
+	handlingSource := string(mustRead(t, "message_handling.go"))
 	source, err := os.ReadFile("text_message_payload.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	textSource := string(source)
 
-	if strings.Contains(mainSource, "func emitTextMessage(") {
+	if strings.Contains(handlingSource, "func emitTextMessage(") {
 		t.Fatal("text payload emission must not remain in HandleMessage's composition file")
 	}
 	for _, fragment := range []string{
@@ -28,7 +28,7 @@ func TestTextPayloadOwnershipIsKeptWithEmitter(t *testing.T) {
 			t.Fatalf("text payload ownership is missing: %q", fragment)
 		}
 	}
-	if strings.Count(mainSource, "emitTextMessage(cinfo,") != 2 {
+	if strings.Count(handlingSource, "emitTextMessage(cinfo,") != 2 {
 		t.Fatal("conversation and extended-text payloads must use the text seam")
 	}
 }


### PR DESCRIPTION
## Summary
- Move exactly `HandleMessage` orchestration into `message_handling.go`.
- Keep the minimal callback ABI include and inseparable ownership test with the orchestration seam.
- Leave `main.go` as the CGO/ABI root plus `func main`.

## Chain context
- Exact base: `refactor/go-text-payload-module` / PR #229.
- Child issue: #232.
- Commits: `d4e8aab`, `7f01168`.

## Changes
| File | Change |
|------|--------|
| `whatsrust/lib/main.go` | Retains CGO/ABI declarations, constants, and `func main`; no message orchestration. |
| `whatsrust/lib/message_handling.go` | Owns the exact `HandleMessage` orchestration with minimal C declarations/includes. |
| `whatsrust/lib/message_handling_test.go` | Verifies orchestration ownership and required call seams. |
| `whatsrust/lib/text_message_payload_test.go` | Keeps text payload ownership assertions attached to the new orchestration file. |

## Behavior preserved
- Existing call order and source text.
- Quote ownership and callback lifetime.
- View-once sanitization and forwarding source handling.
- Text and file/multimedia emission behavior.
- Sync flag and callback routing.

## Test plan
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `git diff --check`
- [x] Authored diff is 177 lines (<400).
- [x] No CI/Cargo/Rust/race/merge work performed.

## Checklist
- [x] Linked child issue
- [x] Conventional commits
- [x] Tests kept with the behavior seam
- [x] No Co-Authored-By trailer

Closes #232
