### PR TITLE
refactor(whatsrust): extract callback registrations

### DIFF
--- a/whatsrust/src/callbacks.rs
+++ b/whatsrust/src/callbacks.rs
@@ -2,12 +2,6 @@ pub trait CallbackTranslator<T> {
     unsafe fn to_rust(c_value: T) -> Self;
 }
 
-// impl<T, U: From<T>> CallbackTranslator<T> for U {
-//     unsafe fn to_rust(c_value: T) -> Self {
-//         Self::from(c_value)
-//     }
-// }
-
 macro_rules! setup_handler {
     ($fn_name:ident, $c_func:ident) => {
         setup_handler!($fn_name, $c_func,);
@@ -23,29 +17,29 @@ macro_rules! setup_handler {
         where
             F: FnMut($($rs_type),*) + 'static,
         {
-            // Go has no unregister API, so this allocation intentionally lives for the
-            // process lifetime. The shim must only borrow it; reconstructing a Box on
-            // each call creates concurrent owners for the same allocation.
             type CallbackType = dyn FnMut($($rs_type),*);
             let callback: Box<CallbackType> = Box::new(callback);
-            let callback_state = Box::new(Arc::new(Mutex::new(callback)));
-            let user_data = Box::into_raw(callback_state) as *mut c_void;
+            let callback_state = Box::new(std::sync::Arc::new(
+                std::sync::Mutex::new(callback),
+            ));
+            let user_data = Box::into_raw(callback_state) as *mut std::ffi::c_void;
 
-            // Shim callback compatible with C
             extern "C" fn shim(
                 $( $param_name: $c_type, )*
-                user_data: *mut c_void
+                user_data: *mut std::ffi::c_void
             ) {
                 unsafe {
-                    let callback_state =
-                        &*(user_data as *const Arc<Mutex<Box<CallbackType>>>);
-                    let closure = Arc::clone(callback_state);
+                    let callback_state = &*(user_data
+                        as *const std::sync::Arc<
+                            std::sync::Mutex<Box<CallbackType>>,
+                        >);
+                    let closure = std::sync::Arc::clone(callback_state);
                     let mut guard = closure.lock().unwrap();
-
                     guard($(
-                        <$rs_type>::to_rust($param_name),
+                        <$rs_type as $crate::callbacks::CallbackTranslator<$c_type>>::to_rust(
+                            $param_name,
+                        ),
                     )*);
-
                 }
             }
 

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
 
 #[macro_use]
 mod callbacks;
+mod registrations;
 mod abi;
 mod caches;
 mod events;
@@ -16,7 +17,11 @@ mod incoming;
 mod models;
 use abi::*;
 pub use abi::{LogoutStatus, ReceiptKind};
-use callbacks::CallbackTranslator;
+pub use callbacks::CallbackTranslator;
+pub use registrations::{
+    connect, set_event_handler, set_log_handler, set_message_handler,
+    set_optimistic_text_sent_handler, set_presence_handler,
+};
 pub(crate) use models::file_kind_discriminant;
 pub use models::{
     ChatSettings, CommunitiesError, CommunityInfo, Contact, DownloadFailed, Event, FileContent,
@@ -654,78 +659,6 @@ impl CallbackTranslator<i64> for i64 {
         value
     }
 }
-
-pub fn set_presence_handler<F>(mut callback: F)
-where
-    F: FnMut(PresenceUpdate) + 'static,
-{
-    setup_presence_handler(move |from, unavailable, last_seen| {
-        if std::env::var("WPTUI_PRESENCE_DEBUG").as_deref() == Ok("1") {
-            PRESENCE_CALLBACK_INGRESS.fetch_add(1, Ordering::Relaxed);
-        }
-        callback(PresenceUpdate {
-            from,
-            unavailable,
-            last_seen,
-        });
-    });
-}
-
-setup_handler!(
-    setup_presence_handler,
-    C_SetPresenceHandler,
-    from: CJID => JID,
-    unavailable: bool => bool,
-    last_seen: i64 => i64
-);
-
-impl CallbackTranslator<bool> for bool {
-    unsafe fn to_rust(ptr: bool) -> bool {
-        ptr
-    }
-}
-
-impl CallbackTranslator<u64> for u64 {
-    unsafe fn to_rust(value: u64) -> Self {
-        value
-    }
-}
-
-setup_handler!(
-    set_message_handler,
-    C_SetMessageHandler,
-    msg: *const CMessage => Message,
-    is_sync: bool => bool
-);
-
-setup_handler!(
-    set_optimistic_text_sent_handler,
-    C_SetOptimisticTextSentHandler,
-    local_send_id: u64 => u64,
-    msg: *const CMessage => Message
-);
-
-impl CallbackTranslator<*const c_char> for String {
-    unsafe fn to_rust(ptr: *const c_char) -> String {
-        let c_str = unsafe { CStr::from_ptr(ptr) };
-        c_str.to_string_lossy().into_owned()
-    }
-}
-
-impl CallbackTranslator<u8> for u8 {
-    unsafe fn to_rust(ptr: u8) -> u8 {
-        ptr
-    }
-}
-
-setup_handler!(
-    set_log_handler,
-    C_SetLogHandler,
-    msg: *const c_char => String,
-    level: u8 => u8
-);
-
-setup_handler!(connect, C_Connect, qr: *const c_char => String);
 
 pub fn disconnect() {
     unsafe { C_Disconnect() }

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -17,9 +17,10 @@ mod incoming;
 mod models;
 use abi::*;
 pub use abi::{LogoutStatus, ReceiptKind};
+pub use events::set_event_handler;
 pub use callbacks::CallbackTranslator;
 pub use registrations::{
-    connect, set_event_handler, set_log_handler, set_message_handler,
+    connect, set_log_handler, set_message_handler,
     set_optimistic_text_sent_handler, set_presence_handler,
 };
 pub(crate) use models::file_kind_discriminant;

--- a/whatsrust/src/registrations.rs
+++ b/whatsrust/src/registrations.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+impl CallbackTranslator<bool> for bool {
+    unsafe fn to_rust(value: bool) -> Self {
+        value
+    }
+}
+
+impl CallbackTranslator<u64> for u64 {
+    unsafe fn to_rust(value: u64) -> Self {
+        value
+    }
+}
+
+impl CallbackTranslator<*const c_char> for String {
+    unsafe fn to_rust(ptr: *const c_char) -> String {
+        let c_str = unsafe { CStr::from_ptr(ptr) };
+        c_str.to_string_lossy().into_owned()
+    }
+}
+
+impl CallbackTranslator<u8> for u8 {
+    unsafe fn to_rust(value: u8) -> Self {
+        value
+    }
+}
+
+pub fn set_presence_handler<F>(mut callback: F)
+where
+    F: FnMut(PresenceUpdate) + 'static,
+{
+    setup_presence_handler(move |from, unavailable, last_seen| {
+        if std::env::var("WPTUI_PRESENCE_DEBUG").as_deref() == Ok("1") {
+            PRESENCE_CALLBACK_INGRESS.fetch_add(1, Ordering::Relaxed);
+        }
+        callback(PresenceUpdate {
+            from,
+            unavailable,
+            last_seen,
+        });
+    });
+}
+
+setup_handler!(
+    setup_presence_handler,
+    C_SetPresenceHandler,
+    from: CJID => JID,
+    unavailable: bool => bool,
+    last_seen: i64 => i64
+);
+
+setup_handler!(
+    set_message_handler,
+    C_SetMessageHandler,
+    msg: *const CMessage => Message,
+    is_sync: bool => bool
+);
+
+setup_handler!(
+    set_optimistic_text_sent_handler,
+    C_SetOptimisticTextSentHandler,
+    local_send_id: u64 => u64,
+    msg: *const CMessage => Message
+);
+
+setup_handler!(
+    set_log_handler,
+    C_SetLogHandler,
+    msg: *const c_char => String,
+    level: u8 => u8
+);
+
+setup_handler!(connect, C_Connect, qr: *const c_char => String);


### PR DESCRIPTION
## Summary

- Extract public callback registration handlers from the whatsrust facade.
- Move the setup macro implementation into the callback registration seam and make its standard-library and trait paths hygienic for moved invocations.

## Changes

- Added `whatsrust/src/registrations.rs` for callback and QR registrations.
- Kept `CallbackTranslator` in `callbacks.rs` and re-exported the public handlers from `lib.rs`.
- Preserved callback ownership, locking, ABI signatures, and process-lifetime allocation behavior.

## Chain Context

- Start: PR #301 (`refactor/whatsrust-event-conversion`).
- End: callback handlers and macro isolated; later lifecycle, presence, media, and action slices remain.
- Dependency: this PR is the immediate parent for the lifecycle slice.
- Diagram: `#301 -> 📍 #302 -> #303 -> #304 -> #305`
- Deferred: Cargo compilation/tests are intentionally deferred per task instructions; only formatting/source/diff checks were run.
- Rollback: revert commit `578582c` / remove `registrations.rs` and restore the handler block in `lib.rs`; no unrelated behavior changes.

## Testing

- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] Source and authored-line budget checks
- [ ] Cargo tests/build (deferred; no Cargo build/test command run)
- [ ] Manual runtime testing (not applicable to this mechanical extraction)

Closes #306