### PR TITLE
refactor(db): isolate connection write coordination

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 use std::{
     ops::Range,
     path::{Path, PathBuf},
-    sync::{Arc, LazyLock, Mutex},
+    sync::{Arc, Mutex},
 };
 
 use log::debug;
@@ -13,22 +13,17 @@ use crate::app::{
     Chat, DELETED_MESSAGE_TEXT, MessageAction, MessageActionKind, STATUS_BROADCAST_CHAT,
 };
 
+#[path = "db/connection.rs"]
+mod connection;
 #[path = "schema.rs"]
 mod schema;
-pub(crate) use schema::try_open_database;
-
-// SQLite allows only one writer. All handlers in this process share this lock,
-// including the asynchronous queue writer started by each handler.
-static DATABASE_WRITE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+pub(crate) use connection::{
+    DATABASE_WRITE_LOCK, open_database, try_open_database, with_database_write_lock,
+};
 
 /// WhatsApp statuses expire 24 hours after posting (server-side). The local
 /// purge uses the same window so status broadcasts do not accumulate forever.
 const STATUS_RETENTION_SECS: i64 = 24 * 60 * 60;
-
-pub(crate) fn with_database_write_lock<T>(operation: impl FnOnce() -> T) -> T {
-    let _lock = DATABASE_WRITE_LOCK.lock().unwrap();
-    operation()
-}
 
 fn encode_mention_ranges(ranges: &[Range<usize>]) -> Option<String> {
     (!ranges.is_empty()).then(|| {
@@ -76,7 +71,7 @@ pub enum MessageActionPersistence {
 
 impl DatabaseHandler {
     pub fn new(db_path: &Path) -> Self {
-        let db = schema::open_database(db_path);
+        let db = open_database(db_path);
         let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
         schema::prepare(&db);
         let new_messages_queue = Arc::new(Mutex::new(Vec::<wr::Message>::new()));
@@ -88,7 +83,7 @@ impl DatabaseHandler {
         let should_stop_clone = Arc::clone(&should_stop);
         let db_path = db_path.to_owned();
         let thread = std::thread::spawn(move || {
-            let mut db = schema::open_database(&db_path);
+            let mut db = open_database(&db_path);
             loop {
                 std::thread::sleep(std::time::Duration::from_secs(1));
                 let new_chats = {

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -1,0 +1,30 @@
+use std::{
+    path::Path,
+    sync::{LazyLock, Mutex},
+    time::Duration,
+};
+
+use rusqlite::Connection;
+
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+
+// SQLite allows only one writer. All handlers in this process share this lock,
+// including the asynchronous queue writer started by each handler.
+pub(crate) static DATABASE_WRITE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+pub(crate) fn open_database(path: &Path) -> Connection {
+    let db = Connection::open(path).unwrap();
+    db.busy_timeout(SQLITE_BUSY_TIMEOUT).unwrap();
+    db
+}
+
+pub(crate) fn try_open_database(path: &Path) -> rusqlite::Result<Connection> {
+    let db = Connection::open(path)?;
+    db.busy_timeout(SQLITE_BUSY_TIMEOUT)?;
+    Ok(db)
+}
+
+pub(crate) fn with_database_write_lock<T>(operation: impl FnOnce() -> T) -> T {
+    let _lock = DATABASE_WRITE_LOCK.lock().unwrap();
+    operation()
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,27 +1,10 @@
-use std::time::Duration;
-use std::{
-    collections::{HashMap, HashSet},
-    path::Path,
-};
+use std::collections::{HashMap, HashSet};
 
 use rusqlite::Connection;
 use strum::IntoEnumIterator;
 use whatsrust as wr;
 
-const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 const READ_RECEIPT_SCHEMA_VERSION: i64 = 2;
-
-pub(crate) fn open_database(path: &Path) -> Connection {
-    let db = Connection::open(path).unwrap();
-    db.busy_timeout(SQLITE_BUSY_TIMEOUT).unwrap();
-    db
-}
-
-pub(crate) fn try_open_database(path: &Path) -> rusqlite::Result<Connection> {
-    let db = Connection::open(path)?;
-    db.busy_timeout(SQLITE_BUSY_TIMEOUT)?;
-    Ok(db)
-}
 
 /// Prepares the tables required by the handler before full initialization.
 /// This preserves the historical constructor lifecycle.


### PR DESCRIPTION
## Summary

- Move SQLite connection opening and process-wide write-lock coordination into a focused database module.
- Preserve existing persistence and read-receipt repository APIs.

## Changes

- Add `src/db/connection.rs` as the owner of connection helpers and `DATABASE_WRITE_LOCK`.
- Reexport crate-visible helpers from the database facade.
- Preserve lock poisoning, busy timeout, opening order, and worker timing.

## Testing

- [x] `cargo fmt --check`
- [x] Focused read-receipt/database tests
- [x] `cargo check --all-targets`
- [x] `cargo test -- --test-threads=1`
- [x] `git diff --check`
- [ ] Manual testing: N/A; behavior-preserving internal extraction.

## Chain context

```text
main
└── PR #261 → PR #264 → PR #269
    └── 📍 refactor/rust-db-connection-coordination
        └── next: action repository extraction
```

- **Depends on:** PR #269.
- **Ends with:** one owner for SQLite connection/write coordination.
- **Out of scope:** feature repositories, cursors, retention, messages, and worker redesign.
- **Review budget:** 70 authored lines.
- **Rollback:** revert `351233d`.

Closes #270