### PR TITLE
refactor(bridge): encapsulate media client access

### DIFF
--- a/whatsrust/lib/client_lifecycle.go
+++ b/whatsrust/lib/client_lifecycle.go
@@ -41,6 +41,21 @@ type clientLifecycleState struct {
 
 var lifecycleState clientLifecycleState
 
+// clientSnapshot returns one lifecycle-consistent client pointer for an
+// operation. The client remains valid while the caller retains this pointer;
+// lifecycle replacement does not mutate the captured client object.
+func (state *clientLifecycleState) clientSnapshot() *whatsmeow.Client {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return client
+}
+
+func (state *clientLifecycleState) publishClient(newClient *whatsmeow.Client) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	client = newClient
+}
+
 func (state *clientLifecycleState) reset() {
 	state.mu.Lock()
 	defer state.mu.Unlock()
@@ -72,8 +87,9 @@ func C_NewClient(dbPath *C.char) {
 	}
 	deviceStore, _ := container.GetFirstDevice(context.Background())
 	clientLog := &WrLogger{}
-	client = whatsmeow.NewClient(deviceStore, clientLog)
-	configurePresenceSubscriptions(client)
+	newClient := whatsmeow.NewClient(deviceStore, clientLog)
+	configurePresenceSubscriptions(newClient)
+	lifecycleState.publishClient(newClient)
 }
 
 func requestFullHistorySync() {

--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -37,6 +37,63 @@ func TestClientLifecycleResetClearsRegistrationAndQR(t *testing.T) {
 	}
 }
 
+func TestClientLifecycleClientSnapshotUsesLifecycleLock(t *testing.T) {
+	previous := client
+	t.Cleanup(func() { lifecycleState.publishClient(previous) })
+	want := &whatsmeow.Client{}
+	lifecycleState.publishClient(want)
+
+	if got := lifecycleState.clientSnapshot(); got != want {
+		t.Fatalf("client snapshot = %p, want %p", got, want)
+	}
+}
+
+func TestClientLifecyclePublicationIsSynchronized(t *testing.T) {
+	var state clientLifecycleState
+	first, second := &whatsmeow.Client{}, &whatsmeow.Client{}
+	state.publishClient(first)
+
+	state.mu.Lock()
+	published := make(chan struct{})
+	go func() {
+		state.publishClient(second)
+		close(published)
+	}()
+	select {
+	case <-published:
+		t.Fatal("publication bypassed lifecycle lock")
+	default:
+	}
+	state.mu.Unlock()
+	<-published
+
+	if got := state.clientSnapshot(); got != second {
+		t.Fatalf("published client = %p, want %p", got, second)
+	}
+}
+
+func TestClientLifecycleOperationKeepsOneSnapshot(t *testing.T) {
+	var state clientLifecycleState
+	first, second := &whatsmeow.Client{}, &whatsmeow.Client{}
+	state.publishClient(first)
+	snapshotTaken := make(chan *whatsmeow.Client)
+	release := make(chan struct{})
+
+	go func() {
+		snapshot := state.clientSnapshot()
+		snapshotTaken <- snapshot
+		<-release
+	}()
+	if got := <-snapshotTaken; got != first {
+		t.Fatalf("operation snapshot = %p, want %p", got, first)
+	}
+	state.publishClient(second)
+	close(release)
+	if got := state.clientSnapshot(); got != second {
+		t.Fatalf("published client = %p, want %p", got, second)
+	}
+}
+
 func TestLogoutStatusAfterRemoteFailure(t *testing.T) {
 	for _, testCase := range []struct {
 		name           string

--- a/whatsrust/lib/lib.go
+++ b/whatsrust/lib/lib.go
@@ -150,6 +150,9 @@ func FileIdToDownloadInfo(fileId string) (DownloadInfo, error) {
 	return info, nil
 }
 func DownloadFromFileId(client *whatsmeow.Client, fileId string, basePath string) int {
+	if client == nil {
+		return FileStatusDownloadFailed
+	}
 	info, err := FileIdToDownloadInfo(fileId)
 	if err != nil {
 		return FileStatusDownloadFailed

--- a/whatsrust/lib/media_downloads.go
+++ b/whatsrust/lib/media_downloads.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"mime"
 	"sort"
+
+	"go.mau.fi/whatsmeow"
 )
 
 func SliceIndex(list []string, value string, defaultValue int) int {
@@ -36,10 +38,18 @@ func ExtensionByType(mimeType string, defaultExt string) string {
 	return ext
 }
 
+func downloadFile(client *whatsmeow.Client, fileID string, basePath string) int {
+	if client == nil {
+		return FileStatusDownloadFailed
+	}
+	return DownloadFromFileId(client, fileID, basePath)
+}
+
 //export C_DownloadFile
 func C_DownloadFile(fileId *C.char, basePath *C.char) C.uint8_t {
 	goFileId := C.GoString(fileId)
 	goBasePath := C.GoString(basePath)
-	status := DownloadFromFileId(client, goFileId, goBasePath)
+	clientSnapshot := lifecycleState.clientSnapshot()
+	status := downloadFile(clientSnapshot, goFileId, goBasePath)
 	return C.uint8_t(status)
 }

--- a/whatsrust/lib/media_downloads_test.go
+++ b/whatsrust/lib/media_downloads_test.go
@@ -1,10 +1,27 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
 )
+
+func TestDownloadFileReturnsFailureWhenClientIsUnavailable(t *testing.T) {
+	fileID, err := json.Marshal(DownloadInfo{Version: downloadInfoVersion, TargetPath: "media.jpg"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := client
+	t.Cleanup(func() { lifecycleState.publishClient(previous) })
+	lifecycleState.publishClient(nil)
+
+	root := t.TempDir()
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if got := downloadFile(clientSnapshot, string(fileID), root); got != FileStatusDownloadFailed {
+		t.Fatalf("download status = %d, want failure", got)
+	}
+}
 
 func TestMediaDownloadExportsAndPathHelpersStayOutOfMain(t *testing.T) {
 	mediaSource, err := os.ReadFile("media_downloads.go")

--- a/whatsrust/lib/profile_picture.go
+++ b/whatsrust/lib/profile_picture.go
@@ -111,20 +111,22 @@ func fetchProfilePicture(ctx context.Context, jidText string, lookup profilePict
 	return fetchProfilePictureWithParams(ctx, jidText, false, lookup, download)
 }
 
-func downloadProfilePicture(ctx context.Context, url string, limit int64) ([]byte, error) {
-	response, err := client.DangerousInternals().DoMediaDownloadRequest(ctx, url)
-	if err != nil {
-		return nil, err
+func downloadProfilePicture(client *whatsmeow.Client) profilePictureDownload {
+	return func(ctx context.Context, url string, limit int64) ([]byte, error) {
+		response, err := client.DangerousInternals().DoMediaDownloadRequest(ctx, url)
+		if err != nil {
+			return nil, err
+		}
+		defer response.Body.Close()
+		data, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(data)) > limit {
+			return nil, errProfilePictureOversized
+		}
+		return data, nil
 	}
-	defer response.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > limit {
-		return nil, errProfilePictureOversized
-	}
-	return data, nil
 }
 
 func profilePictureToC(outcome profilePictureOutcome) C.ProfilePictureResult {
@@ -147,12 +149,13 @@ func C_GetProfilePicture(jid *C.char) C.ProfilePictureResult {
 	if jid == nil {
 		return C.ProfilePictureResult{status: C.uint8_t(profilePictureStatusInvalidJID)}
 	}
-	if client == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil {
 		return C.ProfilePictureResult{status: C.uint8_t(profilePictureStatusClientUnavailable)}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), profilePictureTimeout)
 	defer cancel()
-	return profilePictureToC(fetchProfilePicture(ctx, C.GoString(jid), client.GetProfilePictureInfo, downloadProfilePicture))
+	return profilePictureToC(fetchProfilePicture(ctx, C.GoString(jid), clientSnapshot.GetProfilePictureInfo, downloadProfilePicture(clientSnapshot)))
 }
 
 //export C_GetCommunityProfilePicture
@@ -160,12 +163,13 @@ func C_GetCommunityProfilePicture(jid *C.char) C.ProfilePictureResult {
 	if jid == nil {
 		return C.ProfilePictureResult{status: C.uint8_t(profilePictureStatusInvalidJID)}
 	}
-	if client == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil {
 		return C.ProfilePictureResult{status: C.uint8_t(profilePictureStatusClientUnavailable)}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), profilePictureTimeout)
 	defer cancel()
-	return profilePictureToC(fetchProfilePictureWithParams(ctx, C.GoString(jid), true, client.GetProfilePictureInfo, downloadProfilePicture))
+	return profilePictureToC(fetchProfilePictureWithParams(ctx, C.GoString(jid), true, clientSnapshot.GetProfilePictureInfo, downloadProfilePicture(clientSnapshot)))
 }
 
 //export C_FreeProfilePicture


### PR DESCRIPTION
## Summary

- Route profile-picture and file-download bridge operations through one synchronized lifecycle client snapshot.
- Return the existing download-failure status instead of panicking when no client is available.

## Changes

- Add synchronized client publication and snapshot helpers.
- Bind each profile-picture lookup/download operation to one captured client.
- Bind file downloads to one captured client and handle the absent-client boundary.
- Add no-live-client and replacement-during-operation coverage.

## Testing

- [x] Focused lifecycle/media/profile tests (10 passed)
- [x] `cd whatsrust/lib && go test ./... -count=1`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `cargo fmt --check`
- [ ] Local `cargo test -- --test-threads=1` did not complete before the bounded timeout/disk guard; parent suite passed and CI is the remaining full proof.
- [x] `git diff --check`
- [ ] Manual testing: N/A; internal client-access boundary.

## Chain context

```text
main
└── PR #260: cgo ownership
    └── PR #265: lifecycle registration
        └── 📍 refactor/go-client-media-accessor
            └── next: transactional lifecycle replacement and remaining lifecycle reads
```

- **Depends on:** PR #265 / `refactor/go-client-lifecycle`.
- **Ends with:** synchronized media client access and nil-safe downloads.
- **Follow-up:** make client replacement transactional and migrate direct lifecycle/event reads.
- **Out of scope:** identity policy, outbound sending, and broad event routing.
- **Review budget:** 147 authored lines.
- **Rollback:** revert `5431c6c`; only six media/lifecycle files are affected.

Closes #266