### PR TITLE
feat(messages): display contact names in mentions

### DIFF
--- a/whatsrust/lib/contacts.go
+++ b/whatsrust/lib/contacts.go
@@ -46,12 +46,28 @@ func contactDisplayName(c types.ContactInfo) string {
 }
 
 func lookupContactEntries(ctx context.Context, bridgeClient *whatsmeow.Client) []contactEntry {
-	if bridgeClient == nil || bridgeClient.Store == nil || bridgeClient.Store.Contacts == nil {
+	entries, err := loadContactEntries(ctx, bridgeClient)
+	if err != nil {
+		panic(err)
+	}
+	return entries
+}
+
+func lookupMentionContactEntries() []contactEntry {
+	entries, err := loadContactEntries(context.Background(), client)
+	if err != nil {
 		return nil
+	}
+	return entries
+}
+
+func loadContactEntries(ctx context.Context, bridgeClient *whatsmeow.Client) ([]contactEntry, error) {
+	if bridgeClient == nil || bridgeClient.Store == nil || bridgeClient.Store.Contacts == nil {
+		return nil, nil
 	}
 	contacts, err := bridgeClient.Store.Contacts.GetAllContacts(ctx)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	entries := make([]contactEntry, 0, len(contacts))
 	for jid, contact := range contacts {
@@ -60,13 +76,13 @@ func lookupContactEntries(ctx context.Context, bridgeClient *whatsmeow.Client) [
 			continue
 		}
 		entries = append(entries, contactEntry{jid: jid, name: name})
-		if jid.Server != types.HiddenUserServer {
+		if jid.Server != types.HiddenUserServer && bridgeClient.Store.LIDs != nil {
 			if lid, _ := bridgeClient.Store.LIDs.GetLIDForPN(ctx, jid); !lid.IsEmpty() {
 				entries = append(entries, contactEntry{jid: lid, name: name})
 			}
 		}
 	}
-	return entries
+	return entries, nil
 }
 
 //export C_GetContacts

--- a/whatsrust/lib/mention_names.go
+++ b/whatsrust/lib/mention_names.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// textWithMentionNames resolves mentions for messages with usable metadata and contacts.
+func textWithMentionNames(text string, contextInfo *waE2E.ContextInfo) string {
+	if contextInfo == nil || text == "" {
+		return text
+	}
+	mentionedJIDs := contextInfo.GetMentionedJID()
+	if len(mentionedJIDs) == 0 {
+		return text
+	}
+	contacts := lookupMentionContactEntries()
+	return replaceMentionedNames(text, mentionedJIDs, contacts)
+}
+
+func replaceMentionedNames(text string, mentionedJIDs []string, contacts []contactEntry) string {
+	if text == "" || len(mentionedJIDs) == 0 || len(contacts) == 0 {
+		return text
+	}
+
+	names := make(map[string]string, len(mentionedJIDs))
+	for _, mentionedJID := range mentionedJIDs {
+		jid, err := types.ParseJID(mentionedJID)
+		if err != nil || jid.IsEmpty() || jid.User == "" {
+			continue
+		}
+		for _, contact := range contacts {
+			if contact.jid == jid && strings.TrimSpace(contact.name) != "" {
+				if _, exists := names[jid.User]; !exists {
+					names[jid.User] = contact.name
+				}
+				break
+			}
+		}
+	}
+	if len(names) == 0 {
+		return text
+	}
+
+	return replaceMentionTokens(text, names)
+}
+
+func replaceMentionTokens(text string, names map[string]string) string {
+	var result strings.Builder
+	last := 0
+	changed := false
+
+	for offset := 0; offset < len(text); {
+		relativeAt := strings.IndexByte(text[offset:], '@')
+		if relativeAt < 0 {
+			break
+		}
+		at := offset + relativeAt
+		if !mentionBoundaryBefore(text, at) {
+			offset = at + 1
+			continue
+		}
+
+		end := at + 1
+		for end < len(text) {
+			r, size := utf8.DecodeRuneInString(text[end:])
+			if !mentionTokenRune(r) {
+				break
+			}
+			end += size
+		}
+		user := text[at+1 : end]
+		name, ok := names[user]
+		if !ok {
+			offset = end
+			continue
+		}
+
+		if !changed {
+			result.Grow(len(text))
+		}
+		result.WriteString(text[last:at])
+		result.WriteByte('@')
+		result.WriteString(name)
+		last = end
+		changed = true
+		offset = end
+	}
+
+	if !changed {
+		return text
+	}
+	result.WriteString(text[last:])
+	return result.String()
+}
+
+func mentionBoundaryBefore(text string, at int) bool {
+	if at == 0 {
+		return true
+	}
+	r, _ := utf8.DecodeLastRuneInString(text[:at])
+	return !mentionTokenRune(r)
+}
+
+func mentionTokenRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/whatsrust/lib/mention_names_test.go
+++ b/whatsrust/lib/mention_names_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type mentionContactStore struct{}
+
+func (mentionContactStore) PutPushName(context.Context, types.JID, string) (bool, string, error) {
+	return false, "", nil
+}
+
+func (mentionContactStore) PutBusinessName(context.Context, types.JID, string) (bool, string, error) {
+	return false, "", nil
+}
+
+func (mentionContactStore) PutContactName(context.Context, types.JID, string, string) error {
+	return nil
+}
+
+func (mentionContactStore) PutAllContactNames(context.Context, []store.ContactEntry) error {
+	return nil
+}
+
+func (mentionContactStore) PutManyRedactedPhones(context.Context, []store.RedactedPhoneEntry) error {
+	return nil
+}
+
+func (mentionContactStore) GetContact(context.Context, types.JID) (types.ContactInfo, error) {
+	return types.ContactInfo{}, nil
+}
+
+func (mentionContactStore) GetAllContacts(context.Context) (map[types.JID]types.ContactInfo, error) {
+	return map[types.JID]types.ContactInfo{
+		{User: "123", Server: types.DefaultUserServer}: {FullName: "Alice"},
+	}, nil
+}
+
+func TestTextWithMentionNamesResolvesSynchronizedMessages(t *testing.T) {
+	previousClient := client
+	client = &whatsmeow.Client{Store: &store.Device{Contacts: mentionContactStore{}}}
+	t.Cleanup(func() { client = previousClient })
+
+	contextInfo := &waE2E.ContextInfo{MentionedJID: []string{"123@s.whatsapp.net"}}
+	if got := textWithMentionNames("hello @123", contextInfo); got != "hello @Alice" {
+		t.Fatalf("textWithMentionNames() = %q, want synchronized mention resolved", got)
+	}
+}
+
+func TestReplaceMentionedNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		text      string
+		mentioned []string
+		contacts  []contactEntry
+		want      string
+	}{
+		{
+			name:     "no context preserves text",
+			text:     "hello @123 and @456",
+			contacts: []contactEntry{{jid: types.JID{User: "123", Server: types.DefaultUserServer}, name: "Alice"}},
+			want:     "hello @123 and @456",
+		},
+		{
+			name:      "multiple and repeated mentions replace only matching tokens",
+			text:      "@123 hi @456 @123 @999 @1234",
+			mentioned: []string{"123@s.whatsapp.net", "456@lid"},
+			contacts: []contactEntry{
+				{jid: types.JID{User: "123", Server: types.DefaultUserServer}, name: "Alice"},
+				{jid: types.JID{User: "456", Server: types.HiddenUserServer}, name: "Bob"},
+			},
+			want: "@Alice hi @Bob @Alice @999 @1234",
+		},
+		{
+			name:      "PN and LID aliases resolve to the same contact name",
+			text:      "Replying to @777",
+			mentioned: []string{"777@lid"},
+			contacts: []contactEntry{
+				{jid: types.JID{User: "777", Server: types.DefaultUserServer}, name: "Carol"},
+				{jid: types.JID{User: "777", Server: types.HiddenUserServer}, name: "Carol"},
+			},
+			want: "Replying to @Carol",
+		},
+		{
+			name:      "malformed metadata and unusable names preserve numeric tokens",
+			text:      "@bad @888 @999",
+			mentioned: []string{"not-a-jid", "888@s.whatsapp.net", "999@s.whatsapp.net"},
+			contacts: []contactEntry{
+				{jid: types.JID{User: "888", Server: types.DefaultUserServer}, name: "  "},
+			},
+			want: "@bad @888 @999",
+		},
+		{
+			name:      "tokens require boundaries and preserve punctuation",
+			text:      "abc@123 @123, @123.",
+			mentioned: []string{"123@s.whatsapp.net"},
+			contacts: []contactEntry{
+				{jid: types.JID{User: "123", Server: types.DefaultUserServer}, name: "Alice"},
+			},
+			want: "abc@123 @Alice, @Alice.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := replaceMentionedNames(tt.text, tt.mentioned, tt.contacts); got != tt.want {
+				t.Fatalf("replaceMentionedNames() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/whatsrust/lib/message_handling.go
+++ b/whatsrust/lib/message_handling.go
@@ -38,7 +38,7 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 			}
 		}
 
-		emitTextMessage(cinfo, ext_msg.GetText(), isSync)
+		emitTextMessage(cinfo, textWithMentionNames(ext_msg.GetText(), context_info), isSync)
 	}
 	if msg.ImageMessage != nil {
 		if !emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync) {

--- a/whatsrust/lib/message_handling_test.go
+++ b/whatsrust/lib/message_handling_test.go
@@ -28,7 +28,7 @@ func TestHandleMessageOrchestrationOwnership(t *testing.T) {
 	}
 	for _, fragment := range []string{
 		"emitTextMessage(cinfo, msg.GetConversation(), isSync)",
-		"emitTextMessage(cinfo, ext_msg.GetText(), isSync)",
+		"emitTextMessage(cinfo, textWithMentionNames(ext_msg.GetText(), context_info), isSync)",
 		"emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync)",
 		"emitVideoMessage(cinfo, info.ID, msg.GetVideoMessage(), isSync)",
 		"emitAudioMessage(cinfo, info.ID, msg.GetAudioMessage(), isSync)",


### PR DESCRIPTION
## Summary

- Resolve metadata-backed WhatsApp mention tokens to known contact display names before message ingestion.
- Persist readable `@name` text for live and synchronized messages while preserving unresolved identifiers unchanged.

## Changes

- Add boundary-safe mention replacement using `ContextInfo.MentionedJID`.
- Reuse contact lookup data with PN/LID aliases and graceful lookup failure fallback.
- Add table-driven coverage for multiple, repeated, malformed, aliased, and synchronized mentions.

## Testing

- [x] `cargo test -- --test-threads=1`
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cargo fmt --check`
- [ ] Manual testing done

Closes #247