### PR TITLE
refactor(bridge): encapsulate lifecycle registration

### DIFF
--- a/whatsrust/lib/client_lifecycle.go
+++ b/whatsrust/lib/client_lifecycle.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -27,13 +28,39 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// client and qrChan remain package-owned because the other bridge actions use
-// the same client after this lifecycle boundary is crossed.
+// client remains package-owned because the other bridge actions use the same
+// client after this lifecycle boundary is crossed. The QR stream and handler
+// registration state live here so reconnect setup has one resettable owner.
 var client *whatsmeow.Client
-var qrChan <-chan whatsmeow.QRChannelItem
+
+type clientLifecycleState struct {
+	mu                 sync.Mutex
+	qrChan             <-chan whatsmeow.QRChannelItem
+	handlersRegistered bool
+}
+
+var lifecycleState clientLifecycleState
+
+func (state *clientLifecycleState) reset() {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.qrChan = nil
+	state.handlersRegistered = false
+}
+
+func (state *clientLifecycleState) registerEventHandlers(register func()) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.handlersRegistered {
+		return
+	}
+	register()
+	state.handlersRegistered = true
+}
 
 //export C_NewClient
 func C_NewClient(dbPath *C.char) {
+	lifecycleState.reset()
 	clearAuthenticatedPushNameCache()
 	rawPresenceProbe.reset(os.Getenv("WPTUI_PRESENCE_DEBUG") == "1")
 	requestFullHistorySync()
@@ -68,12 +95,15 @@ func C_Connect(handler C.QrCallback, data unsafe.Pointer) {
 			store.DeviceProps.GetHistorySyncConfig().GetFullSyncSizeMbLimit(),
 			store.DeviceProps.GetPlatformType(),
 		)
-		qrChan, _ = client.GetQRChannel(context.Background())
+		lifecycleState.mu.Lock()
+		lifecycleState.qrChan, _ = client.GetQRChannel(context.Background())
+		qrChannel := lifecycleState.qrChan
+		lifecycleState.mu.Unlock()
 		if err := client.Connect(); err != nil {
 			panic(err)
 		}
 
-		for evt := range qrChan {
+		for evt := range qrChannel {
 			if evt.Event != "code" {
 				continue
 			}

--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -3,7 +3,39 @@ package main
 import (
 	"errors"
 	"testing"
+
+	"go.mau.fi/whatsmeow"
 )
+
+func TestClientLifecycleRegistrationIsIdempotent(t *testing.T) {
+	var state clientLifecycleState
+	registrations := 0
+	register := func() { registrations++ }
+
+	state.registerEventHandlers(register)
+	state.registerEventHandlers(register)
+
+	if registrations != 1 {
+		t.Fatalf("registrations = %d, want one", registrations)
+	}
+}
+
+func TestClientLifecycleResetClearsRegistrationAndQR(t *testing.T) {
+	qr := make(chan whatsmeow.QRChannelItem)
+	state := clientLifecycleState{
+		qrChan:             qr,
+		handlersRegistered: true,
+	}
+
+	state.reset()
+
+	if state.qrChan != nil {
+		t.Fatal("reset retained QR channel")
+	}
+	if state.handlersRegistered {
+		t.Fatal("reset retained handler registration")
+	}
+}
 
 func TestLogoutStatusAfterRemoteFailure(t *testing.T) {
 	for _, testCase := range []struct {

--- a/whatsrust/lib/event_wiring.go
+++ b/whatsrust/lib/event_wiring.go
@@ -64,6 +64,12 @@ func (dispatcher *viewOnceUnavailableDispatcher) dispatchOnce(info types.Message
 }
 
 func AddEventHandlers() {
+	lifecycleState.registerEventHandlers(func() {
+		addEventHandlers()
+	})
+}
+
+func addEventHandlers() {
 	viewOnceDispatcher := newViewOnceUnavailableDispatcher(HandleViewOnceUnavailableMessage)
 	client.AddEventHandler(func(rawEvt any) {
 		messageActionCensusDiagnostic(rawEvt)


### PR DESCRIPTION
## Summary

- Give QR-channel and event-handler registration lifecycle one synchronized owner.
- Make repeated connection setup register the WhatsApp event handler only once.

## Changes

- Add mutex-protected lifecycle state for QR and registration state.
- Reset lifecycle registration when constructing a new client.
- Preserve existing cgo exports, callback order, reconnect behavior, and the parent ownership contracts.
- Add focused idempotency and reset coverage.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test -- --test-threads=1` (604 passed)
- [x] Focused lifecycle tests (2 passed)
- [x] `cd whatsrust/lib && go test ./... -count=1`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `git diff --check`
- [ ] Manual testing: N/A; internal lifecycle extraction.

## Chain context

```text
main
└── PR #260: cgo ownership
    └── 📍 refactor/go-client-lifecycle
        └── next: migrate direct client consumers behind accessors
```

- **Depends on:** PR #260 / `refactor/go-cgo-ownership`.
- **Ends with:** idempotent lifecycle registration and owned QR state.
- **Follow-up:** migrate selected package-level client consumers without broad event-routing changes.
- **Out of scope:** panic mapping, identity policy, outbound builders, and general event routing.
- **Review budget:** 78 authored lines.
- **Rollback:** revert `9a543c6`; only three lifecycle/event-wiring files are affected.

Closes #262