### PR TITLE
refactor(bridge): move EventType protocol ownership

### DIFF
--- a/whatsrust/lib/event_protocol.go
+++ b/whatsrust/lib/event_protocol.go
@@ -1,0 +1,13 @@
+package main
+
+const (
+	EventTypeSyncProgress         = 0
+	EventTypeAppStateSyncComplete = 1
+	EventTypeReceipt              = 2
+	EventTypeReaction             = 3
+	// Event type 4 is reserved for the removed multiplexed Presence event.
+	EventTypeConnected     = 5
+	EventTypeMessageAction = 6
+	EventTypeChat          = 7
+	EventTypeLogoutResult  = 8
+)

--- a/whatsrust/lib/event_protocol_test.go
+++ b/whatsrust/lib/event_protocol_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEventTypeConstantsAreOwnedByEventProtocol(t *testing.T) {
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mainSource), "EventType") {
+		t.Fatal("main.go must not own EventType protocol constants")
+	}
+	for _, declaration := range []string{"MessageTypeText", "FileTypeImage"} {
+		if !strings.Contains(string(mainSource), declaration) {
+			t.Fatalf("main.go must retain %s outside this seam", declaration)
+		}
+	}
+
+	protocolSource, err := os.ReadFile("event_protocol.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, constant := range []string{
+		"EventTypeSyncProgress",
+		"EventTypeAppStateSyncComplete",
+		"EventTypeReceipt",
+		"EventTypeReaction",
+		"EventTypeConnected",
+		"EventTypeMessageAction",
+		"EventTypeChat",
+		"EventTypeLogoutResult",
+	} {
+		if !strings.Contains(string(protocolSource), constant) {
+			t.Fatalf("event_protocol.go must own %s", constant)
+		}
+	}
+}
+
+func TestEventTypeValuesRemainStable(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"sync progress", EventTypeSyncProgress, 0},
+		{"app state sync complete", EventTypeAppStateSyncComplete, 1},
+		{"receipt", EventTypeReceipt, 2},
+		{"reaction", EventTypeReaction, 3},
+		{"connected", EventTypeConnected, 5},
+		{"message action", EventTypeMessageAction, 6},
+		{"chat", EventTypeChat, 7},
+		{"logout result", EventTypeLogoutResult, 8},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("value = %d, want %d", tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -9,18 +9,6 @@ const (
 )
 
 const (
-	EventTypeSyncProgress         = 0
-	EventTypeAppStateSyncComplete = 1
-	EventTypeReceipt              = 2
-	EventTypeReaction             = 3
-	// Event type 4 is reserved for the removed multiplexed Presence event.
-	EventTypeConnected     = 5
-	EventTypeMessageAction = 6
-	EventTypeChat          = 7
-	EventTypeLogoutResult  = 8
-)
-
-const (
 	MessageTypeText = iota
 	MessageTypeFile
 )


### PR DESCRIPTION
## Summary
- Move only the EventType protocol constants out of `whatsrust/lib/main.go` into `event_protocol.go`.
- Add ownership and stable-value tests while retaining MessageType and FileType in `main.go`.

## Changes
| File | Change |
|------|--------|
| `whatsrust/lib/main.go` | Remove only the EventType constant block; retain MessageType, FileType, and `func main`. |
| `whatsrust/lib/event_protocol.go` | Own the EventType protocol constants. |
| `whatsrust/lib/event_protocol_test.go` | Assert ownership boundaries and unchanged numeric values. |

## Testing
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cd whatsrust/lib && CGO_ENABLED=1 go build -buildmode=c-archive -o /tmp/opencode/go-main-finalization-event-protocol.a .`
- [x] `git diff --check`
- [x] Authored diff: 77 lines (<400)
- [x] No CI/Cargo/Rust/race/merge work

## Chain
- Exact base: `refactor/go-main-finalization` / PR #236
- Child issue: #237

Closes #237