### PR TITLE
refactor(bridge): make cgo ownership explicit

### DIFF
--- a/whatsrust/lib/client_lifecycle.go
+++ b/whatsrust/lib/client_lifecycle.go
@@ -97,6 +97,16 @@ func C_PairPhone(phone *C.char) *C.char {
 	return C.CString(code)
 }
 
+// C_FreePairPhoneResult releases the string returned by C_PairPhone. The
+// caller owns the result and must invoke this exactly once after copying it.
+//
+//export C_FreePairPhoneResult
+func C_FreePairPhoneResult(result *C.char) {
+	if result != nil {
+		C.free(unsafe.Pointer(result))
+	}
+}
+
 //export C_Disconnect
 func C_Disconnect() {
 	client.Disconnect()

--- a/whatsrust/lib/contacts.go
+++ b/whatsrust/lib/contacts.go
@@ -131,6 +131,15 @@ func freeContactResult(result C.GetContactsResult) {
 	C.free(unsafe.Pointer(result.entries))
 }
 
+// C_FreeContacts releases the entries and strings returned by C_GetContacts.
+// The caller owns the result and must invoke this exactly once after copying
+// all entries. Empty results are valid and nil-safe.
+//
+//export C_FreeContacts
+func C_FreeContacts(result C.GetContactsResult) {
+	freeContactResult(result)
+}
+
 func contactEntryStrings(entry C.ContactEntry) (string, string) {
 	return C.GoString(entry.jid), C.GoString(entry.name)
 }

--- a/whatsrust/lib/contacts_test.go
+++ b/whatsrust/lib/contacts_test.go
@@ -67,8 +67,10 @@ func TestContactEntriesToCPreservesOrderAndEmptyOwnership(t *testing.T) {
 			t.Errorf("entry %d name = %q, want %q", i, name, want.name)
 		}
 	}
-	freeContactResult(result)
+	C_FreeContacts(result)
 	if empty := contactEntriesToC(nil); empty.entries != nil || empty.size != 0 {
 		t.Fatalf("empty result = (%p, %d), want nil and zero", empty.entries, empty.size)
+	} else {
+		C_FreeContacts(empty)
 	}
 }

--- a/whatsrust/lib/message_callback.go
+++ b/whatsrust/lib/message_callback.go
@@ -65,12 +65,14 @@ func messageCallbackMetadataFrom(info types.MessageInfo, msg *waE2E.Message) mes
 type messageCallback struct {
 	info        C.MessageInfo
 	forwardData unsafe.Pointer
+	locked      bool
+	closed      bool
 }
 
 func beginMessageCallback(info types.MessageInfo, msg *waE2E.Message, rawSource []byte) *messageCallback {
 	messageCallbackMu.Lock()
 	rememberAuthenticatedPushName(info)
-	callback := &messageCallback{}
+	callback := &messageCallback{locked: true}
 	if len(rawSource) > 0 {
 		callback.forwardData = C.CBytes(rawSource)
 	}
@@ -134,13 +136,38 @@ func messageCallbackPushName(callback *messageCallback) string {
 	return C.GoString(callback.info.pushName)
 }
 
+func (callback *messageCallback) setQuoteID(id string) {
+	callback.info.quoteID = C.CString(id)
+}
+
 func (callback *messageCallback) close() {
+	if callback == nil || callback.closed {
+		return
+	}
+	callback.closed = true
 	C.setActiveForwardSource(nil, 0)
 	if callback.forwardData != nil {
 		C.free(callback.forwardData)
+		callback.forwardData = nil
 	}
-	if callback.info.pushName != nil {
-		C.free(unsafe.Pointer(callback.info.pushName))
+	for _, pointer := range []unsafe.Pointer{
+		unsafe.Pointer(callback.info.id),
+		unsafe.Pointer(callback.info.chat),
+		unsafe.Pointer(callback.info.sender),
+		unsafe.Pointer(callback.info.pushName),
+		unsafe.Pointer(callback.info.quoteID),
+	} {
+		if pointer != nil {
+			C.free(pointer)
+		}
 	}
-	messageCallbackMu.Unlock()
+	callback.info.id = nil
+	callback.info.chat = nil
+	callback.info.sender = nil
+	callback.info.pushName = nil
+	callback.info.quoteID = nil
+	if callback.locked {
+		callback.locked = false
+		messageCallbackMu.Unlock()
+	}
 }

--- a/whatsrust/lib/message_callback_test.go
+++ b/whatsrust/lib/message_callback_test.go
@@ -116,6 +116,46 @@ func TestBeginMessageCallbackPreservesPushNameAcrossCMetadata(t *testing.T) {
 	}
 }
 
+func TestHandleMessageQuotedTextUsesOwnedCallbackQuoteID(t *testing.T) {
+	previousObserve := observeTextCallback
+	t.Cleanup(func() { observeTextCallback = previousObserve })
+
+	var output textCallbackOutput
+	observeTextCallback = func(got textCallbackOutput) { output = got }
+	stanzaID := "quoted-message"
+	text := "reply"
+	HandleMessage(types.MessageInfo{ID: "message-id"}, &waE2E.Message{
+		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+			Text:        &text,
+			ContextInfo: &waE2E.ContextInfo{StanzaID: &stanzaID},
+		},
+	}, false)
+
+	if output.quoteID != stanzaID {
+		t.Fatalf("quoted callback quote ID = %q, want %q", output.quoteID, stanzaID)
+	}
+}
+
+func TestMessageCallbackCloseReleasesAllCallbackStateExactlyOnce(t *testing.T) {
+	callback := beginMessageCallback(types.MessageInfo{PushName: "profile"}, &waE2E.Message{}, []byte("forwarded"))
+	callback.setQuoteID("quoted-message")
+	callback.close()
+	callback.close()
+
+	if callback.forwardData != nil || callback.info.id != nil || callback.info.chat != nil || callback.info.sender != nil || callback.info.pushName != nil || callback.info.quoteID != nil {
+		t.Fatalf("callback cleanup left owned state: %#v", callback)
+	}
+
+	// A second callback proves the first close released the serialization lock.
+	next := beginMessageCallback(types.MessageInfo{}, &waE2E.Message{}, nil)
+	next.close()
+}
+
+func TestMessageCallbackCloseNilIsSafe(t *testing.T) {
+	var callback *messageCallback
+	callback.close()
+}
+
 func TestSelfMentionUsesAuthenticatedPushNameLearnedFromOwnCallback(t *testing.T) {
 	previousClient := client
 	t.Cleanup(func() {

--- a/whatsrust/lib/message_handling.go
+++ b/whatsrust/lib/message_handling.go
@@ -40,7 +40,8 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 			id := context_info.GetStanzaID()
 			// LOG_ERROR("asdfasdf %s", co)
 			if id != "" {
-				cinfo.quoteID = C.CString(id)
+				callback.setQuoteID(id)
+				cinfo.quoteID = callback.info.quoteID
 			}
 		}
 

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -920,6 +920,7 @@ unsafe extern "C" {
         forward_source_len: usize,
     ) -> CForwardResult;
     fn C_GetContacts() -> CGetContactsResult;
+    fn C_FreeContacts(result: CGetContactsResult);
     fn C_GetCommunities() -> CGetCommunitiesResult;
     fn C_FreeCommunities(result: CGetCommunitiesResult);
     fn C_GetProfilePicture(jid: CJID) -> CProfilePictureResult;
@@ -937,6 +938,7 @@ unsafe extern "C" {
     fn C_FreeRawPresenceDiagnostics(report: *mut c_char);
     fn C_SubscribePresence(jid: CJID) -> u8;
     fn C_PairPhone(phone: *const c_char) -> *const c_char;
+    fn C_FreePairPhoneResult(result: *const c_char);
     fn C_DownloadFile(file_id: *const c_char, base_path: *const c_char) -> u8;
     fn C_ReactToMessage(
         target_jid: CJID,
@@ -1348,6 +1350,7 @@ pub fn pair_phone(phone: &str) -> String {
     let result_str = unsafe { CStr::from_ptr(result) }
         .to_string_lossy()
         .into_owned();
+    unsafe { C_FreePairPhoneResult(result) };
     result_str
 }
 
@@ -2096,7 +2099,7 @@ pub fn get_contacts() -> Vec<(JID, Arc<str>)> {
     let result = unsafe { C_GetContacts() };
     let entries = unsafe { std::slice::from_raw_parts(result.entries, result.size as usize) };
 
-    entries
+    let contacts = entries
         .iter()
         .map(|e| {
             let jid: JID = (&e.jid).into();
@@ -2106,7 +2109,9 @@ pub fn get_contacts() -> Vec<(JID, Arc<str>)> {
                 .into();
             (jid, name)
         })
-        .collect()
+        .collect();
+    unsafe { C_FreeContacts(result) };
+    contacts
 }
 
 const COMMUNITY_ANNOUNCEMENT_UNKNOWN: u8 = 0;


### PR DESCRIPTION
## Summary

- Make Go-owned callback and result memory explicit across the cgo boundary.
- Prevent callback, pairing-code, and contact-result allocations from outliving their Rust copies.

## Changes

- Release every callback-owned C allocation exactly once after synchronous delivery.
- Attach quoted-message IDs to the owned callback state.
- Add explicit release exports for pairing and contact results and invoke them from Rust after copying.
- Add focused nil, repeated-cleanup, quoted-message, and contact-result coverage.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test -- --test-threads=1` (one unrelated UI assertion failed once; base and candidate targeted comparisons passed)
- [x] `cargo test --all-targets` (604 passed)
- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [ ] Manual testing: N/A; internal ownership refactor with automated boundary coverage.

## Chain context

```text
main
└── 📍 refactor/go-cgo-ownership
    └── next: client lifecycle and callback registry
```

- **Starts from:** `main` at `8c87e46`.
- **Ends with:** explicit callback and returned-result ownership.
- **Follow-up:** encapsulate client lifecycle, handler registration, and error boundaries.
- **Out of scope:** identity policy, outbound request construction, and event routing.
- **Review budget:** 110 authored lines.
- **Rollback:** revert `b941ac7`; only the seven bridge ownership files are affected.

Closes #259