### PR TITLE
refactor(whatsrust): extract callback ABI declarations

### DIFF
--- a/whatsrust/src/abi.rs
+++ b/whatsrust/src/abi.rs
@@ -5,6 +5,113 @@ use strum::FromRepr;
 
 pub(crate) type CJID = *const c_char;
 
+pub(super) type CLogCallback = extern "C" fn(*const c_char, u8, *mut c_void);
+pub(super) type CQrCallback = extern "C" fn(*const c_char, *mut c_void);
+pub(super) type CMessageCallback = extern "C" fn(*const CMessage, bool, *mut c_void);
+pub(super) type COptimisticTextSentCallback = extern "C" fn(u64, *const CMessage, *mut c_void);
+pub(super) type CEventCallback = extern "C" fn(*const CEvent, *mut c_void);
+pub(super) type CPresenceCallback = extern "C" fn(CJID, bool, i64, *mut c_void);
+
+#[repr(C)]
+pub(super) struct CForwardResult {
+    pub(super) succeeded: u32,
+    pub(super) failed: u32,
+    pub(super) failure: u8,
+}
+
+unsafe extern "C" {
+    #[cfg(test)]
+    pub(super) fn C_TestEmitPresenceEvent(from: *const c_char, unavailable: bool, last_seen: i64);
+    #[cfg(test)]
+    pub(super) fn C_TestEmitPresenceEventsConcurrently(from: *const c_char, count: u32);
+    pub(super) fn C_NewClient(db_path: *const c_char);
+    pub(super) fn C_Connect(qr_cb: CQrCallback, data: *mut c_void);
+    pub(super) fn C_SendMessage(
+        jid: CJID,
+        message_type: u8,
+        message_content: *const c_void,
+        quote_id: *const c_char,
+        quote_sender: CJID,
+        quote_chat: CJID,
+        quote_message_type: u8,
+        quote_message_content: *const c_void,
+    );
+    pub(super) fn C_SendTextMessage(
+        jid: CJID,
+        message_content: *const c_void,
+        quote_id: *const c_char,
+        quote_sender: CJID,
+        quote_chat: CJID,
+        quote_message_type: u8,
+        quote_message_content: *const c_void,
+        local_send_id: u64,
+    ) -> u8;
+    pub(super) fn C_ForwardMessage(
+        source_id: *const c_char,
+        source_chat: CJID,
+        source_sender: CJID,
+        source_is_from_me: bool,
+        destinations: *const *const c_char,
+        destination_count: usize,
+        forward_source: *const u8,
+        forward_source_len: usize,
+    ) -> CForwardResult;
+    pub(super) fn C_GetContacts() -> CGetContactsResult;
+    pub(super) fn C_FreeContacts(result: CGetContactsResult);
+    pub(super) fn C_GetCommunities() -> CGetCommunitiesResult;
+    pub(super) fn C_FreeCommunities(result: CGetCommunitiesResult);
+    pub(super) fn C_GetProfilePicture(jid: CJID) -> CProfilePictureResult;
+    pub(super) fn C_GetCommunityProfilePicture(jid: CJID) -> CProfilePictureResult;
+    pub(super) fn C_FreeProfilePicture(result: CProfilePictureResult);
+    pub(super) fn C_GetChatSettings(jid: CJID) -> CChatSettings;
+    pub(super) fn C_GetGroupInfo(jid: CJID) -> CGroupInfoResult;
+    pub(super) fn C_GetGroupParticipants(jid: CJID) -> CGroupParticipantsResult;
+    pub(super) fn C_FreeGroupParticipants(result: CGroupParticipantsResult);
+    pub(super) fn C_ResolveDmChatId(jid: CJID) -> *mut c_char;
+    pub(super) fn C_FreeResolveDmChatId(value: *mut c_char);
+    pub(super) fn C_Disconnect();
+    pub(super) fn C_Logout() -> u8;
+    pub(super) fn C_DrainRawPresenceDiagnostics() -> *mut c_char;
+    pub(super) fn C_FreeRawPresenceDiagnostics(report: *mut c_char);
+    pub(super) fn C_SubscribePresence(jid: CJID) -> u8;
+    pub(super) fn C_PairPhone(phone: *const c_char) -> *const c_char;
+    pub(super) fn C_FreePairPhoneResult(result: *const c_char);
+    pub(super) fn C_DownloadFile(file_id: *const c_char, base_path: *const c_char) -> u8;
+    pub(super) fn C_ReactToMessage(
+        target_jid: CJID,
+        destination_jid: CJID,
+        sender_jid: CJID,
+        message_id: *const c_char,
+        reaction: *const c_char,
+    ) -> u8;
+    pub(super) fn C_EditMessage(
+        chat_jid: CJID,
+        message_id: *const c_char,
+        replacement: *const c_char,
+    ) -> u8;
+    pub(super) fn C_RevokeMessage(
+        chat_jid: CJID,
+        sender_jid: CJID,
+        message_id: *const c_char,
+    ) -> u8;
+    pub(super) fn C_MarkAsRead(msg_id: *const c_char, chat_jid: CJID, sender_jid: CJID) -> i32;
+    pub(super) fn C_MarkChatReadSync(
+        chat_jid: CJID,
+        msg_id: *const c_char,
+        timestamp: i64,
+        from_me: bool,
+        participant_jid: CJID,
+    ) -> i32;
+    pub(super) fn C_SetMessageHandler(message_cb: CMessageCallback, data: *mut c_void);
+    pub(super) fn C_SetOptimisticTextSentHandler(
+        callback: COptimisticTextSentCallback,
+        data: *mut c_void,
+    );
+    pub(super) fn C_SetEventHandler(event_cb: CEventCallback, data: *mut c_void);
+    pub(super) fn C_SetPresenceHandler(presence_cb: CPresenceCallback, data: *mut c_void);
+    pub(super) fn C_SetLogHandler(log_fn: CLogCallback, data: *mut c_void);
+}
+
 #[repr(C)]
 pub(super) struct CMessageInfo {
     pub(super) id: *const c_char,

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -12,13 +12,7 @@ use std::{
 #[macro_use]
 mod callbacks;
 mod abi;
-use abi::{
-    CChatEvent, CChatSettings, CContact, CEvent, CFileMessage, CGetCommunitiesResult,
-    CGetContactsResult, CGroupInfoResult, CGroupParticipantsResult, CIncomingTextMessage, CJID,
-    CLogoutResultEvent, CMarkChatAsReadEvent, CMentionRange, CMessage, CMessageActionEvent,
-    CProfilePictureResult, CReactionEvent, CReceipt, CTextMessage, EventType, MessageType,
-    file_kind_discriminant,
-};
+use abi::*;
 pub use abi::{FileKind, LogoutStatus, ReceiptKind};
 use callbacks::CallbackTranslator;
 use strum::{EnumIter, FromRepr};
@@ -625,104 +619,6 @@ impl From<&CContact> for Contact {
             business_name,
         }
     }
-}
-
-type CLogCallback = extern "C" fn(*const c_char, u8, *mut c_void);
-type CQrCallback = extern "C" fn(*const c_char, *mut c_void);
-type CMessageCallback = extern "C" fn(*const CMessage, bool, *mut c_void);
-type COptimisticTextSentCallback = extern "C" fn(u64, *const CMessage, *mut c_void);
-type CEventCallback = extern "C" fn(*const CEvent, *mut c_void);
-type CPresenceCallback = extern "C" fn(CJID, bool, i64, *mut c_void);
-
-#[repr(C)]
-struct CForwardResult {
-    succeeded: u32,
-    failed: u32,
-    failure: u8,
-}
-
-unsafe extern "C" {
-    #[cfg(test)]
-    fn C_TestEmitPresenceEvent(from: *const c_char, unavailable: bool, last_seen: i64);
-    #[cfg(test)]
-    fn C_TestEmitPresenceEventsConcurrently(from: *const c_char, count: u32);
-    fn C_NewClient(db_path: *const c_char);
-    fn C_Connect(qr_cb: CQrCallback, data: *mut c_void);
-    fn C_SendMessage(
-        jid: CJID,
-        message_type: u8,
-        message_content: *const c_void,
-        quote_id: *const c_char,
-        quote_sender: CJID,
-        quote_chat: CJID,
-        quote_message_type: u8,
-        quote_message_content: *const c_void,
-    );
-    fn C_SendTextMessage(
-        jid: CJID,
-        message_content: *const c_void,
-        quote_id: *const c_char,
-        quote_sender: CJID,
-        quote_chat: CJID,
-        quote_message_type: u8,
-        quote_message_content: *const c_void,
-        local_send_id: u64,
-    ) -> u8;
-    fn C_ForwardMessage(
-        source_id: *const c_char,
-        source_chat: CJID,
-        source_sender: CJID,
-        source_is_from_me: bool,
-        destinations: *const *const c_char,
-        destination_count: usize,
-        forward_source: *const u8,
-        forward_source_len: usize,
-    ) -> CForwardResult;
-    fn C_GetContacts() -> CGetContactsResult;
-    fn C_FreeContacts(result: CGetContactsResult);
-    fn C_GetCommunities() -> CGetCommunitiesResult;
-    fn C_FreeCommunities(result: CGetCommunitiesResult);
-    fn C_GetProfilePicture(jid: CJID) -> CProfilePictureResult;
-    fn C_GetCommunityProfilePicture(jid: CJID) -> CProfilePictureResult;
-    fn C_FreeProfilePicture(result: CProfilePictureResult);
-    fn C_GetChatSettings(jid: CJID) -> CChatSettings;
-    fn C_GetGroupInfo(jid: CJID) -> CGroupInfoResult;
-    fn C_GetGroupParticipants(jid: CJID) -> CGroupParticipantsResult;
-    fn C_FreeGroupParticipants(result: CGroupParticipantsResult);
-    fn C_ResolveDmChatId(jid: CJID) -> *mut c_char;
-    fn C_FreeResolveDmChatId(value: *mut c_char);
-    fn C_Disconnect();
-    fn C_Logout() -> u8;
-    fn C_DrainRawPresenceDiagnostics() -> *mut c_char;
-    fn C_FreeRawPresenceDiagnostics(report: *mut c_char);
-    fn C_SubscribePresence(jid: CJID) -> u8;
-    fn C_PairPhone(phone: *const c_char) -> *const c_char;
-    fn C_FreePairPhoneResult(result: *const c_char);
-    fn C_DownloadFile(file_id: *const c_char, base_path: *const c_char) -> u8;
-    fn C_ReactToMessage(
-        target_jid: CJID,
-        destination_jid: CJID,
-        sender_jid: CJID,
-        message_id: *const c_char,
-        reaction: *const c_char,
-    ) -> u8;
-    fn C_EditMessage(chat_jid: CJID, message_id: *const c_char, replacement: *const c_char) -> u8;
-    fn C_RevokeMessage(chat_jid: CJID, sender_jid: CJID, message_id: *const c_char) -> u8;
-
-    fn C_MarkAsRead(msg_id: *const c_char, chat_jid: CJID, sender_jid: CJID) -> i32;
-    fn C_MarkChatReadSync(
-        chat_jid: CJID,
-        msg_id: *const c_char,
-        timestamp: i64,
-        from_me: bool,
-        participant_jid: CJID,
-    ) -> i32;
-
-    fn C_SetMessageHandler(message_cb: CMessageCallback, data: *mut c_void);
-    fn C_SetOptimisticTextSentHandler(callback: COptimisticTextSentCallback, data: *mut c_void);
-    fn C_SetEventHandler(event_cb: CEventCallback, data: *mut c_void);
-    fn C_SetPresenceHandler(presence_cb: CPresenceCallback, data: *mut c_void);
-    fn C_SetLogHandler(log_fn: CLogCallback, data: *mut c_void);
 }
 
 pub struct DownloadFailed;


### PR DESCRIPTION
## Summary
- Extract callback typedefs, the forward result, and all extern C declarations into the internal `abi` module.
- Preserve existing public API, reexports, ABI layout, and call-site behavior.

## Changes
- Moved callback function-pointer aliases and `CForwardResult` to `whatsrust/src/abi.rs`.
- Moved the Rust-to-Go extern declarations to the same internal ABI boundary.
- Kept `lib.rs` as the consuming facade via an internal ABI import.

## Chain Context
- Start: parent branch `refactor/whatsrust-abi-message-events` at `142eee9` / PR #277.
- End: callback ABI declarations are owned by the internal ABI module.
- Dependency: this PR targets the immediate parent branch and must be reviewed before the next child.
- Diagram: `PR #277 (parent) -> 📍 PR (callback ABI externs) -> message models -> query models`

## Review Budget
- Authored diff: 213 lines (108 additions, 105 deletions).
- Budget: <=400 touched lines.

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Source checks confirm declarations exist in `abi.rs` and call sites remain in `lib.rs`.
- [ ] Cargo compilation/tests: deferred explicitly to CI; no Cargo build/test was run locally because the shared target is owned by the DB agent.
- [ ] Manual runtime testing: not applicable to this mechanical extraction.

## Rollback and Out of Scope
- Rollback: revert commit `ff88e3c`; only the ABI declaration extraction is removed.
- Out of scope: behavior fixes, ABI redesign, public API changes, Cargo builds/tests, and unrelated cleanup.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label (`type:refactor`)
- [x] No modified shell scripts; shellcheck not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #279