### PR TITLE
refactor(whatsrust): relocate forwarding result types

### DIFF
--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -22,7 +22,9 @@ pub use callbacks::CallbackTranslator;
 pub use events::set_event_handler;
 pub use lifecycle::{connect, disconnect, logout, new_client, pair_phone};
 pub use media::{download_file, get_community_profile_picture, get_profile_picture};
-pub use message_send::{TextSendResult, forward_message, send_message, send_text_message};
+pub use message_send::{
+    ForwardFailure, ForwardReport, TextSendResult, forward_message, send_message, send_text_message,
+};
 pub(crate) use models::file_kind_discriminant;
 pub use models::{
     ChatSettings, CommunitiesError, CommunityInfo, Contact, DownloadFailed, Event, FileContent,
@@ -40,7 +42,6 @@ pub use read_sync::{MarkAsReadError, mark_as_read, sync_chat_read};
 pub use registrations::{
     set_log_handler, set_message_handler, set_optimistic_text_sent_handler, set_presence_handler,
 };
-use strum::FromRepr;
 
 #[cfg(test)]
 mod file_kind_tests {
@@ -272,34 +273,6 @@ pub use caches::{
 
 pub const VIEW_ONCE_UNAVAILABLE_DESCRIPTION: &str =
     "View-once media is unavailable here. View it on your phone.";
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct ForwardReport {
-    pub succeeded: usize,
-    pub failed: usize,
-    pub failure: ForwardFailure,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, FromRepr)]
-#[repr(u8)]
-pub enum ForwardFailure {
-    #[default]
-    None = 0,
-    SourceUnavailable = 1,
-    InvalidSource = 2,
-    InvalidDestination = 3,
-    SendFailed = 4,
-}
-
-impl ForwardReport {
-    pub fn with_reason(succeeded: usize, failed: usize, failure: ForwardFailure) -> Self {
-        Self {
-            succeeded,
-            failed,
-            failure,
-        }
-    }
-}
 
 impl CallbackTranslator<CJID> for JID {
     unsafe fn to_rust(from: CJID) -> Self {

--- a/whatsrust/src/message_send.rs
+++ b/whatsrust/src/message_send.rs
@@ -1,7 +1,6 @@
 use std::ffi::{CString, c_char, c_void};
 
 use crate::{
-    ForwardFailure, ForwardReport,
     abi::{CFileMessage, CJID, CTextMessage, MessageType},
     file_kind_discriminant,
     models::{JID, Mention, Message, MessageContent},
@@ -315,5 +314,34 @@ mod tests {
         };
         assert_eq!(pointers.len(), 1);
         assert_eq!(file.mentioned_count, 1);
+    }
+}
+use strum::FromRepr;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ForwardReport {
+    pub succeeded: usize,
+    pub failed: usize,
+    pub failure: ForwardFailure,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, FromRepr)]
+#[repr(u8)]
+pub enum ForwardFailure {
+    #[default]
+    None = 0,
+    SourceUnavailable = 1,
+    InvalidSource = 2,
+    InvalidDestination = 3,
+    SendFailed = 4,
+}
+
+impl ForwardReport {
+    pub fn with_reason(succeeded: usize, failed: usize, failure: ForwardFailure) -> Self {
+        Self {
+            succeeded,
+            failed,
+            failure,
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Relocate ForwardReport and ForwardFailure to the message-send owner.
- Preserve the public facade names and representations.

## Changes

- Added forwarding result types and helper implementation to message_send.rs.
- Added explicit public facade reexports.

## Chain Context

- Immediate parent: PR #327.
- This repaired replacement contains only the forwarding work unit.
- Next: final facade cleanup.

## Testing

- [x] cargo fmt --all -- --check
- [x] CARGO_TARGET_DIR=/home/samael/Escritorio/public/wptui-public/target cargo check --workspace --all-targets
- [x] CARGO_TARGET_DIR=/home/samael/Escritorio/public/wptui-public/target cargo test -p whatsrust --lib -- --test-threads=1
- [x] git diff --check

## Review Budget and Rollback

- Authored diff: 63 lines (32 additions + 31 deletions).
- Rollback: revert commit f30fb97.

Closes #329