### PR TITLE
refactor(bridge): move forward failure protocol ownership

### DIFF
--- a/whatsrust/lib/forwarding.go
+++ b/whatsrust/lib/forwarding.go
@@ -10,6 +10,14 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+const (
+	forwardFailureNone uint8 = iota
+	forwardFailureSourceUnavailable
+	forwardFailureInvalidSource
+	forwardFailureInvalidDestination
+	forwardFailureSendFailed
+)
+
 const maxForwardSources = 1000
 
 func forwardSourceKey(chat, sender types.JID, id types.MessageID) string {

--- a/whatsrust/lib/forwarding_test.go
+++ b/whatsrust/lib/forwarding_test.go
@@ -27,6 +27,51 @@ func TestForwardSourceKeyOwnership(t *testing.T) {
 	}
 }
 
+func TestForwardFailureConstantsAreOwnedByForwarding(t *testing.T) {
+	forwardingSource, err := os.ReadFile("forwarding.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, constant := range []string{
+		"forwardFailureNone",
+		"forwardFailureSourceUnavailable",
+		"forwardFailureInvalidSource",
+		"forwardFailureInvalidDestination",
+		"forwardFailureSendFailed",
+	} {
+		if !strings.Contains(string(forwardingSource), constant) {
+			t.Fatalf("forwarding.go must own %s", constant)
+		}
+		if strings.Contains(string(mainSource), constant) {
+			t.Fatalf("main.go must not own %s", constant)
+		}
+	}
+}
+
+func TestForwardFailureValuesRemainStable(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		got  uint8
+		want uint8
+	}{
+		{"none", forwardFailureNone, 0},
+		{"source unavailable", forwardFailureSourceUnavailable, 1},
+		{"invalid source", forwardFailureInvalidSource, 2},
+		{"invalid destination", forwardFailureInvalidDestination, 3},
+		{"send failed", forwardFailureSendFailed, 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("value = %d, want %d", tt.got, tt.want)
+			}
+		})
+	}
+}
+
 func TestForwardSourceKeyPreservesCompositeFormat(t *testing.T) {
 	chat := types.NewJID("chat", types.DefaultUserServer)
 	sender := types.NewJID("sender", types.DefaultUserServer)

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -1,14 +1,6 @@
 package main
 
 const (
-	forwardFailureNone uint8 = iota
-	forwardFailureSourceUnavailable
-	forwardFailureInvalidSource
-	forwardFailureInvalidDestination
-	forwardFailureSendFailed
-)
-
-const (
 	MessageTypeText = iota
 	MessageTypeFile
 )


### PR DESCRIPTION
## Summary
- move exactly the `forwardFailure*` constants into `forwarding.go`
- add inseparable ownership and stable-value tests
- retain `MessageType`, `FileType`, and `func main` in `main.go`

## Verification
- focused Go tests
- `go vet ./...`
- `go test ./...`
- c-archive build
- `git diff --check`

Closes #239