### PR TITLE
refactor(whatsrust): stage facade test ownership

### DIFF
--- a/whatsrust/src/facade_tests.rs
+++ b/whatsrust/src/facade_tests.rs
@@ -1,53 +1,6 @@
-use std::ffi::CString;
-
-#[macro_use]
-mod callbacks;
-mod abi;
-mod actions;
-mod caches;
-mod events;
-#[cfg(test)]
-mod facade_tests;
-mod incoming;
-mod lifecycle;
-mod media;
-mod message_send;
-mod models;
-mod presence;
-mod queries;
-mod read_sync;
-mod registrations;
-use abi::*;
-pub use abi::{LogoutStatus, ReceiptKind};
-pub use actions::{edit_message, react_to_message, react_to_message_in_chat, revoke_message};
-pub use callbacks::CallbackTranslator;
-pub use events::set_event_handler;
-pub use lifecycle::{connect, disconnect, logout, new_client, pair_phone};
-pub use media::{download_file, get_community_profile_picture, get_profile_picture};
-pub use message_send::{
-    ForwardFailure, ForwardReport, TextSendResult, forward_message, send_message, send_text_message,
-};
-pub(crate) use models::file_kind_discriminant;
-pub use models::{
-    ChatSettings, CommunitiesError, CommunityInfo, Contact, DownloadFailed, Event, FileContent,
-    FileId, FileKind, ForwardingInfo, GroupInfo, GroupInfoError, GroupParticipant, JID,
-    LogoutError, Mention, Message, MessageActionFailed, MessageActionKind, MessageContent,
-    MessageId, MessageInfo, PresenceUpdate, ProfilePicture, ProfilePictureAvailability,
-    ProfilePictureError,
-};
-pub use presence::{SubscribePresenceResult, drain_raw_presence_diagnostics, subscribe_presence};
-pub use queries::{
-    get_chat_settings, get_communities, get_contacts, get_group_info, get_group_participants,
-    resolve_dm_chat,
-};
-pub use read_sync::{MarkAsReadError, mark_as_read, sync_chat_read};
-pub use registrations::{
-    set_log_handler, set_message_handler, set_optimistic_text_sent_handler, set_presence_handler,
-};
-
 #[cfg(test)]
 mod file_kind_tests {
-    use super::{FileKind, file_kind_discriminant};
+    use crate::{FileKind, file_kind_discriminant};
 
     #[test]
     fn ffi_file_kind_discriminants_remain_stable_for_all_media_types() {
@@ -69,9 +22,9 @@ mod file_kind_tests {
 mod message_action_tests {
     use std::ffi::CString;
 
-    use super::actions::{edit_to_ffi, reaction_to_ffi, revoke_to_ffi};
-    use super::events::{message_action_event_from_ffi, reaction_event_from_ffi};
-    use super::{CMessageActionEvent, CReactionEvent, Event, JID, MessageActionKind};
+    use crate::actions::{edit_to_ffi, reaction_to_ffi, revoke_to_ffi};
+    use crate::events::{message_action_event_from_ffi, reaction_event_from_ffi};
+    use crate::{CMessageActionEvent, CReactionEvent, Event, JID, MessageActionKind};
 
     #[test]
     fn reaction_mapping_preserves_every_ordinary_message_field() {
@@ -148,7 +101,7 @@ mod message_action_tests {
     fn revoke_mapping_preserves_every_field() {
         let chat = JID::from("1234567890@s.whatsapp.net".to_owned());
         let sender = JID::from("0987654321@s.whatsapp.net".to_owned());
-        let message_id: super::MessageId = "message".into();
+        let message_id: crate::MessageId = "message".into();
         let (cchat, csender, cid) = revoke_to_ffi(&chat, &sender, &message_id).unwrap();
 
         assert_eq!(cchat.to_str().unwrap(), "1234567890@s.whatsapp.net");
@@ -159,8 +112,8 @@ mod message_action_tests {
     #[test]
     fn revoke_mapping_rejects_nul_before_the_ffi_boundary() {
         let jid = JID::from("1234567890@s.whatsapp.net".to_owned());
-        let invalid_id: super::MessageId = "message\0id".into();
-        let valid_id: super::MessageId = "message".into();
+        let invalid_id: crate::MessageId = "message\0id".into();
+        let valid_id: crate::MessageId = "message".into();
 
         assert!(revoke_to_ffi(&jid, &jid, &invalid_id).is_err());
         assert!(revoke_to_ffi(&jid, &jid, &valid_id).is_ok());
@@ -217,7 +170,7 @@ mod presence_event_tests {
         sync::{Mutex, mpsc},
     };
 
-    use super::{
+    use crate::{
         C_TestEmitPresenceEvent, C_TestEmitPresenceEventsConcurrently, PresenceUpdate,
         set_presence_handler,
     };
@@ -264,26 +217,5 @@ mod presence_event_tests {
             assert!(!update.unavailable);
             assert_eq!(update.last_seen, expected);
         }
-    }
-}
-
-pub use caches::{forward_source, message_mention_ranges, message_push_name};
-pub use caches::{
-    remove_forward_source, store_forward_source, store_message_mention_ranges,
-    store_message_push_name,
-};
-
-pub const VIEW_ONCE_UNAVAILABLE_DESCRIPTION: &str =
-    "View-once media is unavailable here. View it on your phone.";
-
-impl CallbackTranslator<CJID> for JID {
-    unsafe fn to_rust(from: CJID) -> Self {
-        (&from).into()
-    }
-}
-
-impl CallbackTranslator<i64> for i64 {
-    unsafe fn to_rust(value: i64) -> Self {
-        value
     }
 }


### PR DESCRIPTION
## Summary

- Move the residual facade tests into a dedicated test module without changing test behavior.

## Changes

- Added facade_tests.rs containing the existing tests.
- Registered the module while retaining the original tests for this staged chain slice.

## Chain Context

- Immediate parent: PR #332.
- Next child removes the duplicate facade test copies and leaves the facade implementation-only.
- Diagram: #327 -> #332 -> 📍 this PR -> final facade cleanup.

## Testing

- [x] cargo fmt --all -- --check
- [x] CARGO_TARGET_DIR=/home/samael/Escritorio/public/wptui-public/target cargo check --workspace --all-targets
- [x] CARGO_TARGET_DIR=/home/samael/Escritorio/public/wptui-public/target cargo test -p whatsrust --lib -- --test-threads=1
- [x] git diff --check

## Review Budget and Rollback

- Authored diff: 223 lines (223 additions, 0 deletions).
- Rollback: revert commit e4da981.

Closes #331