### PR TITLE
refactor(whatsrust): extract query ABI types

### DIFF
--- a/whatsrust/src/abi.rs
+++ b/whatsrust/src/abi.rs
@@ -1,0 +1,82 @@
+use std::ffi::c_char;
+
+pub(crate) type CJID = *const c_char;
+
+#[repr(C)]
+pub(crate) struct CContact {
+    pub(crate) found: bool,
+    pub(crate) first_name: *const c_char,
+    pub(crate) full_name: *const c_char,
+    pub(crate) push_name: *const c_char,
+    pub(crate) business_name: *const c_char,
+}
+
+#[repr(C)]
+pub(crate) struct CContactEntry {
+    pub(crate) jid: CJID,
+    pub(crate) name: *const c_char,
+}
+
+#[repr(C)]
+pub(crate) struct CCommunityEntry {
+    pub(crate) jid: CJID,
+    pub(crate) name: *const c_char,
+    pub(crate) parent_jid: CJID,
+    pub(crate) is_parent: bool,
+    pub(crate) is_joined: bool,
+    pub(crate) is_default_subgroup: bool,
+    // Stable C encoding: 0 unknown, 1 no, 2 yes.
+    pub(crate) announcement: u8,
+    // Stable C encoding: -1 unknown, otherwise a known signed count.
+    pub(crate) participant_count: i64,
+}
+
+#[repr(C)]
+pub(crate) struct CGetContactsResult {
+    pub(crate) entries: *const CContactEntry,
+    pub(crate) size: u32,
+}
+
+#[repr(C)]
+pub(crate) struct CGetCommunitiesResult {
+    pub(crate) entries: *const CCommunityEntry,
+    pub(crate) size: u32,
+    pub(crate) status: u8,
+}
+
+#[repr(C)]
+pub(crate) struct CProfilePictureResult {
+    pub(crate) status: u8,
+    pub(crate) picture_id: *mut c_char,
+    pub(crate) picture_type: *mut c_char,
+    pub(crate) data: *mut u8,
+    pub(crate) size: u32,
+}
+
+#[repr(C)]
+pub(crate) struct CChatSettings {
+    pub(crate) found: bool,
+    pub(crate) muted_until: i64,
+    pub(crate) pinned: bool,
+    pub(crate) archived: bool,
+}
+
+#[repr(C)]
+pub(crate) struct CGroupInfoResult {
+    pub(crate) status: u8,
+    pub(crate) is_announce: bool,
+    pub(crate) is_admin: bool,
+}
+
+#[repr(C)]
+pub(crate) struct CGroupParticipantEntry {
+    pub(crate) jid: CJID,
+    pub(crate) phone_number: CJID,
+    pub(crate) name: *const c_char,
+}
+
+#[repr(C)]
+pub(crate) struct CGroupParticipantsResult {
+    pub(crate) entries: *const CGroupParticipantEntry,
+    pub(crate) size: u32,
+}

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -11,10 +11,13 @@ use std::{
 
 #[macro_use]
 mod callbacks;
+mod abi;
+use abi::{
+    CChatSettings, CContact, CGetCommunitiesResult, CGetContactsResult, CGroupInfoResult,
+    CGroupParticipantsResult, CJID, CProfilePictureResult,
+};
 use callbacks::CallbackTranslator;
 use strum::{EnumIter, FromRepr};
-
-type CJID = *const c_char;
 
 static PRESENCE_CALLBACK_INGRESS: AtomicUsize = AtomicUsize::new(0);
 static FORWARD_SOURCES: LazyLock<Mutex<HashMap<(Arc<str>, Arc<str>, Arc<str>), Vec<u8>>>> =
@@ -47,85 +50,6 @@ impl From<&JID> for CJID {
     fn from(jid: &JID) -> Self {
         CString::new(jid.0.as_ref()).unwrap().into_raw()
     }
-}
-
-#[repr(C)]
-struct CContact {
-    found: bool,
-    first_name: *const c_char,
-    full_name: *const c_char,
-    push_name: *const c_char,
-    business_name: *const c_char,
-}
-
-#[repr(C)]
-struct CContactEntry {
-    jid: CJID,
-    name: *const c_char,
-}
-
-#[repr(C)]
-struct CCommunityEntry {
-    jid: CJID,
-    name: *const c_char,
-    parent_jid: CJID,
-    is_parent: bool,
-    is_joined: bool,
-    is_default_subgroup: bool,
-    // Stable C encoding: 0 unknown, 1 no, 2 yes.
-    announcement: u8,
-    // Stable C encoding: -1 unknown, otherwise a known signed count.
-    participant_count: i64,
-}
-
-#[repr(C)]
-struct CGetContactsResult {
-    entries: *const CContactEntry,
-    size: u32,
-}
-
-#[repr(C)]
-struct CGetCommunitiesResult {
-    entries: *const CCommunityEntry,
-    size: u32,
-    status: u8,
-}
-
-#[repr(C)]
-struct CProfilePictureResult {
-    status: u8,
-    picture_id: *mut c_char,
-    picture_type: *mut c_char,
-    data: *mut u8,
-    size: u32,
-}
-
-#[repr(C)]
-struct CChatSettings {
-    found: bool,
-    muted_until: i64,
-    pinned: bool,
-    archived: bool,
-}
-
-#[repr(C)]
-struct CGroupInfoResult {
-    status: u8,
-    is_announce: bool,
-    is_admin: bool,
-}
-
-#[repr(C)]
-struct CGroupParticipantEntry {
-    jid: CJID,
-    phone_number: CJID,
-    name: *const c_char,
-}
-
-#[repr(C)]
-struct CGroupParticipantsResult {
-    entries: *const CGroupParticipantEntry,
-    size: u32,
 }
 
 #[repr(C)]


### PR DESCRIPTION
## Summary

- Move query/result C ABI layouts out of the Rust crate facade.
- Begin reducing `whatsrust/src/lib.rs` to module declarations and public reexports.

## Changes

- Add internal `whatsrust/src/abi.rs`.
- Move JID, contact, community, profile-picture, group, participant, and chat-settings ABI layouts without changing field order or types.
- Keep message/event/receipt ABI in the facade for later children.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo check --all-targets`
- [x] Focused whatsrust tests (25 passed)
- [x] `cargo test -- --test-threads=1` (604 passed)
- [x] `git diff --check`
- [ ] Manual testing: N/A; mechanical ABI extraction.

## Chain context

```text
main
└── PR #260 → PR #265 → PR #268
    └── 📍 refactor/whatsrust-abi-query-types
        └── next: message/event ABI extraction
```

- **Depends on:** PR #268.
- **Ends with:** one crate-private owner for query ABI layouts.
- **Out of scope:** public models, callbacks, endpoint logic, queries, and ABI behavior fixes.
- **Review budget:** 168 authored lines.
- **Rollback:** revert `b6f69d7`.

Closes #271