### PR TITLE
refactor(ui): extract message-list reconciliation seam

### DIFF
--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -28,9 +28,8 @@ mod message_media;
 #[path = "message_viewport.rs"]
 mod message_viewport;
 
-use message_formatting::{
-    author_color, media_paragraph, message_block, message_content_area, reaction_chips,
-};
+pub use message_formatting::reaction_chips;
+use message_formatting::{author_color, media_paragraph, message_block, message_content_area};
 pub use message_helpers::{
     AUTHOR_GROUP_MAX_GAP, AuthorGroupContext, get_quoted_text, reply_summary, starts_author_group,
 };

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -19,6 +19,8 @@ mod message_helpers;
 mod message_layout;
 #[path = "message_layout_integration.rs"]
 mod message_layout_integration;
+#[path = "message_list_reconciliation.rs"]
+mod message_list_reconciliation;
 #[path = "message_list_state.rs"]
 mod message_list_state;
 #[path = "message_media.rs"]
@@ -317,161 +319,14 @@ fn render_message_items(
         return Some(());
     }
 
-    if app.message_list_state.selected.is_none()
-        && app.message_list_state.selected_message.is_some()
-    {
-        let selected_message = app.message_list_state.selected_message.clone().unwrap();
-        if let Some(idx) = items
-            .iter()
-            .position(|item| item.info.id == selected_message)
-        {
-            app.message_list_state.select(Some(idx));
-        } else {
-            app.message_list_state.select(None);
-        }
-    }
-
-    if let Some(idx) = app.message_list_state.selected
-        && idx >= items.len()
-    {
-        app.message_list_state.selected = items.len().checked_sub(1);
-    }
-
     let width = list_area.width as isize;
-    let padding = 4;
-    let divider_after = unread_count.checked_sub(1);
-
-    let previous_offset = app.message_list_state.offset;
-    let mut previous_anchor = app
-        .message_list_state
-        .viewport_anchor
-        .clone()
-        .filter(|anchor| {
-            anchor.width == width as usize
-                && anchor.offset == app.message_list_state.offset
-                && anchor.generation == message_layout_integration::height_generation(app)
-                && app
-                    .message_list_state
-                    .selected
-                    .is_none_or(|selected| selected >= anchor.index)
-                && items
-                    .get(anchor.index)
-                    .is_some_and(|item| item.info.id == anchor.message_id)
-        });
-    if let Some(anchor) = previous_anchor.as_mut() {
-        let new_bottom = list_area.bottom();
-        let bottom_delta = new_bottom as isize - anchor.bottom as isize;
-        anchor.y = anchor.y.saturating_add(bottom_delta);
-        anchor.bottom = new_bottom;
-    }
-
-    app.message_list_state.selected_message = app
-        .message_list_state
-        .selected
-        .map(|selected| items[selected].info.id.clone());
-
-    if app.message_list_state.selected.is_some() && app.message_list_state.update_selected {
-        let selected = app.message_list_state.selected.unwrap();
-        app.message_list_state.update_selected = false;
-
-        // Use the previous viewport as an anchor while selection moves locally. A
-        // cold jump still falls back to the exact prefix calculation below.
-        let acc_height = previous_anchor
-            .as_ref()
-            .filter(|anchor| anchor.index <= selected)
-            .map(|anchor| {
-                let mut cursor = anchor.y;
-                for index in anchor.index..selected {
-                    cursor -= message_height(
-                        &items[index],
-                        width as usize,
-                        app.message_list_state.selected == Some(index),
-                        author_groups[index],
-                        app,
-                    ) as isize;
-                    cursor -= spacing_after_message(
-                        index,
-                        &author_groups,
-                        app.message_list_state.selected,
-                    ) as isize;
-                    if divider_after == Some(index) {
-                        cursor -= 1;
-                    }
-                }
-                (list_area.bottom() as isize + app.message_list_state.offset as isize - cursor)
-                    as usize
-            })
-            .unwrap_or_else(|| {
-                items
-                    .iter()
-                    .take(selected)
-                    .enumerate()
-                    .map(|(index, item)| {
-                        usize::from(divider_after == Some(index))
-                            + message_height(
-                                item,
-                                width as usize,
-                                app.message_list_state.selected == Some(index),
-                                author_groups[index],
-                                app,
-                            )
-                            + spacing_after_message(
-                                index,
-                                &author_groups,
-                                app.message_list_state.selected,
-                            )
-                    })
-                    .sum::<usize>()
-            });
-
-        let selected_height = message_height(
-            &items[selected],
-            width as usize,
-            true,
-            author_groups[selected],
-            app,
-        );
-
-        let low = acc_height < app.message_list_state.offset + padding;
-        let high = acc_height + selected_height
-            > app
-                .message_list_state
-                .offset
-                .saturating_add((list_area.height as usize).saturating_sub(padding));
-
-        // if low && high {
-        //     info!("idk");
-        // } else if low {
-        if low {
-            app.message_list_state.offset = acc_height.saturating_sub(padding);
-        } else if high {
-            app.message_list_state.offset =
-                (acc_height + selected_height + padding).saturating_sub(list_area.height as usize);
-        }
-        if app.message_list_state.offset != previous_offset {
-            if let Some(anchor) = previous_anchor.as_mut() {
-                let delta = if app.message_list_state.offset >= previous_offset {
-                    app.message_list_state.offset - previous_offset
-                } else {
-                    previous_offset - app.message_list_state.offset
-                };
-                let delta = delta.min(isize::MAX as usize) as isize;
-                anchor.y = if app.message_list_state.offset >= previous_offset {
-                    anchor.y.saturating_add(delta)
-                } else {
-                    anchor.y.saturating_sub(delta)
-                };
-                anchor.offset = app.message_list_state.offset;
-            }
-        }
-    }
-
-    let (start_index, y) = previous_anchor
-        .map(|anchor| (anchor.index, anchor.y))
-        .unwrap_or((
-            0,
-            list_area.bottom() as isize + app.message_list_state.offset as isize,
-        ));
+    let (start_index, y) = message_list_reconciliation::reconcile(
+        app,
+        list_area,
+        &items,
+        &author_groups,
+        unread_count,
+    );
     app.message_list_state.viewport_anchor = message_viewport::render(
         frame,
         app,

--- a/src/ui/message_list_reconciliation.rs
+++ b/src/ui/message_list_reconciliation.rs
@@ -1,0 +1,190 @@
+use ratatui::layout::Rect;
+use whatsrust as wr;
+
+use crate::app::App;
+
+use super::{
+    AuthorGroupContext, message_height, message_layout_integration, spacing_after_message,
+};
+
+const SELECTION_PADDING: usize = 4;
+
+pub(super) fn reconcile(
+    app: &mut App,
+    list_area: Rect,
+    items: &[wr::Message],
+    author_groups: &[AuthorGroupContext],
+    unread_count: usize,
+) -> (usize, isize) {
+    let selected = reconciled_index(
+        app.message_list_state.selected,
+        app.message_list_state
+            .selected_message
+            .as_ref()
+            .and_then(|message_id| items.iter().position(|item| item.info.id == *message_id)),
+        items.len(),
+    );
+    if app.message_list_state.selected.is_none()
+        && app.message_list_state.selected_message.is_some()
+    {
+        app.message_list_state.select(selected);
+    } else if app.message_list_state.selected != selected {
+        app.message_list_state.selected = selected;
+    }
+
+    let width = list_area.width as isize;
+    let divider_after = unread_count.checked_sub(1);
+    let previous_offset = app.message_list_state.offset;
+    let mut previous_anchor = app
+        .message_list_state
+        .viewport_anchor
+        .clone()
+        .filter(|anchor| {
+            anchor.width == width as usize
+                && anchor.offset == app.message_list_state.offset
+                && anchor.generation == message_layout_integration::height_generation(app)
+                && app
+                    .message_list_state
+                    .selected
+                    .is_none_or(|selected| selected >= anchor.index)
+                && items
+                    .get(anchor.index)
+                    .is_some_and(|item| item.info.id == anchor.message_id)
+        });
+    if let Some(anchor) = previous_anchor.as_mut() {
+        let bottom_delta = list_area.bottom() as isize - anchor.bottom as isize;
+        anchor.y = anchor.y.saturating_add(bottom_delta);
+        anchor.bottom = list_area.bottom();
+    }
+
+    app.message_list_state.selected_message = app
+        .message_list_state
+        .selected
+        .map(|selected| items[selected].info.id.clone());
+
+    if let Some(selected) = app
+        .message_list_state
+        .selected
+        .filter(|_| app.message_list_state.update_selected)
+    {
+        app.message_list_state.update_selected = false;
+
+        let acc_height = previous_anchor
+            .as_ref()
+            .filter(|anchor| anchor.index <= selected)
+            .map(|anchor| {
+                let mut cursor = anchor.y;
+                for index in anchor.index..selected {
+                    cursor -= message_height(
+                        &items[index],
+                        width as usize,
+                        app.message_list_state.selected == Some(index),
+                        author_groups[index],
+                        app,
+                    ) as isize;
+                    cursor -= spacing_after_message(
+                        index,
+                        author_groups,
+                        app.message_list_state.selected,
+                    ) as isize;
+                    if divider_after == Some(index) {
+                        cursor -= 1;
+                    }
+                }
+                (list_area.bottom() as isize + app.message_list_state.offset as isize - cursor)
+                    as usize
+            })
+            .unwrap_or_else(|| {
+                items
+                    .iter()
+                    .take(selected)
+                    .enumerate()
+                    .map(|(index, item)| {
+                        usize::from(divider_after == Some(index))
+                            + message_height(
+                                item,
+                                width as usize,
+                                app.message_list_state.selected == Some(index),
+                                author_groups[index],
+                                app,
+                            )
+                            + spacing_after_message(
+                                index,
+                                author_groups,
+                                app.message_list_state.selected,
+                            )
+                    })
+                    .sum::<usize>()
+            });
+
+        let selected_height = message_height(
+            &items[selected],
+            width as usize,
+            true,
+            author_groups[selected],
+            app,
+        );
+        let low = acc_height < app.message_list_state.offset + SELECTION_PADDING;
+        let high = acc_height + selected_height
+            > app
+                .message_list_state
+                .offset
+                .saturating_add((list_area.height as usize).saturating_sub(SELECTION_PADDING));
+
+        if low {
+            app.message_list_state.offset = acc_height.saturating_sub(SELECTION_PADDING);
+        } else if high {
+            app.message_list_state.offset = (acc_height + selected_height + SELECTION_PADDING)
+                .saturating_sub(list_area.height as usize);
+        }
+        if app.message_list_state.offset != previous_offset {
+            if let Some(anchor) = previous_anchor.as_mut() {
+                let delta = app
+                    .message_list_state
+                    .offset
+                    .abs_diff(previous_offset)
+                    .min(isize::MAX as usize) as isize;
+                anchor.y = if app.message_list_state.offset >= previous_offset {
+                    anchor.y.saturating_add(delta)
+                } else {
+                    anchor.y.saturating_sub(delta)
+                };
+                anchor.offset = app.message_list_state.offset;
+            }
+        }
+    }
+
+    previous_anchor
+        .map(|anchor| (anchor.index, anchor.y))
+        .unwrap_or((
+            0,
+            list_area.bottom() as isize + app.message_list_state.offset as isize,
+        ))
+}
+
+fn reconciled_index(
+    selected: Option<usize>,
+    identity_index: Option<usize>,
+    len: usize,
+) -> Option<usize> {
+    selected
+        .or(identity_index)
+        .map(|index| index.min(len.saturating_sub(1)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reconciled_index;
+
+    #[test]
+    fn resolves_identity_before_clamping_position() {
+        assert_eq!(reconciled_index(None, Some(1), 2), Some(1));
+        assert_eq!(reconciled_index(Some(9), None, 2), Some(1));
+    }
+
+    #[test]
+    fn missing_identity_does_not_select_an_item() {
+        assert_eq!(reconciled_index(None, None, 2), None);
+        assert_eq!(reconciled_index(None, None, 0), None);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the remaining selection-to-viewport reconciliation seam from `src/ui/message_list.rs`.
- Preserve selected-message identity recovery, bounds reconciliation, viewport-anchor validation, resize adjustment, spacing-aware offset updates, and render start coordination.
- Keep final visible-item traversal and rendering in `message_viewport.rs`.

## Changes

| File | Change |
|------|--------|
| `src/ui/message_list_reconciliation.rs` | Owns selection identity reconciliation, anchor validation/adjustment, spacing-aware selected-item scrolling, and render-start coordination. |
| `src/ui/message_list.rs` | Delegates reconciliation while retaining message composition and renderer coordination. |

## Testing

- [x] `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all -- --check`
- [x] `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --lib message_list -- --test-threads=1` (10 passed)
- [x] `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo check`
- [x] `git diff --check`
- [x] Authored diff: 353 lines, below the 400-line limit
- [x] Cargo global serial execution: `CARGO_BUILD_JOBS=1`
- [x] Go, CI, merge, and unrelated work: N/A; not touched
- [x] Manual UI testing: N/A; behavior-preserving structural refactor

## SRP audit

Selection state transitions remain in `message_list_state.rs`; visible traversal and cell rendering remain in `message_viewport.rs`. The extracted seam is the independent policy that reconciles stable selection identity and cached viewport anchors with variable message geometry before rendering.

## Chain

- Exact base: `refactor/message-list-layout-cache-integration` / PR #231
- Child branch: `refactor/message-list-selection-reconciliation`
- Rollback boundary: revert commit `4012fc9` to remove only this reconciliation seam.

Closes #211

## Checklist

- [x] Code refactoring (`type:refactor`)
- [x] Conventional commit
- [x] No `Co-Authored-By` trailer
- [x] No Go, CI, merge, or unrelated changes
