### PR TITLE
refactor(whatsrust): extract message models

### DIFF
--- a/whatsrust/src/abi.rs
+++ b/whatsrust/src/abi.rs
@@ -233,21 +233,6 @@ pub(super) enum MessageType {
     ViewOnceUnavailable = 2,
 }
 
-#[derive(Clone, Debug, Default, FromRepr)]
-#[repr(u8)]
-pub enum FileKind {
-    #[default]
-    Image = 0,
-    Video = 1,
-    Audio = 2,
-    Document = 3,
-    Sticker = 4,
-}
-
-pub(super) fn file_kind_discriminant(kind: &FileKind) -> u8 {
-    kind.clone() as u8
-}
-
 #[derive(Clone, Debug, FromRepr)]
 #[repr(u8)]
 pub(super) enum EventType {

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -12,9 +12,15 @@ use std::{
 #[macro_use]
 mod callbacks;
 mod abi;
+mod models;
 use abi::*;
-pub use abi::{FileKind, LogoutStatus, ReceiptKind};
+pub use abi::{LogoutStatus, ReceiptKind};
 use callbacks::CallbackTranslator;
+pub(crate) use models::file_kind_discriminant;
+pub use models::{
+    FileContent, FileId, FileKind, ForwardingInfo, JID, Mention, Message, MessageContent,
+    MessageId, MessageInfo,
+};
 use strum::{EnumIter, FromRepr};
 
 static PRESENCE_CALLBACK_INGRESS: AtomicUsize = AtomicUsize::new(0);
@@ -24,46 +30,6 @@ static MESSAGE_PUSH_NAMES: LazyLock<Mutex<HashMap<Arc<str>, Arc<str>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static MESSAGE_MENTION_RANGES: LazyLock<Mutex<HashMap<MessageId, (Arc<str>, Vec<Range<usize>>)>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct JID(pub Arc<str>);
-
-impl From<JID> for Arc<str> {
-    fn from(jid: JID) -> Self {
-        jid.0
-    }
-}
-impl From<String> for JID {
-    fn from(jid: String) -> Self {
-        JID(jid.into())
-    }
-}
-
-impl From<&CJID> for JID {
-    fn from(cjid: &CJID) -> Self {
-        JID(unsafe { CStr::from_ptr(*cjid) }.to_string_lossy().into())
-    }
-}
-impl From<&JID> for CJID {
-    fn from(jid: &JID) -> Self {
-        CString::new(jid.0.as_ref()).unwrap().into_raw()
-    }
-}
-
-pub type MessageId = Arc<str>;
-
-#[derive(Clone, Debug)]
-pub struct MessageInfo {
-    pub id: MessageId,
-    pub chat: JID,
-    pub sender: JID,
-    pub mentions_self: bool,
-    pub timestamp: i64,
-    pub is_from_me: bool,
-    pub quote_id: Option<Arc<str>>,
-    pub read_by: u16,
-    pub forwarding: ForwardingInfo,
-}
 
 #[cfg(test)]
 mod message_push_name_tests {
@@ -88,12 +54,6 @@ mod message_push_name_tests {
             Some("WhatsApp Profile")
         );
     }
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct ForwardingInfo {
-    pub is_forwarded: bool,
-    pub score: u32,
 }
 
 #[cfg(test)]
@@ -382,29 +342,6 @@ pub struct PresenceUpdate {
 pub const VIEW_ONCE_UNAVAILABLE_DESCRIPTION: &str =
     "View-once media is unavailable here. View it on your phone.";
 
-pub type FileId = Arc<str>;
-
-#[derive(Clone, Debug, Default)]
-pub struct FileContent {
-    pub kind: FileKind,
-    pub path: Arc<str>,
-    pub file_id: FileId,
-    pub caption: Option<Arc<str>>,
-}
-
-#[derive(Clone, Debug, EnumIter)]
-pub enum MessageContent {
-    Text(Arc<str>),
-    File(FileContent),
-    ViewOnceUnavailable,
-}
-
-#[derive(Clone, Debug)]
-pub struct Message {
-    pub info: MessageInfo,
-    pub message: MessageContent,
-}
-
 fn validated_mention_ranges(text: &str, ranges: &[CMentionRange]) -> Vec<Range<usize>> {
     let mut result = ranges
         .iter()
@@ -557,12 +494,6 @@ pub struct GroupParticipant {
     pub jid: JID,
     pub phone_number: JID,
     pub name: Arc<str>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Mention {
-    pub jid: JID,
-    pub numeric_user: Arc<str>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/whatsrust/src/models.rs
+++ b/whatsrust/src/models.rs
@@ -1,0 +1,101 @@
+use std::{
+    ffi::{CStr, CString},
+    ops::Range,
+    sync::Arc,
+};
+
+use strum::{EnumIter, FromRepr};
+
+use crate::abi::{CJID, CMentionRange};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct JID(pub Arc<str>);
+
+impl From<JID> for Arc<str> {
+    fn from(jid: JID) -> Self {
+        jid.0
+    }
+}
+
+impl From<String> for JID {
+    fn from(jid: String) -> Self {
+        JID(jid.into())
+    }
+}
+
+impl From<&CJID> for JID {
+    fn from(cjid: &CJID) -> Self {
+        JID(unsafe { CStr::from_ptr(*cjid) }.to_string_lossy().into())
+    }
+}
+
+impl From<&JID> for CJID {
+    fn from(jid: &JID) -> Self {
+        CString::new(jid.0.as_ref()).unwrap().into_raw()
+    }
+}
+
+pub type MessageId = Arc<str>;
+
+#[derive(Clone, Debug)]
+pub struct MessageInfo {
+    pub id: MessageId,
+    pub chat: JID,
+    pub sender: JID,
+    pub mentions_self: bool,
+    pub timestamp: i64,
+    pub is_from_me: bool,
+    pub quote_id: Option<Arc<str>>,
+    pub read_by: u16,
+    pub forwarding: ForwardingInfo,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ForwardingInfo {
+    pub is_forwarded: bool,
+    pub score: u32,
+}
+
+#[derive(Clone, Debug, Default, FromRepr)]
+#[repr(u8)]
+pub enum FileKind {
+    #[default]
+    Image = 0,
+    Video = 1,
+    Audio = 2,
+    Document = 3,
+    Sticker = 4,
+}
+
+pub(crate) fn file_kind_discriminant(kind: &FileKind) -> u8 {
+    kind.clone() as u8
+}
+
+pub type FileId = Arc<str>;
+
+#[derive(Clone, Debug, Default)]
+pub struct FileContent {
+    pub kind: FileKind,
+    pub path: Arc<str>,
+    pub file_id: FileId,
+    pub caption: Option<Arc<str>>,
+}
+
+#[derive(Clone, Debug, EnumIter)]
+pub enum MessageContent {
+    Text(Arc<str>),
+    File(FileContent),
+    ViewOnceUnavailable,
+}
+
+#[derive(Clone, Debug)]
+pub struct Message {
+    pub info: MessageInfo,
+    pub message: MessageContent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Mention {
+    pub jid: JID,
+    pub numeric_user: Arc<str>,
+}


### PR DESCRIPTION
## Summary
- Extract the public message-domain models into `whatsrust/src/models.rs`.
- Preserve exact root reexports, derives, fields, conversion behavior, and ABI-facing discriminants.

## Changes
- Moved JID, MessageId, MessageInfo, ForwardingInfo, FileKind, FileId, FileContent, MessageContent, Message, and Mention definitions and JID conversions to `models.rs`.
- Kept `lib.rs` as the public facade with exact model reexports.
- Kept message conversion and mention-range call sites behaviorally unchanged.

## Chain Context
- Start: immediate parent branch `refactor/whatsrust-abi-externs` at `ff88e3c` / PR #280.
- End: public message models are owned by `models.rs`.
- Dependency: this PR targets PR #280 and must be reviewed after it.
- Diagram: `PR #277 -> PR #280 -> 📍 PR (message models) -> query models`

## Review Budget
- Authored diff: 199 lines (108 additions, 91 deletions).
- Budget: <=400 touched lines.

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Source checks confirm the requested public models are defined in `models.rs` and reexported from `lib.rs`.
- [ ] Cargo compilation/tests: deferred explicitly to CI; no Cargo build/test was run locally because the shared target is owned by the DB agent.
- [ ] Manual runtime testing: not applicable to this mechanical extraction.

## Rollback and Out of Scope
- Rollback: revert commit `3dfaf85`; only the message-model extraction is removed.
- Out of scope: behavior fixes, API redesign, ABI changes, Cargo builds/tests, and unrelated cleanup.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label (`type:refactor`)
- [x] No modified shell scripts; shellcheck not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #281