### PR TITLE
refactor(whatsrust): extract message caches

### DIFF
--- a/whatsrust/src/caches.rs
+++ b/whatsrust/src/caches.rs
@@ -1,0 +1,129 @@
+use std::{
+    collections::HashMap,
+    ops::Range,
+    sync::{Arc, LazyLock, Mutex},
+};
+
+use crate::abi::CMentionRange;
+use crate::{JID, MessageId, MessageInfo};
+
+static FORWARD_SOURCES: LazyLock<Mutex<HashMap<(Arc<str>, Arc<str>, Arc<str>), Vec<u8>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static MESSAGE_PUSH_NAMES: LazyLock<Mutex<HashMap<Arc<str>, Arc<str>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static MESSAGE_MENTION_RANGES: LazyLock<Mutex<HashMap<MessageId, (Arc<str>, Vec<Range<usize>>)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub(crate) fn validated_mention_ranges(text: &str, ranges: &[CMentionRange]) -> Vec<Range<usize>> {
+    let mut result = ranges
+        .iter()
+        .filter_map(|range| {
+            (range.start < range.end
+                && range.end <= text.len()
+                && text.is_char_boundary(range.start)
+                && text.is_char_boundary(range.end))
+            .then_some(range.start..range.end)
+        })
+        .collect::<Vec<_>>();
+    result.sort_by_key(|range| (range.start, range.end));
+    result.dedup();
+    result
+}
+
+pub fn store_message_mention_ranges(id: &MessageId, text: &str, ranges: Vec<Range<usize>>) {
+    let mut stored = MESSAGE_MENTION_RANGES.lock().unwrap();
+    if ranges.is_empty() {
+        stored.remove(id);
+    } else {
+        stored.insert(id.clone(), (text.into(), ranges));
+    }
+}
+
+pub fn message_mention_ranges(id: &MessageId, text: &str) -> Vec<Range<usize>> {
+    MESSAGE_MENTION_RANGES
+        .lock()
+        .unwrap()
+        .get(id)
+        .filter(|(stored_text, _)| stored_text.as_ref() == text)
+        .map(|(_, ranges)| ranges.clone())
+        .unwrap_or_default()
+}
+
+pub fn store_message_push_name(id: &MessageId, push_name: &str) {
+    if push_name.trim().is_empty() {
+        return;
+    }
+    MESSAGE_PUSH_NAMES
+        .lock()
+        .unwrap()
+        .insert(id.clone(), push_name.trim().into());
+}
+
+pub fn message_push_name(id: &MessageId) -> Option<Arc<str>> {
+    MESSAGE_PUSH_NAMES.lock().unwrap().get(id).cloned()
+}
+
+pub fn store_forward_source(info: &MessageInfo, source: Vec<u8>) {
+    if !source.is_empty() {
+        FORWARD_SOURCES.lock().unwrap().insert(
+            (info.chat.0.clone(), info.sender.0.clone(), info.id.clone()),
+            source,
+        );
+    }
+}
+
+pub fn forward_source(info: &MessageInfo) -> Option<Vec<u8>> {
+    FORWARD_SOURCES
+        .lock()
+        .unwrap()
+        .get(&(info.chat.0.clone(), info.sender.0.clone(), info.id.clone()))
+        .cloned()
+}
+
+pub fn remove_forward_source(chat: &JID, id: &MessageId) {
+    FORWARD_SOURCES
+        .lock()
+        .unwrap()
+        .retain(|(source_chat, _, source_id), _| {
+            source_chat.as_ref() != chat.0.as_ref() || source_id.as_ref() != id.as_ref()
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ffi_ranges_are_utf8_validated_and_invalid_ranges_are_dropped() {
+        let text = "café @阿丽";
+        let ranges = validated_mention_ranges(
+            text,
+            &[
+                CMentionRange { start: 6, end: 13 },
+                CMentionRange { start: 8, end: 13 },
+                CMentionRange { start: 0, end: 99 },
+            ],
+        );
+        assert_eq!(ranges, vec![6..13]);
+    }
+
+    #[test]
+    fn callback_message_push_name_is_available_to_sender_naming() {
+        let info = MessageInfo {
+            id: "push-name-message".into(),
+            chat: JID::from("chat@example.test".to_owned()),
+            sender: JID::from("sender@example.test".to_owned()),
+            mentions_self: false,
+            timestamp: 0,
+            is_from_me: false,
+            quote_id: None,
+            read_by: 0,
+            forwarding: Default::default(),
+        };
+        store_message_push_name(&info.id, "WhatsApp Profile");
+        assert_eq!(
+            message_push_name(&info.id).as_deref(),
+            Some("WhatsApp Profile")
+        );
+    }
+}

--- a/whatsrust/src/callbacks.rs
+++ b/whatsrust/src/callbacks.rs
@@ -28,18 +28,19 @@ macro_rules! setup_handler {
             // each call creates concurrent owners for the same allocation.
             type CallbackType = dyn FnMut($($rs_type),*);
             let callback: Box<CallbackType> = Box::new(callback);
-            let callback_state = Box::new(Arc::new(Mutex::new(callback)));
-            let user_data = Box::into_raw(callback_state) as *mut c_void;
+            let callback_state = Box::new(std::sync::Arc::new(std::sync::Mutex::new(callback)));
+            let user_data = Box::into_raw(callback_state) as *mut std::ffi::c_void;
 
             // Shim callback compatible with C
             extern "C" fn shim(
                 $( $param_name: $c_type, )*
-                user_data: *mut c_void
+                user_data: *mut std::ffi::c_void
             ) {
                 unsafe {
                     let callback_state =
-                        &*(user_data as *const Arc<Mutex<Box<CallbackType>>>);
-                    let closure = Arc::clone(callback_state);
+                        &*(user_data
+                            as *const std::sync::Arc<std::sync::Mutex<Box<CallbackType>>>);
+                    let closure = std::sync::Arc::clone(callback_state);
                     let mut guard = closure.lock().unwrap();
 
                     guard($(

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -1,10 +1,8 @@
 use std::{
-    collections::HashMap,
     ffi::{CStr, CString, c_char, c_void},
-    ops::Range,
     path::Path,
     sync::{
-        Arc, LazyLock, Mutex,
+        Arc,
         atomic::{AtomicUsize, Ordering},
     },
 };
@@ -12,6 +10,7 @@ use std::{
 #[macro_use]
 mod callbacks;
 mod abi;
+mod caches;
 mod models;
 use abi::*;
 pub use abi::{LogoutStatus, ReceiptKind};
@@ -27,38 +26,6 @@ pub use models::{
 use strum::FromRepr;
 
 static PRESENCE_CALLBACK_INGRESS: AtomicUsize = AtomicUsize::new(0);
-static FORWARD_SOURCES: LazyLock<Mutex<HashMap<(Arc<str>, Arc<str>, Arc<str>), Vec<u8>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-static MESSAGE_PUSH_NAMES: LazyLock<Mutex<HashMap<Arc<str>, Arc<str>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-static MESSAGE_MENTION_RANGES: LazyLock<Mutex<HashMap<MessageId, (Arc<str>, Vec<Range<usize>>)>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-#[cfg(test)]
-mod message_push_name_tests {
-    use super::{JID, MessageInfo, message_push_name, store_message_push_name};
-
-    #[test]
-    fn callback_message_push_name_is_available_to_sender_naming() {
-        let info = MessageInfo {
-            id: "push-name-message".into(),
-            chat: JID::from("chat@example.test".to_owned()),
-            sender: JID::from("sender@example.test".to_owned()),
-            mentions_self: false,
-            timestamp: 0,
-            is_from_me: false,
-            quote_id: None,
-            read_by: 0,
-            forwarding: Default::default(),
-        };
-        store_message_push_name(&info.id, "WhatsApp Profile");
-        assert_eq!(
-            message_push_name(&info.id).as_deref(),
-            Some("WhatsApp Profile")
-        );
-    }
-}
-
 #[cfg(test)]
 mod file_kind_tests {
     use super::{FileKind, file_kind_discriminant};
@@ -282,62 +249,14 @@ mod presence_event_tests {
     }
 }
 
+pub use caches::{forward_source, message_mention_ranges, message_push_name};
+pub use caches::{
+    remove_forward_source, store_forward_source, store_message_mention_ranges,
+    store_message_push_name,
+};
+
 pub const VIEW_ONCE_UNAVAILABLE_DESCRIPTION: &str =
     "View-once media is unavailable here. View it on your phone.";
-
-fn validated_mention_ranges(text: &str, ranges: &[CMentionRange]) -> Vec<Range<usize>> {
-    let mut result = ranges
-        .iter()
-        .filter_map(|range| {
-            (range.start < range.end
-                && range.end <= text.len()
-                && text.is_char_boundary(range.start)
-                && text.is_char_boundary(range.end))
-            .then_some(range.start..range.end)
-        })
-        .collect::<Vec<_>>();
-    result.sort_by_key(|range| (range.start, range.end));
-    result.dedup();
-    result
-}
-
-pub fn store_message_mention_ranges(id: &MessageId, text: &str, ranges: Vec<Range<usize>>) {
-    let mut stored = MESSAGE_MENTION_RANGES.lock().unwrap();
-    if ranges.is_empty() {
-        stored.remove(id);
-    } else {
-        stored.insert(id.clone(), (text.into(), ranges));
-    }
-}
-
-pub fn message_mention_ranges(id: &MessageId, text: &str) -> Vec<Range<usize>> {
-    MESSAGE_MENTION_RANGES
-        .lock()
-        .unwrap()
-        .get(id)
-        .filter(|(stored_text, _)| stored_text.as_ref() == text)
-        .map(|(_, ranges)| ranges.clone())
-        .unwrap_or_default()
-}
-
-#[cfg(test)]
-mod mention_range_tests {
-    use super::{CMentionRange, validated_mention_ranges};
-
-    #[test]
-    fn ffi_ranges_are_utf8_validated_and_invalid_ranges_are_dropped() {
-        let text = "café @阿丽";
-        let ranges = validated_mention_ranges(
-            text,
-            &[
-                CMentionRange { start: 6, end: 13 },
-                CMentionRange { start: 8, end: 13 },
-                CMentionRange { start: 0, end: 99 },
-            ],
-        );
-        assert_eq!(ranges, vec![6..13]);
-    }
-}
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ForwardReport {
@@ -365,46 +284,6 @@ impl ForwardReport {
             failure,
         }
     }
-}
-
-pub fn store_message_push_name(id: &MessageId, push_name: &str) {
-    if push_name.trim().is_empty() {
-        return;
-    }
-    MESSAGE_PUSH_NAMES
-        .lock()
-        .unwrap()
-        .insert(id.clone(), push_name.trim().into());
-}
-
-pub fn message_push_name(id: &MessageId) -> Option<Arc<str>> {
-    MESSAGE_PUSH_NAMES.lock().unwrap().get(id).cloned()
-}
-
-pub fn store_forward_source(info: &MessageInfo, source: Vec<u8>) {
-    if !source.is_empty() {
-        FORWARD_SOURCES.lock().unwrap().insert(
-            (info.chat.0.clone(), info.sender.0.clone(), info.id.clone()),
-            source,
-        );
-    }
-}
-
-pub fn forward_source(info: &MessageInfo) -> Option<Vec<u8>> {
-    FORWARD_SOURCES
-        .lock()
-        .unwrap()
-        .get(&(info.chat.0.clone(), info.sender.0.clone(), info.id.clone()))
-        .cloned()
-}
-
-pub fn remove_forward_source(chat: &JID, id: &MessageId) {
-    FORWARD_SOURCES
-        .lock()
-        .unwrap()
-        .retain(|(source_chat, _, source_id), _| {
-            source_chat.as_ref() != chat.0.as_ref() || source_id.as_ref() != id.as_ref()
-        });
 }
 
 fn profile_picture_from_parts(

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -839,7 +839,7 @@ impl CallbackTranslator<*const CMessage> for Message {
                 {
                     Vec::new()
                 } else {
-                    validated_mention_ranges(&message, unsafe {
+                    crate::caches::validated_mention_ranges(&message, unsafe {
                         std::slice::from_raw_parts(
                             text_message.mention_ranges,
                             text_message.mention_range_count,
@@ -865,7 +865,7 @@ impl CallbackTranslator<*const CMessage> for Message {
                 {
                     Vec::new()
                 } else {
-                    validated_mention_ranges(&caption_text, unsafe {
+                    crate::caches::validated_mention_ranges(&caption_text, unsafe {
                         std::slice::from_raw_parts(
                             image_message.mention_ranges,
                             image_message.mention_range_count,

--- a/whatsrust/src/models.rs
+++ b/whatsrust/src/models.rs
@@ -1,12 +1,11 @@
 use std::{
     ffi::{CStr, CString},
-    ops::Range,
     sync::Arc,
 };
 
 use strum::{EnumIter, FromRepr};
 
-use crate::abi::{CContact, CJID, CMentionRange, LogoutStatus, ReceiptKind};
+use crate::abi::{CContact, CJID, LogoutStatus, ReceiptKind};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct JID(pub Arc<str>);


### PR DESCRIPTION
## Summary
- Extract mention ranges, push names, and forwarding sources into `caches.rs`.
- Preserve the cache APIs, validation, keying, locking, and cleanup behavior.

## Changes
- Moved cache state, accessors, and focused tests out of `lib.rs`.
- Reexported the same public cache functions from the root facade.

## Chain Context
- Start: immediate parent `refactor/whatsrust-event-models` at `0b4cb40` / PR #298.
- End: message cache responsibilities are owned by `caches.rs`.
- Dependency: review after PR #298; later slices target this PR’s branch.
- Diagram: `PR #284 -> 📍 PR (event models) -> 📍 PR (caches) -> incoming -> events`

## Review Budget
- Authored diff: 266 lines (137 additions, 129 deletions).
- Budget: <=400 touched lines.

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Source checks confirm cache functions remain publicly available through `lib.rs`.
- [ ] Cargo compilation/tests: deferred explicitly to CI; not run locally.
- [ ] Manual runtime testing: N/A for this mechanical extraction.

## Rollback and Out of Scope
- Rollback: revert commit `b703b63`; only this cache extraction is removed.
- Out of scope: behavior fixes, API redesign, ABI changes, Cargo builds/tests, and unrelated cleanup.

## Contributor Checklist
- [x] Linked issue: #295
- [x] Exactly one type label: `type:refactor`
- [x] No modified shell scripts; shellcheck not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #295