### PR TITLE
refactor(whatsrust): extract presence wrappers

### DIFF
--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -3,7 +3,6 @@ use std::{
     path::Path,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -11,6 +10,7 @@ use std::{
 mod callbacks;
 mod registrations;
 mod lifecycle;
+mod presence;
 mod abi;
 mod caches;
 mod events;
@@ -24,6 +24,7 @@ pub use registrations::{
     set_optimistic_text_sent_handler, set_presence_handler,
 };
 pub use lifecycle::{connect, disconnect, logout, new_client, pair_phone};
+pub use presence::{SubscribePresenceResult, drain_raw_presence_diagnostics, subscribe_presence};
 pub(crate) use models::file_kind_discriminant;
 pub use models::{
     ChatSettings, CommunitiesError, CommunityInfo, Contact, DownloadFailed, Event, FileContent,
@@ -644,84 +645,6 @@ impl CallbackTranslator<CJID> for JID {
 impl CallbackTranslator<i64> for i64 {
     unsafe fn to_rust(value: i64) -> Self {
         value
-    }
-}
-
-unsafe fn take_owned_c_string(
-    value: *mut c_char,
-    free: unsafe extern "C" fn(*mut c_char),
-) -> Option<String> {
-    if value.is_null() {
-        return None;
-    }
-    let result = unsafe { CStr::from_ptr(value) }
-        .to_string_lossy()
-        .into_owned();
-    unsafe { free(value) };
-    Some(result)
-}
-
-pub fn drain_raw_presence_diagnostics() -> Option<String> {
-    unsafe {
-        let mut report = take_owned_c_string(
-            C_DrainRawPresenceDiagnostics(),
-            C_FreeRawPresenceDiagnostics,
-        );
-        if std::env::var("WPTUI_PRESENCE_DEBUG").as_deref() == Ok("1") {
-            let ingress = PRESENCE_CALLBACK_INGRESS.swap(0, Ordering::Relaxed);
-            report.get_or_insert_default().push_str(&format!(
-                "Rust callback ingress Presence events: {ingress}\n"
-            ));
-        }
-        report
-    }
-}
-
-#[cfg(test)]
-mod raw_presence_diagnostic_tests {
-    use std::{
-        ffi::{CString, c_char},
-        sync::atomic::{AtomicBool, Ordering},
-    };
-
-    use super::take_owned_c_string;
-
-    static FREED: AtomicBool = AtomicBool::new(false);
-
-    unsafe extern "C" fn free_test_string(value: *mut c_char) {
-        drop(unsafe { CString::from_raw(value) });
-        FREED.store(true, Ordering::SeqCst);
-    }
-
-    #[test]
-    fn owned_diagnostic_string_is_copied_and_freed_once() {
-        FREED.store(false, Ordering::SeqCst);
-        let value = CString::new("raw presence events received: 0\n")
-            .unwrap()
-            .into_raw();
-
-        let report = unsafe { take_owned_c_string(value, free_test_string) };
-
-        assert_eq!(report.as_deref(), Some("raw presence events received: 0\n"));
-        assert!(FREED.load(Ordering::SeqCst));
-        assert!(unsafe { take_owned_c_string(std::ptr::null_mut(), free_test_string) }.is_none());
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u8)]
-pub enum SubscribePresenceResult {
-    Accepted = 0,
-    NoPrivacyToken = 1,
-    Rejected = 2,
-}
-
-pub fn subscribe_presence(jid: &JID) -> SubscribePresenceResult {
-    let jid = CString::new(jid.0.as_ref()).unwrap();
-    match unsafe { C_SubscribePresence(jid.as_ptr()) } {
-        0 => SubscribePresenceResult::Accepted,
-        1 => SubscribePresenceResult::NoPrivacyToken,
-        _ => SubscribePresenceResult::Rejected,
     }
 }
 

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -1,9 +1,7 @@
 use std::{
     ffi::{CStr, CString, c_char, c_void},
     path::Path,
-    sync::{
-        Arc,
-    },
+    sync::Arc,
 };
 
 #[macro_use]
@@ -36,7 +34,6 @@ pub use models::{
 };
 use strum::FromRepr;
 
-static PRESENCE_CALLBACK_INGRESS: AtomicUsize = AtomicUsize::new(0);
 #[cfg(test)]
 mod file_kind_tests {
     use super::{FileKind, file_kind_discriminant};
@@ -1176,7 +1173,7 @@ mod group_info_tests {
 /// JID is unusable.
 pub fn resolve_dm_chat(jid: &JID) -> Option<JID> {
     unsafe {
-        take_owned_c_string(C_ResolveDmChatId(CJID::from(jid)), C_FreeResolveDmChatId)
+        presence::take_owned_c_string(C_ResolveDmChatId(CJID::from(jid)), C_FreeResolveDmChatId)
             .map(JID::from)
     }
 }

--- a/whatsrust/src/presence.rs
+++ b/whatsrust/src/presence.rs
@@ -8,7 +8,7 @@ pub(crate) fn record_callback_ingress() {
     PRESENCE_CALLBACK_INGRESS.fetch_add(1, Ordering::Relaxed);
 }
 
-unsafe fn take_owned_c_string(
+pub(crate) unsafe fn take_owned_c_string(
     value: *mut c_char,
     free: unsafe extern "C" fn(*mut c_char),
 ) -> Option<String> {

--- a/whatsrust/src/presence.rs
+++ b/whatsrust/src/presence.rs
@@ -1,0 +1,85 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::*;
+
+static PRESENCE_CALLBACK_INGRESS: AtomicUsize = AtomicUsize::new(0);
+
+pub(crate) fn record_callback_ingress() {
+    PRESENCE_CALLBACK_INGRESS.fetch_add(1, Ordering::Relaxed);
+}
+
+unsafe fn take_owned_c_string(
+    value: *mut c_char,
+    free: unsafe extern "C" fn(*mut c_char),
+) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+    let result = unsafe { CStr::from_ptr(value) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { free(value) };
+    Some(result)
+}
+
+pub fn drain_raw_presence_diagnostics() -> Option<String> {
+    unsafe {
+        let mut report = take_owned_c_string(
+            C_DrainRawPresenceDiagnostics(),
+            C_FreeRawPresenceDiagnostics,
+        );
+        if std::env::var("WPTUI_PRESENCE_DEBUG").as_deref() == Ok("1") {
+            let ingress = PRESENCE_CALLBACK_INGRESS.swap(0, Ordering::Relaxed);
+            report.get_or_insert_default().push_str(&format!(
+                "Rust callback ingress Presence events: {ingress}\n"
+            ));
+        }
+        report
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum SubscribePresenceResult {
+    Accepted = 0,
+    NoPrivacyToken = 1,
+    Rejected = 2,
+}
+
+pub fn subscribe_presence(jid: &JID) -> SubscribePresenceResult {
+    let jid = CString::new(jid.0.as_ref()).unwrap();
+    match unsafe { C_SubscribePresence(jid.as_ptr()) } {
+        0 => SubscribePresenceResult::Accepted,
+        1 => SubscribePresenceResult::NoPrivacyToken,
+        _ => SubscribePresenceResult::Rejected,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        ffi::{CString, c_char},
+        sync::atomic::{AtomicBool, Ordering},
+    };
+
+    use super::take_owned_c_string;
+
+    static FREED: AtomicBool = AtomicBool::new(false);
+
+    unsafe extern "C" fn free_test_string(value: *mut c_char) {
+        drop(unsafe { CString::from_raw(value) });
+        FREED.store(true, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn owned_diagnostic_string_is_copied_and_freed_once() {
+        FREED.store(false, Ordering::SeqCst);
+        let value = CString::new("raw presence events received: 0\n")
+            .unwrap()
+            .into_raw();
+        let report = unsafe { take_owned_c_string(value, free_test_string) };
+        assert_eq!(report.as_deref(), Some("raw presence events received: 0\n"));
+        assert!(FREED.load(Ordering::SeqCst));
+        assert!(unsafe { take_owned_c_string(std::ptr::null_mut(), free_test_string) }.is_none());
+    }
+}

--- a/whatsrust/src/registrations.rs
+++ b/whatsrust/src/registrations.rs
@@ -24,7 +24,7 @@ where
 {
     setup_presence_handler(move |from, unavailable, last_seen| {
         if std::env::var("WPTUI_PRESENCE_DEBUG").as_deref() == Ok("1") {
-            PRESENCE_CALLBACK_INGRESS.fetch_add(1, Ordering::Relaxed);
+            super::presence::record_callback_ingress();
         }
         callback(PresenceUpdate {
             from,


### PR DESCRIPTION
## Summary

- Extract raw presence diagnostics, callback ingress counters, and presence subscription wrappers from the whatsrust facade.
- Preserve diagnostic ownership, counter reset behavior, ABI calls, and public result mapping.

## Changes

- Added `whatsrust/src/presence.rs`.
- Re-exported `SubscribePresenceResult`, `drain_raw_presence_diagnostics`, and `subscribe_presence` from `lib.rs`.
- Kept callback registration behavior unchanged while routing ingress counting through the presence seam.

## Chain Context

- Start: PR #312 (`refactor/whatsrust-lifecycle-wrappers`).
- End: presence wrappers isolated; media and action slices remain.
- Dependency: this PR is the immediate parent for the media slice.
- Diagram: `#301 -> #311 -> #312 -> 📍 #313 -> #314 -> #315`.
- Deferred: Cargo compilation/tests are intentionally deferred per task instructions; only formatting/source/diff checks were run.
- Rollback: revert commit `9d43523` / remove `presence.rs` and restore the presence block in `lib.rs`; no unrelated behavior changes.

## Testing

- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] Source and authored-line budget checks
- [ ] Cargo tests/build (deferred; no Cargo build/test command run)
- [ ] Manual runtime testing (not applicable to this mechanical extraction)

Closes #308