### PR TITLE
refactor(whatsrust): remove final facade-owned definitions

### DIFF
--- a/whatsrust/src/actions.rs
+++ b/whatsrust/src/actions.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+
 use super::*;
 
 pub(crate) fn reaction_to_ffi(

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -2,8 +2,6 @@
 //! Implementation and focused tests live in owning modules.
 //! Explicit reexports keep the public API boundary auditable.
 
-use std::ffi::CString;
-
 #[macro_use]
 mod callbacks;
 mod abi;
@@ -37,7 +35,7 @@ pub use models::{
     FileId, FileKind, ForwardingInfo, GroupInfo, GroupInfoError, GroupParticipant, JID,
     LogoutError, Mention, Message, MessageActionFailed, MessageActionKind, MessageContent,
     MessageId, MessageInfo, PresenceUpdate, ProfilePicture, ProfilePictureAvailability,
-    ProfilePictureError,
+    ProfilePictureError, VIEW_ONCE_UNAVAILABLE_DESCRIPTION,
 };
 pub use presence::{SubscribePresenceResult, drain_raw_presence_diagnostics, subscribe_presence};
 pub use queries::{
@@ -54,18 +52,3 @@ pub use caches::{
     remove_forward_source, store_forward_source, store_message_mention_ranges,
     store_message_push_name,
 };
-
-pub const VIEW_ONCE_UNAVAILABLE_DESCRIPTION: &str =
-    "View-once media is unavailable here. View it on your phone.";
-
-impl CallbackTranslator<CJID> for JID {
-    unsafe fn to_rust(from: CJID) -> Self {
-        (&from).into()
-    }
-}
-
-impl CallbackTranslator<i64> for i64 {
-    unsafe fn to_rust(value: i64) -> Self {
-        value
-    }
-}

--- a/whatsrust/src/lifecycle.rs
+++ b/whatsrust/src/lifecycle.rs
@@ -1,4 +1,4 @@
-use std::ffi::{CStr, c_char};
+use std::ffi::{CStr, CString, c_char};
 
 use super::*;
 

--- a/whatsrust/src/media.rs
+++ b/whatsrust/src/media.rs
@@ -1,4 +1,7 @@
-use std::{ffi::CStr, path::Path};
+use std::{
+    ffi::{CStr, CString},
+    path::Path,
+};
 
 use super::*;
 

--- a/whatsrust/src/models.rs
+++ b/whatsrust/src/models.rs
@@ -6,6 +6,7 @@ use std::{
 use strum::{EnumIter, FromRepr};
 
 use crate::abi::{CContact, CJID, LogoutStatus, ReceiptKind};
+use crate::callbacks::CallbackTranslator;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct JID(pub Arc<str>);
@@ -33,6 +34,15 @@ impl From<&JID> for CJID {
         CString::new(jid.0.as_ref()).unwrap().into_raw()
     }
 }
+
+impl CallbackTranslator<CJID> for JID {
+    unsafe fn to_rust(from: CJID) -> Self {
+        (&from).into()
+    }
+}
+
+pub const VIEW_ONCE_UNAVAILABLE_DESCRIPTION: &str =
+    "View-once media is unavailable here. View it on your phone.";
 
 pub type MessageId = Arc<str>;
 

--- a/whatsrust/src/presence.rs
+++ b/whatsrust/src/presence.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::{CStr, c_char},
+    ffi::{CStr, CString, c_char},
     sync::atomic::{AtomicUsize, Ordering},
 };
 

--- a/whatsrust/src/registrations.rs
+++ b/whatsrust/src/registrations.rs
@@ -20,6 +20,12 @@ impl CallbackTranslator<u8> for u8 {
     }
 }
 
+impl CallbackTranslator<i64> for i64 {
+    unsafe fn to_rust(value: i64) -> Self {
+        value
+    }
+}
+
 pub fn set_presence_handler<F>(mut callback: F)
 where
     F: FnMut(PresenceUpdate) + 'static,


### PR DESCRIPTION
## Summary

- Move the last constant and callback translator implementations out of `whatsrust/src/lib.rs`.
- Keep the existing public API and ABI while making the facade declarations and explicit reexports only.
- Closes #336.

## Changes

- Moved `CallbackTranslator<CJID> for JID` to `models.rs`.
- Moved `CallbackTranslator<i64> for i64` to `registrations.rs`.
- Moved `VIEW_ONCE_UNAVAILABLE_DESCRIPTION` to `models.rs` and reexported it.
- Relocated required `CString` imports to their owning modules and removed the lib.rs residue.

## Chain Context

- Immediate parent: PR #335, exact base `refactor/whatsrust-facade-final` at `7a4d8b1`.
- Diagram: PR #335 -> 📍 this PR.
- Start: PR #335 leaves residual callback translators, a public model constant, and a shared CString import in the facade.
- End: `whatsrust/src/lib.rs` is a 54-line module-and-reexport facade with no constants, impls, unsafe blocks, or logic.
- Follow-up: none; this is the final facade cleanup slice.
- Out of scope: behavior, ABI, and unrelated refactors.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/public/wptui-public/target cargo check --workspace --all-targets`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/public/wptui-public/target cargo test -p whatsrust --lib -- --test-threads=1` (24 passed)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/public/wptui-public/target cargo test --test whatsrust_api_contract -- --test-threads=1` (1 passed)
- [x] `go test ./...` and `go vet ./...` in `whatsrust/lib` (passed)
- [x] `git diff --check`
- [ ] Full `cargo test --workspace -- --test-threads=1`: attempted, but the shared filesystem had no free space (`No space left on device`).
- [ ] Manual/runtime testing: N/A; this is a source ownership refactor with no behavior change.

## Review Budget and Rollback

- Authored diff: 46 lines (25 additions + 21 deletions), under the 400-line budget.
- Commit: `5cbbd3d`.
- Rollback: revert `5cbbd3d`; this removes only the final facade ownership cleanup and restores PR #335 source layout.

## Contributor Checklist

- [x] Linked issue #336.
- [x] Added exactly one `type:*` label: `type:refactor`.
- [x] Ran formatting and diff checks.
- [x] Ran Rust workspace check and focused/API tests.
- [x] Ran Go tests and vet; no Go files changed.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailer.

Closes #336