### PR TITLE
refactor(whatsrust): make ABI dependencies explicit

### DIFF
--- a/whatsrust/src/actions.rs
+++ b/whatsrust/src/actions.rs
@@ -1,6 +1,7 @@
 use std::ffi::CString;
 
 use super::*;
+use crate::abi::{C_EditMessage, C_ReactToMessage, C_RevokeMessage};
 
 pub(crate) fn reaction_to_ffi(
     target_jid: &JID,

--- a/whatsrust/src/facade_tests.rs
+++ b/whatsrust/src/facade_tests.rs
@@ -22,9 +22,10 @@ mod file_kind_tests {
 mod message_action_tests {
     use std::ffi::CString;
 
+    use crate::abi::{CMessageActionEvent, CReactionEvent};
     use crate::actions::{edit_to_ffi, reaction_to_ffi, revoke_to_ffi};
     use crate::events::{message_action_event_from_ffi, reaction_event_from_ffi};
-    use crate::{CMessageActionEvent, CReactionEvent, Event, JID, MessageActionKind};
+    use crate::{Event, JID, MessageActionKind};
 
     #[test]
     fn reaction_mapping_preserves_every_ordinary_message_field() {
@@ -171,7 +172,8 @@ mod presence_event_tests {
     };
 
     use crate::{
-        C_TestEmitPresenceEvent, C_TestEmitPresenceEventsConcurrently, PresenceUpdate,
+        PresenceUpdate,
+        abi::{C_TestEmitPresenceEvent, C_TestEmitPresenceEventsConcurrently},
         set_presence_handler,
     };
 

--- a/whatsrust/src/lib.rs
+++ b/whatsrust/src/lib.rs
@@ -19,7 +19,6 @@ mod presence;
 mod queries;
 mod read_sync;
 mod registrations;
-use abi::*;
 pub use abi::{LogoutStatus, ReceiptKind};
 pub use actions::{edit_message, react_to_message, react_to_message_in_chat, revoke_message};
 pub use callbacks::CallbackTranslator;

--- a/whatsrust/src/lifecycle.rs
+++ b/whatsrust/src/lifecycle.rs
@@ -1,6 +1,9 @@
 use std::ffi::{CStr, CString, c_char};
 
 use super::*;
+use crate::abi::{
+    C_Connect, C_Disconnect, C_FreePairPhoneResult, C_Logout, C_NewClient, C_PairPhone,
+};
 
 impl CallbackTranslator<*const c_char> for String {
     unsafe fn to_rust(ptr: *const c_char) -> String {

--- a/whatsrust/src/media.rs
+++ b/whatsrust/src/media.rs
@@ -4,6 +4,10 @@ use std::{
 };
 
 use super::*;
+use crate::abi::{
+    C_DownloadFile, C_FreeProfilePicture, C_GetCommunityProfilePicture, C_GetProfilePicture, CJID,
+    CProfilePictureResult,
+};
 
 fn profile_picture_from_parts(
     status: u8,

--- a/whatsrust/src/presence.rs
+++ b/whatsrust/src/presence.rs
@@ -4,6 +4,9 @@ use std::{
 };
 
 use super::*;
+use crate::abi::{
+    C_DrainRawPresenceDiagnostics, C_FreeRawPresenceDiagnostics, C_SubscribePresence,
+};
 
 static PRESENCE_CALLBACK_INGRESS: AtomicUsize = AtomicUsize::new(0);
 

--- a/whatsrust/src/queries.rs
+++ b/whatsrust/src/queries.rs
@@ -2,12 +2,12 @@ use std::ffi::CStr;
 use std::sync::Arc;
 
 use super::{
+    ChatSettings, CommunitiesError, CommunityInfo, GroupInfo, GroupInfoError, GroupParticipant, JID,
+};
+use crate::abi::{
     C_FreeCommunities, C_FreeContacts, C_FreeGroupParticipants, C_FreeResolveDmChatId,
     C_GetChatSettings, C_GetCommunities, C_GetContacts, C_GetGroupInfo, C_GetGroupParticipants,
     C_ResolveDmChatId, CJID,
-};
-use super::{
-    ChatSettings, CommunitiesError, CommunityInfo, GroupInfo, GroupInfoError, GroupParticipant, JID,
 };
 
 /// Returns all contacts and groups as (JID, display name). Includes LID aliases for contacts.

--- a/whatsrust/src/read_sync.rs
+++ b/whatsrust/src/read_sync.rs
@@ -1,9 +1,7 @@
 use std::ffi::{CString, c_char};
 
-use crate::{
-    abi::*,
-    models::{JID, MessageId},
-};
+use crate::abi::{C_MarkAsRead, C_MarkChatReadSync};
+use crate::models::{JID, MessageId};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MarkAsReadError {

--- a/whatsrust/src/registrations.rs
+++ b/whatsrust/src/registrations.rs
@@ -1,6 +1,10 @@
 use std::ffi::c_char;
 
 use super::*;
+use crate::abi::{
+    C_SetLogHandler, C_SetMessageHandler, C_SetOptimisticTextSentHandler, C_SetPresenceHandler,
+    CJID, CMessage,
+};
 
 impl CallbackTranslator<bool> for bool {
     unsafe fn to_rust(value: bool) -> Self {


### PR DESCRIPTION
## Summary

- Remove the private `use abi::*;` facade import.
- Make every affected Rust module and facade test import its ABI symbols from `crate::abi` explicitly.
- Preserve behavior, public API, and ABI while making coupling auditable.

## Changes

| File | Change |
|---|---|
| `whatsrust/src/lib.rs` | Removed the wildcard ABI import; facade now contains module declarations and explicit reexports only. |
| `whatsrust/src/{actions,facade_tests,lifecycle,media,presence,queries,read_sync,registrations}.rs` | Added or relocated explicit `crate::abi::{...}` imports for required bridge symbols. |

## Chain Context

- Immediate parent: PR #337, exact base `refactor/whatsrust-facade-final-cleanup` at `5cbbd3d`.
- Diagram: PR #337 -> 📍 this PR.
- Start: PR #337 leaves private wildcard ABI coupling available to child modules and tests.
- End: ABI consumers declare their dependencies explicitly; no wildcard ABI import was added elsewhere.
- Follow-up: none; this is the final child cleanup slice.
- Out of scope: behavior, public API, ABI, unrelated refactors, merge, and CI waiting.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo check -p whatsrust --all-targets` (passed, no warnings introduced)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test -p whatsrust --lib -- --test-threads=1` (24 passed)
- [x] `CARGO_TARGET_DIR=/home/samael/Escritorio/Programacion/public/wptui-public/target cargo test --test whatsrust_api_contract -- --test-threads=1` (1 passed)
- [x] Verified no `use abi::*` or `abi::*` remains in Rust sources.
- [ ] Manual/runtime testing: N/A; source-ownership refactor with no behavior change.
- [ ] Full workspace tests: not run; outside this focused child budget.

## Review Budget and Rollback

- Authored diff: 34 lines (24 additions + 10 deletions), under the 400-line budget.
- Commit: `acd43c4`.
- Rollback: revert `acd43c4`; this restores only the wildcard-import source layout on top of PR #337.

## Contributor Checklist

- [x] Linked issue #338.
- [x] Added exactly one `type:*` label: `type:refactor`.
- [x] Ran formatting and diff checks.
- [x] Ran focused whatsrust and API tests.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailer.

Closes #338