### PR TITLE
refactor(db): extract read cursor repository

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -15,6 +15,8 @@ use crate::app::{Chat, DELETED_MESSAGE_TEXT, MessageAction, STATUS_BROADCAST_CHA
 mod action_repository;
 #[path = "db/connection.rs"]
 mod connection;
+#[path = "db/cursor_repository.rs"]
+mod cursor_repository;
 #[path = "db/reaction_repository.rs"]
 mod reaction_repository;
 #[path = "schema.rs"]
@@ -492,31 +494,11 @@ impl DatabaseHandler {
         message_id: Option<wr::MessageId>,
         timestamp: i64,
     ) {
-        let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
-        self.db
-            .execute(
-                "INSERT INTO chat_read_cursors (chat_jid, message_id, timestamp)
-                 VALUES (?1, ?2, ?3)
-                 ON CONFLICT(chat_jid) DO UPDATE SET message_id = excluded.message_id, timestamp = excluded.timestamp",
-                rusqlite::params![chat.0, message_id, timestamp],
-            )
-            .unwrap();
+        cursor_repository::set_last_read(&self.db, chat, message_id, timestamp);
     }
 
     pub fn read_cursors(&self) -> Vec<(wr::JID, wr::MessageId, i64)> {
-        self.db
-            .prepare("SELECT chat_jid, message_id, timestamp FROM chat_read_cursors")
-            .unwrap()
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?.into(),
-                    row.get::<_, String>(1)?.into(),
-                    row.get(2)?,
-                ))
-            })
-            .unwrap()
-            .map(Result::unwrap)
-            .collect()
+        cursor_repository::read_cursors(&self.db)
     }
 
     pub fn set_status_last_seen(
@@ -524,22 +506,11 @@ impl DatabaseHandler {
         contact: &wr::JID,
         timestamp: i64,
     ) -> Result<usize, rusqlite::Error> {
-        let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
-        self.db
-            .execute(
-                "INSERT INTO status_read_cursors (contact_jid, timestamp) VALUES (?1, ?2)
-                 ON CONFLICT(contact_jid) DO UPDATE SET timestamp = MAX(timestamp, excluded.timestamp)",
-                rusqlite::params![contact.0, timestamp],
-            )
+        cursor_repository::set_status_last_seen(&self.db, contact, timestamp)
     }
 
     pub fn status_last_seen(&self) -> Result<Vec<(wr::JID, i64)>, rusqlite::Error> {
-        let mut query = self
-            .db
-            .prepare("SELECT contact_jid, timestamp FROM status_read_cursors")?;
-        query
-            .query_map([], |row| Ok((row.get::<_, String>(0)?.into(), row.get(1)?)))?
-            .collect()
+        cursor_repository::status_last_seen(&self.db)
     }
 }
 

--- a/src/db/cursor_repository.rs
+++ b/src/db/cursor_repository.rs
@@ -1,0 +1,55 @@
+use rusqlite::Connection;
+use whatsrust as wr;
+
+use super::DATABASE_WRITE_LOCK;
+
+pub(super) fn set_last_read(
+    db: &Connection,
+    chat: &wr::JID,
+    message_id: Option<wr::MessageId>,
+    timestamp: i64,
+) {
+    let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
+    db.execute(
+        "INSERT INTO chat_read_cursors (chat_jid, message_id, timestamp)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(chat_jid) DO UPDATE SET message_id = excluded.message_id, timestamp = excluded.timestamp",
+        rusqlite::params![chat.0, message_id, timestamp],
+    )
+    .unwrap();
+}
+
+pub(super) fn read_cursors(db: &Connection) -> Vec<(wr::JID, wr::MessageId, i64)> {
+    db.prepare("SELECT chat_jid, message_id, timestamp FROM chat_read_cursors")
+        .unwrap()
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?.into(),
+                row.get::<_, String>(1)?.into(),
+                row.get(2)?,
+            ))
+        })
+        .unwrap()
+        .map(Result::unwrap)
+        .collect()
+}
+
+pub(super) fn set_status_last_seen(
+    db: &Connection,
+    contact: &wr::JID,
+    timestamp: i64,
+) -> Result<usize, rusqlite::Error> {
+    let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
+    db.execute(
+        "INSERT INTO status_read_cursors (contact_jid, timestamp) VALUES (?1, ?2)
+         ON CONFLICT(contact_jid) DO UPDATE SET timestamp = MAX(timestamp, excluded.timestamp)",
+        rusqlite::params![contact.0, timestamp],
+    )
+}
+
+pub(super) fn status_last_seen(db: &Connection) -> Result<Vec<(wr::JID, i64)>, rusqlite::Error> {
+    let mut query = db.prepare("SELECT contact_jid, timestamp FROM status_read_cursors")?;
+    query
+        .query_map([], |row| Ok((row.get::<_, String>(0)?.into(), row.get(1)?)))?
+        .collect()
+}


### PR DESCRIPTION
## Summary
- Extract chat and status read-cursor persistence into a dedicated internal repository.
- Preserve `DatabaseHandler` APIs and exact existing cursor semantics.

## Changes
- Added `src/db/cursor_repository.rs` for chat/status cursor reads and writes.
- Kept `DatabaseHandler` methods as signature-preserving delegations, including the pre-existing `NULL` message-ID panic path in `read_cursors`.

## Chain Context
- Start: `refactor/rust-db-reaction-repository` / PR #285
- Current: `refactor/rust-db-cursor-repository` / this PR 📍
- End: cursor repository extraction; retention slice follows.
- Dependency diagram: `refactor/rust-db-action-repository` → `refactor/rust-db-reaction-repository` → 📍 `refactor/rust-db-cursor-repository` → `refactor/rust-db-retention-repository`

## Testing
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --test status_retention -- --test-threads=1` — passed
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -- --test-threads=1` — 360 library, 2 binary, and all integration/doc tests passed
- [x] `git diff --check`

## Budget
- 96 authored changed lines (61 additions / 35 deletions), within the 400-line limit.

## Rollback
- Revert commit `5ec9616` to remove only this cursor repository extraction.

## Out of scope
- No schema, API, SQL, locking, panic, or behavior changes.

Closes #286