### PR TITLE
refactor(whatsrust): extract lifecycle wrappers

### DIFF
--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
 #[macro_use]
 mod callbacks;
 mod registrations;
+mod lifecycle;
 mod abi;
 mod caches;
 mod events;
@@ -19,9 +20,10 @@ use abi::*;
 pub use abi::{LogoutStatus, ReceiptKind};
 pub use callbacks::CallbackTranslator;
 pub use registrations::{
-    connect, set_event_handler, set_log_handler, set_message_handler,
+    set_event_handler, set_log_handler, set_message_handler,
     set_optimistic_text_sent_handler, set_presence_handler,
 };
+pub use lifecycle::{connect, disconnect, logout, new_client, pair_phone};
 pub(crate) use models::file_kind_discriminant;
 pub use models::{
     ChatSettings, CommunitiesError, CommunityInfo, Contact, DownloadFailed, Event, FileContent,
@@ -633,21 +635,6 @@ mod read_receipt_ffi_tests {
     }
 }
 
-pub fn pair_phone(phone: &str) -> String {
-    let phone_c = CString::new(phone).unwrap();
-    let result = unsafe { C_PairPhone(phone_c.as_ptr()) };
-    let result_str = unsafe { CStr::from_ptr(result) }
-        .to_string_lossy()
-        .into_owned();
-    unsafe { C_FreePairPhoneResult(result) };
-    result_str
-}
-
-pub fn new_client(db_path: &str) {
-    let db_path_c = CString::new(db_path).unwrap();
-    unsafe { C_NewClient(db_path_c.as_ptr()) }
-}
-
 impl CallbackTranslator<CJID> for JID {
     unsafe fn to_rust(from: CJID) -> Self {
         (&from).into()
@@ -658,18 +645,6 @@ impl CallbackTranslator<i64> for i64 {
     unsafe fn to_rust(value: i64) -> Self {
         value
     }
-}
-
-pub fn disconnect() {
-    unsafe { C_Disconnect() }
-}
-
-pub fn logout() {
-    // Performs a deterministic local sign-out on the Go side (disconnect +
-    // clear the persisted device). The result arrives via Event::LogoutResult
-    // so the app can remove the DB file and quit. No network round-trip, so
-    // the UI never blocks.
-    unsafe { C_Logout() };
 }
 
 unsafe fn take_owned_c_string(

--- a/whatsrust/src/lifecycle.rs
+++ b/whatsrust/src/lifecycle.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+impl CallbackTranslator<*const c_char> for String {
+    unsafe fn to_rust(ptr: *const c_char) -> String {
+        let c_str = unsafe { CStr::from_ptr(ptr) };
+        c_str.to_string_lossy().into_owned()
+    }
+}
+
+setup_handler!(connect, C_Connect, qr: *const c_char => String);
+
+pub fn new_client(db_path: &str) {
+    let db_path_c = CString::new(db_path).unwrap();
+    unsafe { C_NewClient(db_path_c.as_ptr()) }
+}
+
+pub fn disconnect() {
+    unsafe { C_Disconnect() }
+}
+
+pub fn logout() {
+    // Performs a deterministic local sign-out on the Go side (disconnect +
+    // clear the persisted device). The result arrives via Event::LogoutResult
+    // so the app can remove the DB file and quit. No network round-trip, so
+    // the UI never blocks.
+    unsafe { C_Logout() };
+}
+
+pub fn pair_phone(phone: &str) -> String {
+    let phone_c = CString::new(phone).unwrap();
+    let result = unsafe { C_PairPhone(phone_c.as_ptr()) };
+    let result_str = unsafe { CStr::from_ptr(result) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { C_FreePairPhoneResult(result) };
+    result_str
+}

--- a/whatsrust/src/registrations.rs
+++ b/whatsrust/src/registrations.rs
@@ -12,13 +12,6 @@ impl CallbackTranslator<u64> for u64 {
     }
 }
 
-impl CallbackTranslator<*const c_char> for String {
-    unsafe fn to_rust(ptr: *const c_char) -> String {
-        let c_str = unsafe { CStr::from_ptr(ptr) };
-        c_str.to_string_lossy().into_owned()
-    }
-}
-
 impl CallbackTranslator<u8> for u8 {
     unsafe fn to_rust(value: u8) -> Self {
         value
@@ -69,5 +62,3 @@ setup_handler!(
     msg: *const c_char => String,
     level: u8 => u8
 );
-
-setup_handler!(connect, C_Connect, qr: *const c_char => String);


### PR DESCRIPTION
## Summary

- Extract the public client lifecycle wrappers from the whatsrust facade.
- Keep client creation, QR connection callback, disconnect, logout, and phone pairing behavior unchanged.

## Changes

- Added `whatsrust/src/lifecycle.rs`.
- Re-exported `new_client`, `connect`, `disconnect`, `logout`, and `pair_phone` from `lib.rs`.
- Kept the callback translator and setup macro contract intact at the FFI boundary.

## Chain Context

- Start: PR #311 (`refactor/whatsrust-callback-registrations`).
- End: lifecycle wrappers isolated; presence, media, and action slices remain.
- Dependency: this PR is the immediate parent for the presence slice.
- Diagram: `#301 -> #311 -> 📍 #312 -> #313 -> #314 -> #315`.
- Deferred: Cargo compilation/tests are intentionally deferred per task instructions; only formatting/source/diff checks were run.
- Rollback: revert commit `235b3ba` / remove `lifecycle.rs` and restore these wrappers in `lib.rs`; no unrelated behavior changes.

## Testing

- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] Source and authored-line budget checks
- [ ] Cargo tests/build (deferred; no Cargo build/test command run)
- [ ] Manual runtime testing (not applicable to this mechanical extraction)

Closes #307