### PR TITLE
refactor(db): extract reaction repository

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -15,6 +15,8 @@ use crate::app::{Chat, DELETED_MESSAGE_TEXT, MessageAction, STATUS_BROADCAST_CHA
 mod action_repository;
 #[path = "db/connection.rs"]
 mod connection;
+#[path = "db/reaction_repository.rs"]
+mod reaction_repository;
 #[path = "schema.rs"]
 mod schema;
 pub use action_repository::MessageActionPersistence;
@@ -263,40 +265,11 @@ impl DatabaseHandler {
         participant: wr::JID,
         emoji: Arc<str>,
     ) {
-        let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
-        if emoji.is_empty() {
-            self.db
-                .execute(
-                    "DELETE FROM message_reactions WHERE message_id = ?1 AND participant_jid = ?2",
-                    rusqlite::params![message_id, participant.0],
-                )
-                .unwrap();
-        } else {
-            self.db
-                .execute(
-                    "INSERT OR REPLACE INTO message_reactions (message_id, participant_jid, emoji) VALUES (?1, ?2, ?3)",
-                    rusqlite::params![message_id, participant.0, emoji],
-                )
-                .unwrap();
-        }
+        reaction_repository::record(&self.db, message_id, participant, emoji);
     }
 
     pub fn get_reactions(&self) -> Vec<(wr::MessageId, wr::JID, Arc<str>)> {
-        let mut query = self
-            .db
-            .prepare("SELECT message_id, participant_jid, emoji FROM message_reactions ORDER BY message_id, participant_jid")
-            .unwrap();
-        query
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?.into(),
-                    row.get::<_, String>(1)?.into(),
-                    Arc::from(row.get::<_, String>(2)?),
-                ))
-            })
-            .unwrap()
-            .map(Result::unwrap)
-            .collect()
+        reaction_repository::get(&self.db)
     }
 
     /// Inserts once by the protocol action ID. A duplicate arriving from

--- a/src/db/reaction_repository.rs
+++ b/src/db/reaction_repository.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use rusqlite::Connection;
+use whatsrust as wr;
+
+use super::DATABASE_WRITE_LOCK;
+
+pub(super) fn record(
+    db: &Connection,
+    message_id: &wr::MessageId,
+    participant: wr::JID,
+    emoji: Arc<str>,
+) {
+    let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
+    if emoji.is_empty() {
+        db.execute(
+            "DELETE FROM message_reactions WHERE message_id = ?1 AND participant_jid = ?2",
+            rusqlite::params![message_id, participant.0],
+        )
+        .unwrap();
+    } else {
+        db.execute(
+            "INSERT OR REPLACE INTO message_reactions (message_id, participant_jid, emoji) VALUES (?1, ?2, ?3)",
+            rusqlite::params![message_id, participant.0, emoji],
+        )
+        .unwrap();
+    }
+}
+
+pub(super) fn get(db: &Connection) -> Vec<(wr::MessageId, wr::JID, Arc<str>)> {
+    let mut query = db
+        .prepare("SELECT message_id, participant_jid, emoji FROM message_reactions ORDER BY message_id, participant_jid")
+        .unwrap();
+    query
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?.into(),
+                row.get::<_, String>(1)?.into(),
+                Arc::from(row.get::<_, String>(2)?),
+            ))
+        })
+        .unwrap()
+        .map(Result::unwrap)
+        .collect()
+}


### PR DESCRIPTION
## Summary
- Extract reaction persistence SQL into a dedicated internal repository.
- Preserve the public `DatabaseHandler` API and existing reaction semantics.

## Changes
- Added `src/db/reaction_repository.rs` for `record_reaction` and `get_reactions` operations.
- Kept `DatabaseHandler` methods as signature-preserving delegations.

## Chain Context
- Start: `refactor/rust-db-action-repository` / PR #276
- Current: `refactor/rust-db-reaction-repository` / this PR 📍
- End: reaction repository extraction; follow-up cursor and retention slices remain.
- Dependency diagram: `refactor/rust-db-action-repository` → 📍 `refactor/rust-db-reaction-repository` → `refactor/rust-db-cursor-repository` → `refactor/rust-db-retention-repository`

## Testing
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --test reaction_persistence -- --test-threads=1` — 5 passed
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -- --test-threads=1` — 360 library, 2 binary, and all integration/doc tests passed
- [x] `git diff --check`

## Budget
- 80 authored changed lines (49 additions / 31 deletions), well within the 400-line limit.

## Rollback
- Revert commit `374fa1b` to remove only this repository extraction.

## Out of scope
- No schema, API, SQL, locking, or behavior changes.

Closes #278