### PR TITLE
refactor(whatsrust): extract message event ABI

### DIFF
--- a/whatsrust/src/abi.rs
+++ b/whatsrust/src/abi.rs
@@ -1,6 +1,178 @@
 use std::ffi::c_char;
+use std::ffi::c_void;
+
+use strum::FromRepr;
 
 pub(crate) type CJID = *const c_char;
+
+#[repr(C)]
+pub(super) struct CMessageInfo {
+    pub(super) id: *const c_char,
+    pub(super) chat: CJID,
+    pub(super) sender: CJID,
+    pub(super) push_name: *const c_char,
+    pub(super) mentions_self: bool,
+    pub(super) timestamp: i64,
+    pub(super) is_from_me: bool,
+    pub(super) quote_id: *const c_char,
+    pub(super) read_by: u16,
+    pub(super) is_forwarded: bool,
+    pub(super) forwarding_score: u32,
+}
+
+#[repr(C)]
+pub(super) struct CMentionRange {
+    pub(super) start: usize,
+    pub(super) end: usize,
+}
+
+#[repr(C)]
+pub(super) struct CIncomingTextMessage {
+    pub(super) text: *const c_char,
+    pub(super) mention_ranges: *const CMentionRange,
+    pub(super) mention_range_count: usize,
+}
+
+#[repr(C)]
+pub(super) struct CTextMessage {
+    pub(super) text: *const c_char,
+    pub(super) mentioned_jids: *const CJID,
+    pub(super) mentioned_count: usize,
+}
+
+#[repr(C)]
+pub(super) struct CFileMessage {
+    pub(super) kind: u8,
+    pub(super) path: *const c_char,
+    pub(super) file_id: *const c_char,
+    pub(super) caption: *const c_char,
+    pub(super) mentioned_jids: *const CJID,
+    pub(super) mentioned_count: usize,
+    pub(super) mention_ranges: *const CMentionRange,
+    pub(super) mention_range_count: usize,
+}
+
+#[repr(C)]
+pub(super) struct CMessage {
+    pub(super) info: CMessageInfo,
+    pub(super) message_type: u8,
+    pub(super) message: *const c_void,
+    pub(super) forward_source: *const u8,
+    pub(super) forward_source_len: usize,
+}
+
+#[repr(C)]
+pub(super) struct CReceipt {
+    pub(super) kind: u8,
+    pub(super) chat: CJID,
+    pub(super) message_ids: *const *const c_char,
+    pub(super) count: u32,
+}
+
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub(super) struct CEvent {
+    pub(super) event_type: u8,
+    pub(super) data: *const c_void,
+}
+
+#[repr(C)]
+pub(super) struct CReactionEvent {
+    pub(super) chat: CJID,
+    pub(super) target_message_id: *const c_char,
+    pub(super) participant: CJID,
+    pub(super) text: *const c_char,
+    pub(super) is_from_me: bool,
+}
+
+#[repr(C)]
+pub(super) struct CMessageActionEvent {
+    pub(super) action_id: *const c_char,
+    pub(super) chat: CJID,
+    pub(super) sender: CJID,
+    pub(super) target_message_id: *const c_char,
+    pub(super) replacement: *const c_char,
+    pub(super) occurred_at: i64,
+    pub(super) arrival_order: u64,
+    pub(super) kind: u8,
+}
+
+#[repr(C)]
+pub(super) struct CChatEvent {
+    pub(super) chat: CJID,
+    pub(super) last_message_time: i64,
+}
+
+#[repr(C)]
+pub(super) struct CMarkChatAsReadEvent {
+    pub(super) chat: CJID,
+    pub(super) message_id: *const c_char,
+    pub(super) read: bool,
+    pub(super) timestamp: i64,
+    pub(super) from_me: bool,
+    pub(super) participant: CJID,
+}
+
+#[repr(C)]
+pub(super) struct CLogoutResultEvent {
+    pub(super) status: u8,
+}
+
+#[derive(FromRepr)]
+#[repr(u8)]
+pub(super) enum MessageType {
+    Text = 0,
+    File = 1,
+    ViewOnceUnavailable = 2,
+}
+
+#[derive(Clone, Debug, Default, FromRepr)]
+#[repr(u8)]
+pub enum FileKind {
+    #[default]
+    Image = 0,
+    Video = 1,
+    Audio = 2,
+    Document = 3,
+    Sticker = 4,
+}
+
+pub(super) fn file_kind_discriminant(kind: &FileKind) -> u8 {
+    kind.clone() as u8
+}
+
+#[derive(Clone, Debug, FromRepr)]
+#[repr(u8)]
+pub(super) enum EventType {
+    SyncProgress = 0,
+    AppStateSyncComplete = 1,
+    Receipt = 2,
+    Reaction = 3,
+    // Event type 4 is reserved (removed multiplexed Presence event on Go side)
+    Connected = 5,
+    MessageAction = 6,
+    Chat = 7,
+    LogoutResult = 8,
+    MarkChatAsRead = 9,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromRepr)]
+#[repr(u8)]
+pub enum ReceiptKind {
+    Read = 0,
+    ReadSelf = 1,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromRepr)]
+#[repr(u8)]
+pub enum LogoutStatus {
+    LoggedOut = 0,
+    NotLoggedIn = 1,
+    Failed = 2,
+    /// Remote revocation failed, but the local sign-out succeeded. The device
+    /// remains linked on the phone until removed manually.
+    LocalOnly = 3,
+}
 
 #[repr(C)]
 pub(crate) struct CContact {

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -13,9 +13,13 @@ use std::{
 mod callbacks;
 mod abi;
 use abi::{
-    CChatSettings, CContact, CGetCommunitiesResult, CGetContactsResult, CGroupInfoResult,
-    CGroupParticipantsResult, CJID, CProfilePictureResult,
+    CChatEvent, CChatSettings, CContact, CEvent, CFileMessage, CGetCommunitiesResult,
+    CGetContactsResult, CGroupInfoResult, CGroupParticipantsResult, CIncomingTextMessage, CJID,
+    CLogoutResultEvent, CMarkChatAsReadEvent, CMentionRange, CMessage, CMessageActionEvent,
+    CProfilePictureResult, CReactionEvent, CReceipt, CTextMessage, EventType, MessageType,
+    file_kind_discriminant,
 };
+pub use abi::{FileKind, LogoutStatus, ReceiptKind};
 use callbacks::CallbackTranslator;
 use strum::{EnumIter, FromRepr};
 
@@ -50,119 +54,6 @@ impl From<&JID> for CJID {
     fn from(jid: &JID) -> Self {
         CString::new(jid.0.as_ref()).unwrap().into_raw()
     }
-}
-
-#[repr(C)]
-struct CMessageInfo {
-    id: *const c_char,
-    chat: CJID,
-    sender: CJID,
-    push_name: *const c_char,
-    mentions_self: bool,
-    timestamp: i64,
-    is_from_me: bool,
-    quote_id: *const c_char,
-    read_by: u16,
-    is_forwarded: bool,
-    forwarding_score: u32,
-}
-
-#[repr(C)]
-struct CMentionRange {
-    start: usize,
-    end: usize,
-}
-
-#[repr(C)]
-struct CIncomingTextMessage {
-    text: *const c_char,
-    mention_ranges: *const CMentionRange,
-    mention_range_count: usize,
-}
-
-#[repr(C)]
-struct CTextMessage {
-    text: *const c_char,
-    mentioned_jids: *const CJID,
-    mentioned_count: usize,
-}
-
-#[repr(C)]
-struct CFileMessage {
-    kind: u8,
-    path: *const c_char,
-    file_id: *const c_char,
-    caption: *const c_char,
-    mentioned_jids: *const CJID,
-    mentioned_count: usize,
-    mention_ranges: *const CMentionRange,
-    mention_range_count: usize,
-}
-
-#[repr(C)]
-struct CMessage {
-    info: CMessageInfo,
-    message_type: u8,
-    message: *const c_void,
-    forward_source: *const u8,
-    forward_source_len: usize,
-}
-
-#[repr(C)]
-struct CReceipt {
-    kind: u8,
-    chat: CJID,
-    message_ids: *const *const c_char,
-    count: u32,
-}
-
-#[derive(Clone, Debug)]
-#[repr(C)]
-struct CEvent {
-    event_type: u8,
-    data: *const c_void,
-}
-
-#[repr(C)]
-struct CReactionEvent {
-    chat: CJID,
-    target_message_id: *const c_char,
-    participant: CJID,
-    text: *const c_char,
-    is_from_me: bool,
-}
-
-#[repr(C)]
-struct CMessageActionEvent {
-    action_id: *const c_char,
-    chat: CJID,
-    sender: CJID,
-    target_message_id: *const c_char,
-    replacement: *const c_char,
-    occurred_at: i64,
-    arrival_order: u64,
-    kind: u8,
-}
-
-#[repr(C)]
-struct CChatEvent {
-    chat: CJID,
-    last_message_time: i64,
-}
-
-#[repr(C)]
-struct CMarkChatAsReadEvent {
-    chat: CJID,
-    message_id: *const c_char,
-    read: bool,
-    timestamp: i64,
-    from_me: bool,
-    participant: CJID,
-}
-
-#[repr(C)]
-struct CLogoutResultEvent {
-    status: u8,
 }
 
 pub type MessageId = Arc<str>;
@@ -209,29 +100,6 @@ mod message_push_name_tests {
 pub struct ForwardingInfo {
     pub is_forwarded: bool,
     pub score: u32,
-}
-
-#[derive(FromRepr)]
-#[repr(u8)]
-enum MessageType {
-    Text = 0,
-    File = 1,
-    ViewOnceUnavailable = 2,
-}
-
-#[derive(Clone, Debug, Default, FromRepr)]
-#[repr(u8)]
-pub enum FileKind {
-    #[default]
-    Image = 0,
-    Video = 1,
-    Audio = 2,
-    Document = 3,
-    Sticker = 4,
-}
-
-fn file_kind_discriminant(kind: &FileKind) -> u8 {
-    kind.clone() as u8
 }
 
 #[cfg(test)]
@@ -455,39 +323,6 @@ mod presence_event_tests {
             assert_eq!(update.last_seen, expected);
         }
     }
-}
-
-#[derive(Clone, Debug, FromRepr)]
-#[repr(u8)]
-enum EventType {
-    SyncProgress = 0,
-    AppStateSyncComplete = 1,
-    Receipt = 2,
-    Reaction = 3,
-    // Event type 4 is reserved (removed multiplexed Presence event on Go side)
-    Connected = 5,
-    MessageAction = 6,
-    Chat = 7,
-    LogoutResult = 8,
-    MarkChatAsRead = 9,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, FromRepr)]
-#[repr(u8)]
-pub enum ReceiptKind {
-    Read = 0,
-    ReadSelf = 1,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, FromRepr)]
-#[repr(u8)]
-pub enum LogoutStatus {
-    LoggedOut = 0,
-    NotLoggedIn = 1,
-    Failed = 2,
-    /// Remote revocation failed, but the local sign-out succeeded. The device
-    /// remains linked on the phone until removed manually.
-    LocalOnly = 3,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
- Move message, event, receipt, and related C ABI layouts out of `whatsrust/src/lib.rs`.
- Continue reducing the crate root to a public facade.

## Changes
- Extend internal `abi.rs` with message/event structs and discriminants.
- Preserve exact repr, field order, types, conversion behavior, and public API.
- Leave callback typedefs and extern declarations for the next child.

## Testing
- [x] `cargo fmt --check`
- [x] `cargo check --workspace --all-targets`
- [x] Focused whatsrust tests (25 passed)
- [x] Complete single-threaded Cargo suite, including API contract
- [x] `git diff --check`
- [ ] Manual testing: N/A; mechanical ABI extraction.

## Chain context
```text
PR #260 → #265 → #268 → #273
    └── 📍 refactor/whatsrust-abi-message-events
        └── next: callback typedefs and extern declarations
```
- **Depends on:** PR #273.
- **Review budget:** 349 authored lines.
- **Out of scope:** models, callbacks, endpoints, and ABI behavior fixes.
- **Rollback:** revert `142eee9`.

Closes #275