### PR TITLE
refactor(bridge): move payload protocol ownership

### DIFF
--- a/whatsrust/lib/event_protocol_test.go
+++ b/whatsrust/lib/event_protocol_test.go
@@ -14,12 +14,6 @@ func TestEventTypeConstantsAreOwnedByEventProtocol(t *testing.T) {
 	if strings.Contains(string(mainSource), "EventType") {
 		t.Fatal("main.go must not own EventType protocol constants")
 	}
-	for _, declaration := range []string{"MessageTypeText", "FileTypeImage"} {
-		if !strings.Contains(string(mainSource), declaration) {
-			t.Fatalf("main.go must retain %s outside this seam", declaration)
-		}
-	}
-
 	protocolSource, err := os.ReadFile("event_protocol.go")
 	if err != nil {
 		t.Fatal(err)

--- a/whatsrust/lib/main.go
+++ b/whatsrust/lib/main.go
@@ -1,16 +1,3 @@
 package main
 
-const (
-	MessageTypeText = iota
-	MessageTypeFile
-)
-
-const (
-	FileTypeImage = iota
-	FileTypeVideo
-	FileTypeAudio
-	FileTypeDocument
-	FileTypeSticker
-)
-
-func main() {} // Required for CGO
+func main() {}

--- a/whatsrust/lib/payload_protocol.go
+++ b/whatsrust/lib/payload_protocol.go
@@ -1,0 +1,14 @@
+package main
+
+const (
+	MessageTypeText = iota
+	MessageTypeFile
+)
+
+const (
+	FileTypeImage = iota
+	FileTypeVideo
+	FileTypeAudio
+	FileTypeDocument
+	FileTypeSticker
+)

--- a/whatsrust/lib/payload_protocol_test.go
+++ b/whatsrust/lib/payload_protocol_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPayloadProtocolConstantsAreOwnedByPayloadProtocol(t *testing.T) {
+	payloadSource, err := os.ReadFile("payload_protocol.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainSource, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, constant := range []string{
+		"MessageTypeText",
+		"MessageTypeFile",
+		"FileTypeImage",
+		"FileTypeVideo",
+		"FileTypeAudio",
+		"FileTypeDocument",
+		"FileTypeSticker",
+	} {
+		if !strings.Contains(string(payloadSource), constant) {
+			t.Fatalf("payload_protocol.go must own %s", constant)
+		}
+		if strings.Contains(string(mainSource), constant) {
+			t.Fatalf("main.go must not own %s", constant)
+		}
+	}
+}
+
+func TestPayloadProtocolValuesRemainStable(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"message text", MessageTypeText, 0},
+		{"message file", MessageTypeFile, 1},
+		{"file image", FileTypeImage, 0},
+		{"file video", FileTypeVideo, 1},
+		{"file audio", FileTypeAudio, 2},
+		{"file document", FileTypeDocument, 3},
+		{"file sticker", FileTypeSticker, 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("value = %d, want %d", tt.got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Move exactly the `MessageType*` and `FileType*` constants out of `whatsrust/lib/main.go` into one payload-protocol owner.
- Complete the Go main finalization chain from PR #240 without changing ABI values or behavior.

## Changes

- Add `payload_protocol.go` as the single owner for message discriminators and file subtypes.
- Add ownership and numeric-stability tests.
- Remove the stale prior-seam assertion and leave `main.go` exactly as the cgo entrypoint.

## Testing

- [x] `gofmt -w` on changed Go files
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cd whatsrust/lib && CGO_ENABLED=1 go build -buildmode=c-archive -o /tmp/message-payload-protocol.a .`
- [x] `git diff --check`
- [x] Exact audit: `main.go` is only `package main` plus `func main() {}`
- [x] Authored diff is under 400 lines (91 lines)
- [x] No Cargo/Rust/race/merge/privacy/CI work; CI was not awaited

## Chain

- Exact base: `refactor/go-forward-failure-ownership` / PR #240
- Child issue: #241

Closes #241