### PR TITLE
refactor(db): extract message schema migrations

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -31,61 +31,6 @@ pub(crate) fn with_database_write_lock<T>(operation: impl FnOnce() -> T) -> T {
     operation()
 }
 
-fn ensure_forwarding_columns(db: &Connection, table: &str) {
-    let columns = db
-        .prepare(&format!("PRAGMA table_info({table})"))
-        .unwrap()
-        .query_map([], |row| row.get::<_, String>(1))
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    if columns.is_empty() {
-        return;
-    }
-    for (column, definition) in [
-        ("is_forwarded", "INTEGER NOT NULL DEFAULT 0"),
-        ("forwarding_score", "INTEGER NOT NULL DEFAULT 0"),
-    ] {
-        if !columns.iter().any(|present| present == column) {
-            db.execute(
-                &format!("ALTER TABLE {table} ADD COLUMN {column} {definition}"),
-                [],
-            )
-            .unwrap();
-        }
-    }
-}
-
-fn ensure_mention_columns(db: &Connection) {
-    for table in ["text_messages", "file_messages"] {
-        let columns = db
-            .prepare(&format!("PRAGMA table_info({table})"))
-            .unwrap()
-            .query_map([], |row| row.get::<_, String>(1))
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        if !columns.is_empty() {
-            if !columns.iter().any(|column| column == "mention_ranges") {
-                db.execute(
-                    &format!("ALTER TABLE {table} ADD COLUMN mention_ranges TEXT"),
-                    [],
-                )
-                .unwrap();
-            }
-            if !columns.iter().any(|column| column == "mentions_self") {
-                db.execute(
-                    &format!(
-                        "ALTER TABLE {table} ADD COLUMN mentions_self INTEGER NOT NULL DEFAULT 0"
-                    ),
-                    [],
-                )
-                .unwrap();
-            }
-        }
-    }
-}
-
 fn encode_mention_ranges(ranges: &[Range<usize>]) -> Option<String> {
     (!ranges.is_empty()).then(|| {
         ranges
@@ -314,8 +259,7 @@ impl DatabaseHandler {
     }
 
     pub fn add_message(&self, message: &wr::Message) {
-        self.migrate_forwarding_columns();
-        ensure_mention_columns(&self.db);
+        schema::prepare_legacy_message_schema(&self.db);
         let mut queue = self.new_messages_queue.lock().unwrap();
         queue.push(message.clone());
     }
@@ -370,7 +314,7 @@ impl DatabaseHandler {
     /// Inserts once by the protocol action ID. A duplicate arriving from
     /// live delivery or history sync is ignored.
     pub fn record_message_action(&self, action: &MessageAction) -> MessageActionPersistence {
-        self.migrate_forwarding_columns();
+        schema::prepare_legacy_forwarding_schema(&self.db);
         let kind = match &action.kind {
             MessageActionKind::Edit { .. } => 0_u8,
             MessageActionKind::Delete => 1_u8,
@@ -542,8 +486,7 @@ impl DatabaseHandler {
     }
 
     pub fn get_messages(&self) -> Vec<wr::Message> {
-        self.migrate_forwarding_columns();
-        ensure_mention_columns(&self.db);
+        schema::prepare_legacy_message_schema(&self.db);
         let mut messages = Vec::new();
         for kind in wr::MessageContent::iter() {
             let msgs = match kind {
@@ -719,104 +662,7 @@ impl DatabaseHandler {
 
     pub fn init(&self) {
         let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
-        self.db
-            .execute(
-                "CREATE TABLE IF NOT EXISTS chats (
-                    jid TEXT PRIMARY KEY
-                )",
-                [],
-            )
-            .unwrap();
-
-        self.db
-            .execute(
-                "CREATE TABLE IF NOT EXISTS contacts (
-                    jid TEXT PRIMARY KEY,
-                    name TEXT NOT NULL
-                )",
-                [],
-            )
-            .unwrap();
-        self.db
-            .execute(
-                "CREATE TABLE IF NOT EXISTS chat_read_cursors (
-                    chat_jid TEXT PRIMARY KEY,
-                    message_id TEXT NOT NULL,
-                    timestamp INTEGER NOT NULL
-                )",
-                [],
-            )
-            .unwrap();
-        self.db
-            .execute(
-                "CREATE TABLE IF NOT EXISTS status_read_cursors (
-                    contact_jid TEXT PRIMARY KEY,
-                    timestamp INTEGER NOT NULL
-                )",
-                [],
-            )
-            .unwrap();
-
-        for kind in wr::MessageContent::iter() {
-            match kind {
-                wr::MessageContent::Text(_) => {
-                    self.db
-                        .execute(
-                            "CREATE TABLE IF NOT EXISTS text_messages (
-                                id TEXT PRIMARY KEY,
-                                chat_jid TEXT,
-                                sender_jid TEXT,
-                                timestamp INTEGER,
-                                quote_id TEXT,
-                                is_from_me INTEGER,
-                                read INTEGER,
-
-                                message TEXT
-                            )",
-                            [],
-                        )
-                        .unwrap();
-                }
-                wr::MessageContent::File(_) => {
-                    self.db
-                        .execute(
-                            "CREATE TABLE IF NOT EXISTS file_messages (
-                                id TEXT PRIMARY KEY,
-                                chat_jid TEXT,
-                                sender_jid TEXT,
-                                timestamp INTEGER,
-                                quote_id TEXT,
-                                is_from_me INTEGER,
-                                read INTEGER,
-
-                                kind INTEGER,
-                                path TEXT,
-                                file_id TEXT,
-                                caption TEXT
-                            )",
-                            [],
-                        )
-                        .unwrap();
-                }
-                wr::MessageContent::ViewOnceUnavailable => {}
-            }
-        }
-        self.db
-            .execute(
-                "CREATE TABLE IF NOT EXISTS view_once_unavailable_messages (
-                    id TEXT PRIMARY KEY,
-                    chat_jid TEXT,
-                    sender_jid TEXT,
-                    timestamp INTEGER,
-                    is_from_me INTEGER,
-                    read INTEGER,
-                    mentions_self INTEGER NOT NULL DEFAULT 0
-                )",
-                [],
-            )
-            .unwrap();
-        self.migrate_forwarding_columns();
-        ensure_mention_columns(&self.db);
+        schema::initialize(&self.db);
         self.migrate_message_action_columns();
     }
 
@@ -953,11 +799,6 @@ impl DatabaseHandler {
         self.db
             .execute("ALTER TABLE message_actions DROP COLUMN replacement", [])
             .unwrap();
-    }
-
-    fn migrate_forwarding_columns(&self) {
-        ensure_forwarding_columns(&self.db, "text_messages");
-        ensure_forwarding_columns(&self.db, "file_messages");
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use rusqlite::Connection;
+use strum::IntoEnumIterator;
+use whatsrust as wr;
 
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 const READ_RECEIPT_SCHEMA_VERSION: i64 = 2;
@@ -71,10 +73,164 @@ pub(crate) fn prepare(db: &Connection) {
     .unwrap();
 }
 
+/// Applies message-table migrations needed by ordinary operations before
+/// callers explicitly request full schema initialization.
+pub(crate) fn prepare_legacy_message_schema(db: &Connection) {
+    prepare_legacy_forwarding_schema(db);
+    ensure_mention_columns(db);
+}
+
+pub(crate) fn prepare_legacy_forwarding_schema(db: &Connection) {
+    ensure_forwarding_columns(db, "text_messages");
+    ensure_forwarding_columns(db, "file_messages");
+}
+
+/// Creates the complete message schema and applies its legacy migrations.
+/// Callers hold the process-wide database write lock.
+pub(crate) fn initialize(db: &Connection) {
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS chats (jid TEXT PRIMARY KEY)",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS contacts (jid TEXT PRIMARY KEY, name TEXT NOT NULL)",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS chat_read_cursors (chat_jid TEXT PRIMARY KEY, message_id TEXT NOT NULL, timestamp INTEGER NOT NULL)",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS status_read_cursors (contact_jid TEXT PRIMARY KEY, timestamp INTEGER NOT NULL)",
+        [],
+    )
+    .unwrap();
+    for kind in wr::MessageContent::iter() {
+        match kind {
+            wr::MessageContent::Text(_) => {
+                db.execute(
+                    "CREATE TABLE IF NOT EXISTS text_messages (
+                        id TEXT PRIMARY KEY, chat_jid TEXT, sender_jid TEXT, timestamp INTEGER,
+                        quote_id TEXT, is_from_me INTEGER, read INTEGER, message TEXT
+                    )",
+                    [],
+                )
+                .unwrap();
+            }
+            wr::MessageContent::File(_) => {
+                db.execute(
+                    "CREATE TABLE IF NOT EXISTS file_messages (
+                        id TEXT PRIMARY KEY, chat_jid TEXT, sender_jid TEXT, timestamp INTEGER,
+                        quote_id TEXT, is_from_me INTEGER, read INTEGER, kind INTEGER,
+                        path TEXT, file_id TEXT, caption TEXT
+                    )",
+                    [],
+                )
+                .unwrap();
+            }
+            wr::MessageContent::ViewOnceUnavailable => {}
+        }
+    }
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS view_once_unavailable_messages (
+            id TEXT PRIMARY KEY, chat_jid TEXT, sender_jid TEXT, timestamp INTEGER,
+            is_from_me INTEGER, read INTEGER, mentions_self INTEGER NOT NULL DEFAULT 0
+        )",
+        [],
+    )
+    .unwrap();
+    prepare_legacy_message_schema(db);
+}
+
 fn ensure_read_receipt_schema(db: &Connection) -> rusqlite::Result<()> {
     let version: i64 = db.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if version < READ_RECEIPT_SCHEMA_VERSION {
         db.execute_batch("CREATE TABLE IF NOT EXISTS read_receipt_pending (chat TEXT NOT NULL, sender TEXT NOT NULL, message_id TEXT NOT NULL, timestamp INTEGER NOT NULL, kind INTEGER NOT NULL, PRIMARY KEY (chat, sender, message_id)); CREATE INDEX IF NOT EXISTS idx_read_receipt_pending_timestamp ON read_receipt_pending(timestamp); CREATE TABLE IF NOT EXISTS read_receipt_sent (chat TEXT NOT NULL, sender TEXT NOT NULL, message_id TEXT NOT NULL, PRIMARY KEY (chat, sender, message_id)); CREATE TABLE IF NOT EXISTS read_receipt_rejected (chat TEXT NOT NULL, sender TEXT NOT NULL, message_id TEXT NOT NULL, PRIMARY KEY (chat, sender, message_id)); PRAGMA user_version = 2")?;
     }
     Ok(())
+}
+
+fn columns(db: &Connection, table: &str) -> Vec<String> {
+    db.prepare(&format!("PRAGMA table_info({table})"))
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+fn ensure_forwarding_columns(db: &Connection, table: &str) {
+    let present = columns(db, table);
+    if present.is_empty() {
+        return;
+    }
+    for (column, definition) in [
+        ("is_forwarded", "INTEGER NOT NULL DEFAULT 0"),
+        ("forwarding_score", "INTEGER NOT NULL DEFAULT 0"),
+    ] {
+        if !present.iter().any(|item| item == column) {
+            db.execute(
+                &format!("ALTER TABLE {table} ADD COLUMN {column} {definition}"),
+                [],
+            )
+            .unwrap();
+        }
+    }
+}
+
+fn ensure_mention_columns(db: &Connection) {
+    for table in ["text_messages", "file_messages"] {
+        let present = columns(db, table);
+        if !present.is_empty() {
+            if !present.iter().any(|column| column == "mention_ranges") {
+                db.execute(
+                    &format!("ALTER TABLE {table} ADD COLUMN mention_ranges TEXT"),
+                    [],
+                )
+                .unwrap();
+            }
+            if !present.iter().any(|column| column == "mentions_self") {
+                db.execute(
+                    &format!(
+                        "ALTER TABLE {table} ADD COLUMN mentions_self INTEGER NOT NULL DEFAULT 0"
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_schema_initialization_is_idempotent() {
+        let db = Connection::open_in_memory().unwrap();
+        initialize(&db);
+        initialize(&db);
+        assert_eq!(columns(&db, "text_messages").len(), 12);
+        assert_eq!(columns(&db, "file_messages").len(), 15);
+    }
+
+    #[test]
+    fn legacy_message_columns_migrate_forwarding_and_mentions() {
+        let db = Connection::open_in_memory().unwrap();
+        db.execute_batch(
+            "CREATE TABLE text_messages (id TEXT PRIMARY KEY, chat_jid TEXT, sender_jid TEXT, timestamp INTEGER, quote_id TEXT, is_from_me INTEGER, read INTEGER, message TEXT);
+             CREATE TABLE file_messages (id TEXT PRIMARY KEY, chat_jid TEXT, sender_jid TEXT, timestamp INTEGER, quote_id TEXT, is_from_me INTEGER, read INTEGER, kind INTEGER, path TEXT, file_id TEXT, caption TEXT);",
+        )
+        .unwrap();
+        prepare_legacy_message_schema(&db);
+        prepare_legacy_message_schema(&db);
+        assert!(columns(&db, "text_messages").contains(&"is_forwarded".into()));
+        assert!(columns(&db, "text_messages").contains(&"mention_ranges".into()));
+        assert!(columns(&db, "text_messages").contains(&"mentions_self".into()));
+        assert!(columns(&db, "file_messages").contains(&"forwarding_score".into()));
+    }
 }

--- a/tests/mention_persistence.rs
+++ b/tests/mention_persistence.rs
@@ -73,6 +73,80 @@ fn mention_ranges_round_trip_and_legacy_rows_reload_empty() {
 }
 
 #[test]
+fn legacy_message_schema_survives_lazy_reads_and_repeated_init_with_positional_order() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("initialized-legacy.db");
+    let connection = rusqlite::Connection::open(&path).unwrap();
+    connection
+        .execute_batch(
+            "CREATE TABLE chats (jid TEXT PRIMARY KEY);
+             CREATE TABLE contacts (jid TEXT PRIMARY KEY, name TEXT NOT NULL);
+             CREATE TABLE text_messages (id TEXT PRIMARY KEY, chat_jid TEXT, sender_jid TEXT, timestamp INTEGER, quote_id TEXT, is_from_me INTEGER, read INTEGER, message TEXT);
+             CREATE TABLE file_messages (id TEXT PRIMARY KEY, chat_jid TEXT, sender_jid TEXT, timestamp INTEGER, quote_id TEXT, is_from_me INTEGER, read INTEGER, kind INTEGER, path TEXT, file_id TEXT, caption TEXT);
+             CREATE TABLE view_once_unavailable_messages (id TEXT PRIMARY KEY, chat_jid TEXT, sender_jid TEXT, timestamp INTEGER, is_from_me INTEGER, read INTEGER, mentions_self INTEGER NOT NULL DEFAULT 0);
+             INSERT INTO text_messages VALUES ('legacy-text', 'chat@example.test', 'chat@example.test', 1, NULL, 0, 0, 'hello');
+             INSERT INTO file_messages VALUES ('legacy-file', 'chat@example.test', 'chat@example.test', 2, NULL, 0, 0, 3, 'file.bin', 'file-id', NULL);",
+        )
+        .unwrap();
+    drop(connection);
+
+    let mut handler = DatabaseHandler::new(&path);
+    let lazy_messages = handler.get_messages();
+    assert_eq!(lazy_messages.len(), 2);
+    handler.init();
+    handler.init();
+    handler.stop();
+
+    let connection = rusqlite::Connection::open(path).unwrap();
+    let columns = |table: &str| {
+        connection
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert_eq!(
+        columns("text_messages"),
+        [
+            "id",
+            "chat_jid",
+            "sender_jid",
+            "timestamp",
+            "quote_id",
+            "is_from_me",
+            "read",
+            "message",
+            "is_forwarded",
+            "forwarding_score",
+            "mention_ranges",
+            "mentions_self",
+        ]
+    );
+    assert_eq!(
+        columns("file_messages"),
+        [
+            "id",
+            "chat_jid",
+            "sender_jid",
+            "timestamp",
+            "quote_id",
+            "is_from_me",
+            "read",
+            "kind",
+            "path",
+            "file_id",
+            "caption",
+            "is_forwarded",
+            "forwarding_score",
+            "mention_ranges",
+            "mentions_self",
+        ]
+    );
+}
+
+#[test]
 fn message_ownership_is_monotonic_for_text_and_file_rows() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("ownership.db");


### PR DESCRIPTION
## Summary

- Move message-table creation and forwarding/mention migrations behind the schema boundary.
- Preserve established lazy migration paths before explicit database initialization.

## Changes

- Move message schema SQL and idempotent migration helpers into `src/schema.rs`.
- Keep message-action migration in `src/db.rs` for the next child.
- Preserve forwarding-only preparation on the message-action path.
- Add realistic file-backed lifecycle coverage for pre-init reads, repeated init, and exact positional column order.

## Testing

- [x] `cargo fmt --check`
- [x] Focused schema, lifecycle, forwarding, and mention suites
- [x] `cargo check --lib`
- [x] `cargo test -- --test-threads=1` (605 passed before the final narrow timing correction; affected focused suites pass afterward)
- [x] `git diff --check`
- [ ] Manual testing: N/A; behavior-preserving schema extraction.

## Chain context

```text
main
└── PR #261: connection schema setup
    └── 📍 refactor/rust-db-message-schema
        └── next: message-action migration and legacy compatibility
```

- **Depends on:** PR #261 / `refactor/rust-db-schema-core`.
- **Ends with:** one owner for message schema and forwarding/mention migrations.
- **Follow-up:** extract message-action migration and its legacy compatibility coverage.
- **Out of scope:** message stores, repositories, reactions, cursors, cleanup, and worker redesign.
- **Review budget:** 397 authored lines.
- **Rollback:** revert `09f1806`; only `src/db.rs`, `src/schema.rs`, and the lifecycle regression test are affected.

Closes #263