### PR TITLE
refactor(whatsrust): extract event models

### DIFF
--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -18,12 +18,13 @@ pub use abi::{LogoutStatus, ReceiptKind};
 use callbacks::CallbackTranslator;
 pub(crate) use models::file_kind_discriminant;
 pub use models::{
-    ChatSettings, CommunitiesError, CommunityInfo, Contact, DownloadFailed, FileContent, FileId,
-    FileKind, ForwardingInfo, GroupInfo, GroupInfoError, GroupParticipant, JID, LogoutError,
-    Mention, Message, MessageActionFailed, MessageContent, MessageId, MessageInfo, ProfilePicture,
-    ProfilePictureAvailability, ProfilePictureError,
+    ChatSettings, CommunitiesError, CommunityInfo, Contact, DownloadFailed, Event, FileContent,
+    FileId, FileKind, ForwardingInfo, GroupInfo, GroupInfoError, GroupParticipant, JID,
+    LogoutError, Mention, Message, MessageActionFailed, MessageActionKind, MessageContent,
+    MessageId, MessageInfo, PresenceUpdate, ProfilePicture, ProfilePictureAvailability,
+    ProfilePictureError,
 };
-use strum::{EnumIter, FromRepr};
+use strum::FromRepr;
 
 static PRESENCE_CALLBACK_INGRESS: AtomicUsize = AtomicUsize::new(0);
 static FORWARD_SOURCES: LazyLock<Mutex<HashMap<(Arc<str>, Arc<str>, Arc<str>), Vec<u8>>>> =
@@ -279,66 +280,6 @@ mod presence_event_tests {
             assert_eq!(update.last_seen, expected);
         }
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum MessageActionKind {
-    Edit { replacement: Arc<str> },
-    Delete,
-}
-
-#[derive(Clone, Debug)]
-pub enum Event {
-    SyncProgress(u8),
-    AppStateSyncComplete,
-    Receipt {
-        kind: ReceiptKind,
-        chat: JID,
-        message_ids: Vec<MessageId>,
-    },
-    Reaction {
-        chat: JID,
-        target_message_id: MessageId,
-        participant: JID,
-        text: Arc<str>,
-        is_from_me: bool,
-    },
-    Connected,
-    MessageAction {
-        action_id: Arc<str>,
-        target_message_id: MessageId,
-        chat: JID,
-        sender: JID,
-        kind: MessageActionKind,
-        occurred_at: i64,
-        arrival_order: u64,
-    },
-    /// A chat that exists even though the history sync batch carried no
-    /// messages for it. Lets the app populate the full chat list instead of
-    /// only the subset that shipped messages.
-    Chat {
-        jid: JID,
-        last_message_time: i64,
-    },
-    /// Terminal outcome of an asynchronous logout. The Go bridge runs the
-    /// remove-companion-device IQ off the event loop so `logout()` no longer
-    /// blocks the UI; this event drives the local cleanup on completion.
-    LogoutResult(LogoutStatus),
-    MarkChatAsRead {
-        chat: JID,
-        message_id: MessageId,
-        read: bool,
-        timestamp: i64,
-        from_me: bool,
-        participant: Option<JID>,
-    },
-}
-
-#[derive(Clone, Debug)]
-pub struct PresenceUpdate {
-    pub from: JID,
-    pub unavailable: bool,
-    pub last_seen: i64,
 }
 
 pub const VIEW_ONCE_UNAVAILABLE_DESCRIPTION: &str =

--- a/whatsrust/src/models.rs
+++ b/whatsrust/src/models.rs
@@ -6,7 +6,7 @@ use std::{
 
 use strum::{EnumIter, FromRepr};
 
-use crate::abi::{CContact, CJID, CMentionRange};
+use crate::abi::{CContact, CJID, CMentionRange, LogoutStatus, ReceiptKind};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct JID(pub Arc<str>);
@@ -92,6 +92,66 @@ pub enum MessageContent {
 pub struct Message {
     pub info: MessageInfo,
     pub message: MessageContent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MessageActionKind {
+    Edit { replacement: Arc<str> },
+    Delete,
+}
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    SyncProgress(u8),
+    AppStateSyncComplete,
+    Receipt {
+        kind: ReceiptKind,
+        chat: JID,
+        message_ids: Vec<MessageId>,
+    },
+    Reaction {
+        chat: JID,
+        target_message_id: MessageId,
+        participant: JID,
+        text: Arc<str>,
+        is_from_me: bool,
+    },
+    Connected,
+    MessageAction {
+        action_id: Arc<str>,
+        target_message_id: MessageId,
+        chat: JID,
+        sender: JID,
+        kind: MessageActionKind,
+        occurred_at: i64,
+        arrival_order: u64,
+    },
+    /// A chat that exists even though the history sync batch carried no
+    /// messages for it. Lets the app populate the full chat list instead of
+    /// only the subset that shipped messages.
+    Chat {
+        jid: JID,
+        last_message_time: i64,
+    },
+    /// Terminal outcome of an asynchronous logout. The Go bridge runs the
+    /// remove-companion-device IQ off the event loop so `logout()` no longer
+    /// blocks the UI; this event drives the local cleanup on completion.
+    LogoutResult(LogoutStatus),
+    MarkChatAsRead {
+        chat: JID,
+        message_id: MessageId,
+        read: bool,
+        timestamp: i64,
+        from_me: bool,
+        participant: Option<JID>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct PresenceUpdate {
+    pub from: JID,
+    pub unavailable: bool,
+    pub last_seen: i64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
- Extract `Event`, `PresenceUpdate`, and message-action models into `models.rs`.
- Keep `lib.rs` as the public facade with exact reexports and unchanged behavior.

## Changes
- Moved the requested public model definitions without changing fields, variants, derives, documentation, ABI, or callback behavior.

## Chain Context
- Start: immediate parent `refactor/whatsrust-query-models` at `feafc7a` / PR #284.
- End: event and presence public models are owned by `models.rs`.
- Dependency: review after PR #284; later slices target this PR’s branch.
- Diagram: `PR #277 -> PR #280 -> PR #282 -> PR #284 -> 📍 PR (event models) -> caches -> incoming -> events`

## Review Budget
- Authored diff: 133 lines (67 additions, 66 deletions).
- Budget: <=400 touched lines.

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Source checks confirm exact public reexports and model definitions.
- [ ] Cargo compilation/tests: deferred explicitly to CI; not run locally.
- [ ] Manual runtime testing: N/A for this mechanical extraction.

## Rollback and Out of Scope
- Rollback: revert commit `0b4cb40`; only this model extraction is removed.
- Out of scope: behavior fixes, API redesign, ABI changes, Cargo builds/tests, and unrelated cleanup.

## Contributor Checklist
- [x] Linked issue: #294
- [x] Exactly one type label: `type:refactor`
- [x] No modified shell scripts; shellcheck not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #294