### PR TITLE
refactor(db): extract chat contact repository

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -93,18 +93,7 @@ impl DatabaseHandler {
     }
 
     pub fn get_chats(&self) -> Vec<Chat> {
-        let mut query = self.db.prepare("SELECT jid FROM chats").unwrap();
-        query
-            .query_map([], |row| {
-                let jid: String = row.get(0).unwrap();
-                Ok(Chat {
-                    jid: jid.into(),
-                    last_message_time: None,
-                })
-            })
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap()
+        chat_store::get_chats(&self.db)
     }
 
     pub fn get_messages(&self) -> Vec<wr::Message> {
@@ -112,25 +101,11 @@ impl DatabaseHandler {
     }
 
     pub fn add_contact(&self, jid: &wr::JID, name: &str) {
-        let _write_lock = DATABASE_WRITE_LOCK.lock().unwrap();
-        self.db
-            .execute(
-                "INSERT OR REPLACE INTO contacts (jid, name) VALUES (?1, ?2)",
-                rusqlite::params![&*jid.0, name],
-            )
-            .unwrap();
+        chat_store::add_contact(&self.db, jid, name);
     }
 
     pub fn get_contacts(&self) -> Vec<(wr::JID, Arc<str>)> {
-        let mut stmt = self.db.prepare("SELECT jid, name FROM contacts").unwrap();
-        let rows = stmt
-            .query_map([], |row| {
-                let jid: String = row.get(0).unwrap();
-                let name: String = row.get(1).unwrap();
-                Ok((jid.into(), Arc::from(name)))
-            })
-            .unwrap();
-        rows.map(|r| r.unwrap()).collect()
+        chat_store::get_contacts(&self.db)
     }
 
     pub fn init(&self) {

--- a/src/db/chat_store.rs
+++ b/src/db/chat_store.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use rusqlite::Connection;
+use whatsrust as wr;
 
 use crate::app::Chat;
 
@@ -14,4 +17,40 @@ pub(super) fn persist(db: &mut Connection, chats: Vec<Chat>) {
     }
     drop(statement);
     tx.commit().unwrap();
+}
+
+pub(super) fn get_chats(db: &Connection) -> Vec<Chat> {
+    let mut query = db.prepare("SELECT jid FROM chats").unwrap();
+    query
+        .query_map([], |row| {
+            let jid: String = row.get(0).unwrap();
+            Ok(Chat {
+                jid: jid.into(),
+                last_message_time: None,
+            })
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+pub(super) fn add_contact(db: &Connection, jid: &wr::JID, name: &str) {
+    let _write_lock = super::DATABASE_WRITE_LOCK.lock().unwrap();
+    db.execute(
+        "INSERT OR REPLACE INTO contacts (jid, name) VALUES (?1, ?2)",
+        rusqlite::params![&*jid.0, name],
+    )
+    .unwrap();
+}
+
+pub(super) fn get_contacts(db: &Connection) -> Vec<(wr::JID, Arc<str>)> {
+    let mut stmt = db.prepare("SELECT jid, name FROM contacts").unwrap();
+    let rows = stmt
+        .query_map([], |row| {
+            let jid: String = row.get(0).unwrap();
+            let name: String = row.get(1).unwrap();
+            Ok((jid.into(), Arc::from(name)))
+        })
+        .unwrap();
+    rows.map(|r| r.unwrap()).collect()
 }


### PR DESCRIPTION
## Summary
- Move chat and contact SQL into `src/db/chat_store.rs`.
- Leave `DatabaseHandler` as a truthful public facade and composition root.

## Changes
- Added chat loading, contact persistence, and contact loading repository functions.
- Kept public `DatabaseHandler` methods as signature-preserving delegations.

## Chain Context
- Start: `refactor/rust-db-worker-coordination` / PR #304
- Current: `refactor/rust-db-chat-contact-repository` / this PR 📍
- End: the requested four-slice DB decomposition chain.
- Dependency diagram: `refactor/rust-db-retention-repository` → `refactor/rust-db-message-reader` → `refactor/rust-db-message-writer` → `refactor/rust-db-worker-coordination` → 📍 `refactor/rust-db-chat-contact-repository`

## Testing
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo fmt --all`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --test mention_persistence -- --test-threads=1` — passed (3 tests)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -- --test-threads=1` — passed (360 library, 2 binary, and all integration/doc tests)
- [x] `git diff --check`

## Budget
- 70 authored changed lines (42 additions / 28 deletions), within the 400-line limit.

## Rollback
- Revert commit `4e71e05` to remove only this chat/contact repository extraction.

## Out of scope
- No schema, API, SQL behavior, or pre-existing bug fixes.

Closes #293