### PR TITLE
refactor(whatsrust): extract incoming message conversion

### DIFF
--- a/whatsrust/src/incoming.rs
+++ b/whatsrust/src/incoming.rs
@@ -1,0 +1,135 @@
+use std::ffi::{CStr, c_char};
+
+use crate::abi::{CFileMessage, CIncomingTextMessage, CMessage, MessageType};
+use crate::caches::{
+    store_forward_source, store_message_mention_ranges, store_message_push_name,
+    validated_mention_ranges,
+};
+use crate::{
+    CallbackTranslator, FileContent, FileKind, ForwardingInfo, Message, MessageContent, MessageInfo,
+};
+
+impl CallbackTranslator<*const CMessage> for Message {
+    unsafe fn to_rust(ptr: *const CMessage) -> Self {
+        let msg = unsafe { &(*ptr) };
+        let id = unsafe { CStr::from_ptr(msg.info.id) }
+            .to_string_lossy()
+            .into_owned()
+            .into();
+        let chat: JID = (&msg.info.chat).into();
+        let sender: JID = (&msg.info.sender).into();
+        let push_name = if msg.info.push_name.is_null() {
+            String::new()
+        } else {
+            unsafe { CStr::from_ptr(msg.info.push_name) }
+                .to_string_lossy()
+                .into_owned()
+        };
+        store_message_push_name(&id, &push_name);
+
+        let c_quote_id = msg.info.quote_id;
+        let quote_id = if c_quote_id.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { CStr::from_ptr(c_quote_id) }
+                    .to_string_lossy()
+                    .into_owned()
+                    .into(),
+            )
+        };
+
+        let message = match MessageType::from_repr(msg.message_type).unwrap() {
+            MessageType::Text => {
+                let text_message = unsafe { &*(msg.message as *const CIncomingTextMessage) };
+
+                let message = unsafe { CStr::from_ptr(text_message.text) }
+                    .to_string_lossy()
+                    .into_owned();
+                let ranges = if text_message.mention_ranges.is_null()
+                    || text_message.mention_range_count == 0
+                {
+                    Vec::new()
+                } else {
+                    validated_mention_ranges(&message, unsafe {
+                        std::slice::from_raw_parts(
+                            text_message.mention_ranges,
+                            text_message.mention_range_count,
+                        )
+                    })
+                };
+                store_message_mention_ranges(&id, &message, ranges);
+                MessageContent::Text(message.into())
+            }
+            MessageType::ViewOnceUnavailable => MessageContent::ViewOnceUnavailable,
+            MessageType::File => {
+                let image_message = unsafe { &*(msg.message as *const CFileMessage) };
+
+                let caption_text = if image_message.caption.is_null() {
+                    String::new()
+                } else {
+                    unsafe { CStr::from_ptr(image_message.caption) }
+                        .to_string_lossy()
+                        .into_owned()
+                };
+                let ranges = if image_message.mention_ranges.is_null()
+                    || image_message.mention_range_count == 0
+                {
+                    Vec::new()
+                } else {
+                    validated_mention_ranges(&caption_text, unsafe {
+                        std::slice::from_raw_parts(
+                            image_message.mention_ranges,
+                            image_message.mention_range_count,
+                        )
+                    })
+                };
+                store_message_mention_ranges(&id, &caption_text, ranges);
+
+                let path = unsafe { CStr::from_ptr(image_message.path) }
+                    .to_string_lossy()
+                    .into_owned()
+                    .into();
+
+                let file_id = unsafe { CStr::from_ptr(image_message.file_id) }
+                    .to_string_lossy()
+                    .into_owned()
+                    .into();
+
+                let caption = if image_message.caption.is_null() {
+                    None
+                } else {
+                    Some(caption_text.into())
+                };
+                MessageContent::File(FileContent {
+                    kind: FileKind::from_repr(image_message.kind).unwrap(),
+                    path,
+                    file_id,
+                    caption,
+                })
+            }
+        };
+
+        let info = MessageInfo {
+            id,
+            chat,
+            sender,
+            mentions_self: msg.info.mentions_self,
+
+            timestamp: msg.info.timestamp,
+            is_from_me: msg.info.is_from_me,
+            quote_id,
+            read_by: msg.info.read_by,
+            forwarding: ForwardingInfo {
+                is_forwarded: msg.info.is_forwarded,
+                score: msg.info.forwarding_score,
+            },
+        };
+        if !msg.forward_source.is_null() && msg.forward_source_len > 0 {
+            store_forward_source(&info, unsafe {
+                std::slice::from_raw_parts(msg.forward_source, msg.forward_source_len).to_vec()
+            });
+        }
+        Message { info, message }
+    }
+}

--- a/whatsrust/src/incoming.rs
+++ b/whatsrust/src/incoming.rs
@@ -1,4 +1,4 @@
-use std::ffi::{CStr, c_char};
+use std::ffi::CStr;
 
 use crate::abi::{CFileMessage, CIncomingTextMessage, CMessage, MessageType};
 use crate::caches::{
@@ -6,7 +6,8 @@ use crate::caches::{
     validated_mention_ranges,
 };
 use crate::{
-    CallbackTranslator, FileContent, FileKind, ForwardingInfo, Message, MessageContent, MessageInfo,
+    CallbackTranslator, FileContent, FileKind, ForwardingInfo, JID, Message, MessageContent,
+    MessageInfo,
 };
 
 impl CallbackTranslator<*const CMessage> for Message {

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
 mod callbacks;
 mod abi;
 mod caches;
+mod incoming;
 mod models;
 use abi::*;
 pub use abi::{LogoutStatus, ReceiptKind};
@@ -796,131 +797,6 @@ setup_handler!(
     unavailable: bool => bool,
     last_seen: i64 => i64
 );
-
-impl CallbackTranslator<*const CMessage> for Message {
-    unsafe fn to_rust(ptr: *const CMessage) -> Self {
-        let msg = unsafe { &(*ptr) };
-        let id = unsafe { CStr::from_ptr(msg.info.id) }
-            .to_string_lossy()
-            .into_owned()
-            .into();
-        let chat: JID = (&msg.info.chat).into();
-        let sender: JID = (&msg.info.sender).into();
-        let push_name = if msg.info.push_name.is_null() {
-            String::new()
-        } else {
-            unsafe { CStr::from_ptr(msg.info.push_name) }
-                .to_string_lossy()
-                .into_owned()
-        };
-        store_message_push_name(&id, &push_name);
-
-        let c_quote_id = msg.info.quote_id;
-        let quote_id = if c_quote_id.is_null() {
-            None
-        } else {
-            Some(
-                unsafe { CStr::from_ptr(c_quote_id) }
-                    .to_string_lossy()
-                    .into_owned()
-                    .into(),
-            )
-        };
-
-        let message = match MessageType::from_repr(msg.message_type).unwrap() {
-            MessageType::Text => {
-                let text_message = unsafe { &*(msg.message as *const CIncomingTextMessage) };
-
-                let message = unsafe { CStr::from_ptr(text_message.text) }
-                    .to_string_lossy()
-                    .into_owned();
-                let ranges = if text_message.mention_ranges.is_null()
-                    || text_message.mention_range_count == 0
-                {
-                    Vec::new()
-                } else {
-                    validated_mention_ranges(&message, unsafe {
-                        std::slice::from_raw_parts(
-                            text_message.mention_ranges,
-                            text_message.mention_range_count,
-                        )
-                    })
-                };
-                store_message_mention_ranges(&id, &message, ranges);
-                MessageContent::Text(message.into())
-            }
-            MessageType::ViewOnceUnavailable => MessageContent::ViewOnceUnavailable,
-            MessageType::File => {
-                let image_message = unsafe { &*(msg.message as *const CFileMessage) };
-
-                let caption_text = if image_message.caption.is_null() {
-                    String::new()
-                } else {
-                    unsafe { CStr::from_ptr(image_message.caption) }
-                        .to_string_lossy()
-                        .into_owned()
-                };
-                let ranges = if image_message.mention_ranges.is_null()
-                    || image_message.mention_range_count == 0
-                {
-                    Vec::new()
-                } else {
-                    validated_mention_ranges(&caption_text, unsafe {
-                        std::slice::from_raw_parts(
-                            image_message.mention_ranges,
-                            image_message.mention_range_count,
-                        )
-                    })
-                };
-                store_message_mention_ranges(&id, &caption_text, ranges);
-
-                let path = unsafe { CStr::from_ptr(image_message.path) }
-                    .to_string_lossy()
-                    .into_owned()
-                    .into();
-
-                let file_id = unsafe { CStr::from_ptr(image_message.file_id) }
-                    .to_string_lossy()
-                    .into_owned()
-                    .into();
-
-                let caption = if image_message.caption.is_null() {
-                    None
-                } else {
-                    Some(caption_text.into())
-                };
-                MessageContent::File(FileContent {
-                    kind: FileKind::from_repr(image_message.kind).unwrap(),
-                    path,
-                    file_id,
-                    caption,
-                })
-            }
-        };
-
-        let info = MessageInfo {
-            id,
-            chat,
-            sender,
-            mentions_self: msg.info.mentions_self,
-
-            timestamp: msg.info.timestamp,
-            is_from_me: msg.info.is_from_me,
-            quote_id,
-            read_by: msg.info.read_by,
-            forwarding: ForwardingInfo {
-                is_forwarded: msg.info.is_forwarded,
-                score: msg.info.forwarding_score,
-            },
-        };
-        if !msg.forward_source.is_null() && msg.forward_source_len > 0 {
-            store_forward_source(&info, unsafe {
-                std::slice::from_raw_parts(msg.forward_source, msg.forward_source_len).to_vec()
-            });
-        }
-        Message { info, message }
-    }
-}
 
 impl CallbackTranslator<bool> for bool {
     unsafe fn to_rust(ptr: bool) -> bool {


### PR DESCRIPTION
## Summary
- Extract `CMessage` to `Message` conversion into `incoming.rs`.
- Keep mention validation/storage and push-name/forward-source capture behavior unchanged.

## Changes
- Moved incoming callback translation and message construction out of `lib.rs`.
- Preserved the existing handler registrations and public facade behavior.

## Chain Context
- Start: immediate parent `refactor/whatsrust-message-caches` at `b703b63` / PR #299.
- End: incoming message conversion is owned by `incoming.rs`.
- Dependency: review after PR #299; later slices target this PR’s branch.
- Diagram: `PR #298 -> 📍 PR (caches) -> 📍 PR (incoming) -> events`

## Review Budget
- Authored diff: 261 lines (136 additions, 125 deletions).
- Budget: <=400 touched lines.

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Source checks confirm message handlers remain registered.
- [ ] Cargo compilation/tests: deferred explicitly to CI; not run locally.
- [ ] Manual runtime testing: N/A for this mechanical extraction.

## Rollback and Out of Scope
- Rollback: revert commit `13e69a4`; only incoming conversion extraction is removed.
- Out of scope: behavior fixes, API redesign, ABI changes, Cargo builds/tests, and unrelated cleanup.

## Contributor Checklist
- [x] Linked issue: #296
- [x] Exactly one type label: `type:refactor`
- [x] No modified shell scripts; shellcheck not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #296