### PR TITLE
refactor(db): extract status retention repository

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -9,7 +9,7 @@ use rusqlite::{Connection, OptionalExtension, TransactionBehavior};
 use strum::IntoEnumIterator;
 use whatsrust as wr;
 
-use crate::app::{Chat, DELETED_MESSAGE_TEXT, MessageAction, STATUS_BROADCAST_CHAT};
+use crate::app::{Chat, DELETED_MESSAGE_TEXT, MessageAction};
 
 #[path = "db/action_repository.rs"]
 mod action_repository;
@@ -19,16 +19,14 @@ mod connection;
 mod cursor_repository;
 #[path = "db/reaction_repository.rs"]
 mod reaction_repository;
+#[path = "db/retention.rs"]
+mod retention;
 #[path = "schema.rs"]
 mod schema;
 pub use action_repository::MessageActionPersistence;
 pub(crate) use connection::{
     DATABASE_WRITE_LOCK, open_database, try_open_database, with_database_write_lock,
 };
-
-/// WhatsApp statuses expire 24 hours after posting (server-side). The local
-/// purge uses the same window so status broadcasts do not accumulate forever.
-const STATUS_RETENTION_SECS: i64 = 24 * 60 * 60;
 
 fn encode_mention_ranges(ranges: &[Range<usize>]) -> Option<String> {
     (!ranges.is_empty()).then(|| {
@@ -519,38 +517,6 @@ impl DatabaseHandler {
     /// retention window. Returns the relative media paths of the purged
     /// file messages so the caller can remove them from disk.
     pub fn purge_expired_statuses(&mut self, now: i64) -> Vec<PathBuf> {
-        let cutoff = now - STATUS_RETENTION_SECS;
-        let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
-        let tx = self
-            .db
-            .transaction_with_behavior(TransactionBehavior::Immediate)
-            .unwrap();
-
-        let purged_paths = {
-            let mut query = tx
-                .prepare("SELECT path FROM file_messages WHERE chat_jid = ?1 AND timestamp < ?2")
-                .unwrap();
-            query
-                .query_map(rusqlite::params![STATUS_BROADCAST_CHAT, cutoff], |row| {
-                    row.get::<_, String>(0)
-                })
-                .unwrap()
-                .filter_map(Result::ok)
-                .map(PathBuf::from)
-                .collect::<Vec<_>>()
-        };
-
-        tx.execute(
-            "DELETE FROM file_messages WHERE chat_jid = ?1 AND timestamp < ?2",
-            rusqlite::params![STATUS_BROADCAST_CHAT, cutoff],
-        )
-        .unwrap();
-        tx.execute(
-            "DELETE FROM text_messages WHERE chat_jid = ?1 AND timestamp < ?2",
-            rusqlite::params![STATUS_BROADCAST_CHAT, cutoff],
-        )
-        .unwrap();
-        tx.commit().unwrap();
-        purged_paths
+        retention::purge(&mut self.db, now)
     }
 }

--- a/src/db/retention.rs
+++ b/src/db/retention.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+
+use rusqlite::{Connection, TransactionBehavior};
+
+use crate::app::STATUS_BROADCAST_CHAT;
+
+use super::DATABASE_WRITE_LOCK;
+
+/// WhatsApp statuses expire 24 hours after posting (server-side). The local
+/// purge uses the same window so status broadcasts do not accumulate forever.
+const STATUS_RETENTION_SECS: i64 = 24 * 60 * 60;
+
+pub(super) fn purge(db: &mut Connection, now: i64) -> Vec<PathBuf> {
+    let cutoff = now - STATUS_RETENTION_SECS;
+    let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
+    let tx = db
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .unwrap();
+
+    let purged_paths = {
+        let mut query = tx
+            .prepare("SELECT path FROM file_messages WHERE chat_jid = ?1 AND timestamp < ?2")
+            .unwrap();
+        query
+            .query_map(rusqlite::params![STATUS_BROADCAST_CHAT, cutoff], |row| {
+                row.get::<_, String>(0)
+            })
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(PathBuf::from)
+            .collect::<Vec<_>>()
+    };
+
+    tx.execute(
+        "DELETE FROM file_messages WHERE chat_jid = ?1 AND timestamp < ?2",
+        rusqlite::params![STATUS_BROADCAST_CHAT, cutoff],
+    )
+    .unwrap();
+    tx.execute(
+        "DELETE FROM text_messages WHERE chat_jid = ?1 AND timestamp < ?2",
+        rusqlite::params![STATUS_BROADCAST_CHAT, cutoff],
+    )
+    .unwrap();
+    tx.commit().unwrap();
+    purged_paths
+}


### PR DESCRIPTION
## Summary
- Extract status retention configuration and purge SQL into a dedicated internal repository.
- Preserve `DatabaseHandler` API, the 24-hour boundary, and current cleanup gaps.

## Changes
- Added `src/db/retention.rs` for the retention constant and transactional purge operation.
- Kept `DatabaseHandler::purge_expired_statuses` as a signature-preserving delegation returning relative media paths.

## Chain Context
- Start: `refactor/rust-db-cursor-repository` / PR #287
- Current: `refactor/rust-db-retention-repository` / this PR 📍
- End: retention repository extraction; this completes the requested three-slice chain.
- Dependency diagram: `refactor/rust-db-action-repository` → `refactor/rust-db-reaction-repository` → `refactor/rust-db-cursor-repository` → 📍 `refactor/rust-db-retention-repository`

## Testing
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --test status_retention -- --test-threads=1` — passed
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -- --test-threads=1` — 360 library, 2 binary, and all integration/doc tests passed
- [x] `git diff --check`

## Budget
- 88 authored changed lines (50 additions / 38 deletions), within the 400-line limit.

## Rollback
- Revert commit `2fd8ad0` to remove only this retention repository extraction.

## Out of scope
- No schema, API, SQL predicates, transaction mode, cleanup behavior, or media-path behavior changes.

Closes #288