### PR TITLE
refactor(whatsrust): extract action wrappers

### DIFF
--- a/whatsrust/src/actions.rs
+++ b/whatsrust/src/actions.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+pub(crate) fn reaction_to_ffi(
+    target_jid: &JID,
+    destination_jid: &JID,
+    sender_jid: &JID,
+    message_id: &MessageId,
+    reaction: &str,
+) -> Result<(CString, CString, CString, CString, CString), MessageActionFailed> {
+    Ok((
+        CString::new(target_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
+        CString::new(destination_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
+        CString::new(sender_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
+        CString::new(message_id.as_ref()).map_err(|_| MessageActionFailed)?,
+        CString::new(reaction).map_err(|_| MessageActionFailed)?,
+    ))
+}
+
+pub fn react_to_message(
+    chat_jid: &JID,
+    sender_jid: &JID,
+    message_id: &MessageId,
+    reaction: &str,
+) -> Result<(), MessageActionFailed> {
+    react_to_message_in_chat(chat_jid, chat_jid, sender_jid, message_id, reaction)
+}
+
+pub fn react_to_message_in_chat(
+    target_jid: &JID,
+    destination_jid: &JID,
+    sender_jid: &JID,
+    message_id: &MessageId,
+    reaction: &str,
+) -> Result<(), MessageActionFailed> {
+    let (target, destination, sender, id, reaction) =
+        reaction_to_ffi(target_jid, destination_jid, sender_jid, message_id, reaction)?;
+    let result = unsafe {
+        C_ReactToMessage(
+            target.as_ptr(),
+            destination.as_ptr(),
+            sender.as_ptr(),
+            id.as_ptr(),
+            reaction.as_ptr(),
+        )
+    };
+    if result == 0 { Ok(()) } else { Err(MessageActionFailed) }
+}
+
+pub(crate) fn edit_to_ffi(
+    chat_jid: &JID,
+    message_id: &MessageId,
+    replacement: &str,
+) -> Result<(CString, CString, CString), MessageActionFailed> {
+    if replacement.trim().is_empty() {
+        return Err(MessageActionFailed);
+    }
+    Ok((
+        CString::new(chat_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
+        CString::new(message_id.as_ref()).map_err(|_| MessageActionFailed)?,
+        CString::new(replacement).map_err(|_| MessageActionFailed)?,
+    ))
+}
+
+pub fn edit_message(
+    chat_jid: &JID,
+    message_id: &MessageId,
+    replacement: &str,
+) -> Result<(), MessageActionFailed> {
+    let (chat, id, replacement) = edit_to_ffi(chat_jid, message_id, replacement)?;
+    let result = unsafe { C_EditMessage(chat.as_ptr(), id.as_ptr(), replacement.as_ptr()) };
+    if result == 0 { Ok(()) } else { Err(MessageActionFailed) }
+}
+
+pub(crate) fn revoke_to_ffi(
+    chat_jid: &JID,
+    sender_jid: &JID,
+    message_id: &MessageId,
+) -> Result<(CString, CString, CString), MessageActionFailed> {
+    Ok((
+        CString::new(chat_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
+        CString::new(sender_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
+        CString::new(message_id.as_ref()).map_err(|_| MessageActionFailed)?,
+    ))
+}
+
+pub fn revoke_message(
+    chat_jid: &JID,
+    sender_jid: &JID,
+    message_id: &MessageId,
+) -> Result<(), MessageActionFailed> {
+    let (chat, sender, id) = revoke_to_ffi(chat_jid, sender_jid, message_id)?;
+    let result = unsafe { C_RevokeMessage(chat.as_ptr(), sender.as_ptr(), id.as_ptr()) };
+    if result == 0 { Ok(()) } else { Err(MessageActionFailed) }
+}

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -12,6 +12,7 @@ mod registrations;
 mod lifecycle;
 mod presence;
 mod media;
+mod actions;
 mod abi;
 mod caches;
 mod events;
@@ -27,6 +28,8 @@ pub use registrations::{
 pub use lifecycle::{connect, disconnect, logout, new_client, pair_phone};
 pub use presence::{SubscribePresenceResult, drain_raw_presence_diagnostics, subscribe_presence};
 pub use media::{download_file, get_community_profile_picture, get_profile_picture};
+pub use actions::{edit_message, react_to_message, react_to_message_in_chat, revoke_message};
+pub(crate) use actions::{edit_to_ffi, reaction_to_ffi, revoke_to_ffi};
 pub(crate) use models::file_kind_discriminant;
 pub use models::{
     ChatSettings, CommunitiesError, CommunityInfo, Contact, DownloadFailed, Event, FileContent,
@@ -295,116 +298,6 @@ impl ForwardReport {
             failed,
             failure,
         }
-    }
-}
-
-fn reaction_to_ffi(
-    target_jid: &JID,
-    destination_jid: &JID,
-    sender_jid: &JID,
-    message_id: &MessageId,
-    reaction: &str,
-) -> Result<(CString, CString, CString, CString, CString), MessageActionFailed> {
-    Ok((
-        CString::new(target_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
-        CString::new(destination_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
-        CString::new(sender_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
-        CString::new(message_id.as_ref()).map_err(|_| MessageActionFailed)?,
-        CString::new(reaction).map_err(|_| MessageActionFailed)?,
-    ))
-}
-
-pub fn react_to_message(
-    chat_jid: &JID,
-    sender_jid: &JID,
-    message_id: &MessageId,
-    reaction: &str,
-) -> Result<(), MessageActionFailed> {
-    react_to_message_in_chat(chat_jid, chat_jid, sender_jid, message_id, reaction)
-}
-
-pub fn react_to_message_in_chat(
-    target_jid: &JID,
-    destination_jid: &JID,
-    sender_jid: &JID,
-    message_id: &MessageId,
-    reaction: &str,
-) -> Result<(), MessageActionFailed> {
-    let (target, destination, sender, id, reaction) = reaction_to_ffi(
-        target_jid,
-        destination_jid,
-        sender_jid,
-        message_id,
-        reaction,
-    )?;
-    let result = unsafe {
-        C_ReactToMessage(
-            target.as_ptr(),
-            destination.as_ptr(),
-            sender.as_ptr(),
-            id.as_ptr(),
-            reaction.as_ptr(),
-        )
-    };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(MessageActionFailed)
-    }
-}
-
-fn edit_to_ffi(
-    chat_jid: &JID,
-    message_id: &MessageId,
-    replacement: &str,
-) -> Result<(CString, CString, CString), MessageActionFailed> {
-    if replacement.trim().is_empty() {
-        return Err(MessageActionFailed);
-    }
-    Ok((
-        CString::new(chat_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
-        CString::new(message_id.as_ref()).map_err(|_| MessageActionFailed)?,
-        CString::new(replacement).map_err(|_| MessageActionFailed)?,
-    ))
-}
-
-pub fn edit_message(
-    chat_jid: &JID,
-    message_id: &MessageId,
-    replacement: &str,
-) -> Result<(), MessageActionFailed> {
-    let (chat, id, replacement) = edit_to_ffi(chat_jid, message_id, replacement)?;
-    let result = unsafe { C_EditMessage(chat.as_ptr(), id.as_ptr(), replacement.as_ptr()) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(MessageActionFailed)
-    }
-}
-
-fn revoke_to_ffi(
-    chat_jid: &JID,
-    sender_jid: &JID,
-    message_id: &MessageId,
-) -> Result<(CString, CString, CString), MessageActionFailed> {
-    Ok((
-        CString::new(chat_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
-        CString::new(sender_jid.0.as_ref()).map_err(|_| MessageActionFailed)?,
-        CString::new(message_id.as_ref()).map_err(|_| MessageActionFailed)?,
-    ))
-}
-
-pub fn revoke_message(
-    chat_jid: &JID,
-    sender_jid: &JID,
-    message_id: &MessageId,
-) -> Result<(), MessageActionFailed> {
-    let (chat, sender, id) = revoke_to_ffi(chat_jid, sender_jid, message_id)?;
-    let result = unsafe { C_RevokeMessage(chat.as_ptr(), sender.as_ptr(), id.as_ptr()) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(MessageActionFailed)
     }
 }
 

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -40,7 +40,6 @@ pub use models::{
 };
 use strum::FromRepr;
 
-static PRESENCE_CALLBACK_INGRESS: AtomicUsize = AtomicUsize::new(0);
 #[cfg(test)]
 mod file_kind_tests {
     use super::{FileKind, file_kind_discriminant};


### PR DESCRIPTION
## Summary

- Extract reaction, edit, and revoke wrappers from the whatsrust facade.
- Preserve argument validation, CString ownership, bridge status mapping, public signatures, and ABI behavior.

## Changes

- Added `whatsrust/src/actions.rs`.
- Re-exported the four public action wrapper entry points from `lib.rs`.
- Kept conversion helpers available to the existing facade tests without changing their behavior.

## Chain Context

- Start: PR #314 (`refactor/whatsrust-media-wrappers`).
- End: action wrappers isolated; this completes the requested five-slice chain.
- Dependency: immediate parent is PR #314; no merge or CI wait requested.
- Diagram: `#301 -> #311 -> #312 -> #313 -> #314 -> 📍 #315`.
- Deferred: Cargo compilation/tests are intentionally deferred per task instructions; only formatting/source/diff checks were run.
- Rollback: revert commit `ce2a3e5` / remove `actions.rs` and restore the action wrapper block in `lib.rs`; no unrelated behavior changes.

## Testing

- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] Source and authored-line budget checks
- [ ] Cargo tests/build (deferred; no Cargo build/test command run)
- [ ] Manual runtime testing (not applicable to this mechanical extraction)

Closes #310