### PR TITLE
refactor(app): extract terminal key translation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -62,6 +62,7 @@ pub mod status_actions;
 pub mod status_input;
 pub mod status_projection;
 pub mod terminal_session;
+pub mod terminal_input_translation;
 #[cfg(test)]
 pub(crate) mod test_support;
 pub mod unread_messages;

--- a/src/app.rs
+++ b/src/app.rs
@@ -61,8 +61,8 @@ pub mod share_picker_input;
 pub mod status_actions;
 pub mod status_input;
 pub mod status_projection;
-pub mod terminal_session;
 pub mod terminal_input_translation;
+pub mod terminal_session;
 #[cfg(test)]
 pub(crate) mod test_support;
 pub mod unread_messages;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -1,4 +1,4 @@
-use ratatui::crossterm::event::{Event, KeyEventKind};
+use ratatui::crossterm::event::Event;
 
 use crate::app::App;
 use crate::app::actions::{
@@ -14,6 +14,7 @@ use crate::app::input_mapping::{
 use crate::app::leader_menu::{LeaderMenuContext, build_leader_menu};
 use crate::app::log_toggle::is_toggle_logs_key;
 use crate::app::status_input::status_view_allows;
+use crate::app::terminal_input_translation::translate_terminal_event;
 use crate::input_key::{Key, KeyCode};
 use crate::keybindings::SequenceResolution;
 use crate::keybindings::matches_leader_binding;
@@ -67,46 +68,7 @@ impl App<'_> {
     }
 
     pub fn on_terminal_event(&mut self, event: Event) {
-        if let Event::Key(key_event) = event
-            && key_event.kind == KeyEventKind::Press
-        {
-            let key = Key {
-                code: match key_event.code {
-                    ratatui::crossterm::event::KeyCode::Backspace => KeyCode::Backspace,
-                    ratatui::crossterm::event::KeyCode::Enter => KeyCode::Enter,
-                    ratatui::crossterm::event::KeyCode::Esc => KeyCode::Esc,
-                    ratatui::crossterm::event::KeyCode::Left => KeyCode::Left,
-                    ratatui::crossterm::event::KeyCode::Right => KeyCode::Right,
-                    ratatui::crossterm::event::KeyCode::Up => KeyCode::Up,
-                    ratatui::crossterm::event::KeyCode::Down => KeyCode::Down,
-                    ratatui::crossterm::event::KeyCode::Tab => KeyCode::Tab,
-                    ratatui::crossterm::event::KeyCode::Char(c) => KeyCode::Char(c),
-                    _ => return,
-                },
-                modifiers: {
-                    let mut modifiers = crate::input_key::KeyModifiers::NONE;
-                    if key_event
-                        .modifiers
-                        .contains(ratatui::crossterm::event::KeyModifiers::SHIFT)
-                    {
-                        modifiers = modifiers | crate::input_key::KeyModifiers::SHIFT;
-                    }
-                    if key_event
-                        .modifiers
-                        .contains(ratatui::crossterm::event::KeyModifiers::CONTROL)
-                    {
-                        modifiers = modifiers | crate::input_key::KeyModifiers::CONTROL;
-                    }
-                    if key_event
-                        .modifiers
-                        .contains(ratatui::crossterm::event::KeyModifiers::ALT)
-                    {
-                        modifiers = modifiers | crate::input_key::KeyModifiers::ALT;
-                    }
-                    modifiers
-                },
-            };
-
+        if let Some(key) = translate_terminal_event(&event) {
             if self.pending_logout {
                 if self.logout_in_progress {
                     // The async logout is running (off the event loop). Ignore

--- a/src/app/terminal_input_translation.rs
+++ b/src/app/terminal_input_translation.rs
@@ -1,0 +1,87 @@
+use ratatui::crossterm::event::{Event, KeyCode as TerminalKeyCode, KeyEventKind, KeyModifiers};
+
+use crate::input_key::{Key, KeyCode, KeyModifiers as InputKeyModifiers};
+
+pub(crate) fn translate_terminal_event(event: &Event) -> Option<Key> {
+    let Event::Key(key_event) = event else {
+        return None;
+    };
+    if key_event.kind != KeyEventKind::Press {
+        return None;
+    }
+
+    let code = match key_event.code {
+        TerminalKeyCode::Backspace => KeyCode::Backspace,
+        TerminalKeyCode::Enter => KeyCode::Enter,
+        TerminalKeyCode::Esc => KeyCode::Esc,
+        TerminalKeyCode::Left => KeyCode::Left,
+        TerminalKeyCode::Right => KeyCode::Right,
+        TerminalKeyCode::Up => KeyCode::Up,
+        TerminalKeyCode::Down => KeyCode::Down,
+        TerminalKeyCode::Tab => KeyCode::Tab,
+        TerminalKeyCode::Char(character) => KeyCode::Char(character),
+        _ => return None,
+    };
+
+    let mut modifiers = InputKeyModifiers::NONE;
+    if key_event.modifiers.contains(KeyModifiers::SHIFT) {
+        modifiers = modifiers | InputKeyModifiers::SHIFT;
+    }
+    if key_event.modifiers.contains(KeyModifiers::CONTROL) {
+        modifiers = modifiers | InputKeyModifiers::CONTROL;
+    }
+    if key_event.modifiers.contains(KeyModifiers::ALT) {
+        modifiers = modifiers | InputKeyModifiers::ALT;
+    }
+
+    Some(Key { code, modifiers })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translates_supported_terminal_key_and_modifiers() {
+        let event = Event::Key(
+            ratatui::crossterm::event::KeyEvent::new(
+                TerminalKeyCode::Char('x'),
+                KeyModifiers::SHIFT | KeyModifiers::CONTROL | KeyModifiers::ALT,
+            ),
+        );
+
+        assert_eq!(
+            translate_terminal_event(&event),
+            Some(Key {
+                code: KeyCode::Char('x'),
+                modifiers: InputKeyModifiers::SHIFT
+                    | InputKeyModifiers::CONTROL
+                    | InputKeyModifiers::ALT,
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_non_key_events_and_non_press_keys() {
+        assert_eq!(translate_terminal_event(&Event::Resize(80, 24)), None);
+
+        let release = Event::Key(ratatui::crossterm::event::KeyEvent {
+            code: TerminalKeyCode::Enter,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Release,
+            state: ratatui::crossterm::event::KeyEventState::NONE,
+        });
+
+        assert_eq!(translate_terminal_event(&release), None);
+    }
+
+    #[test]
+    fn ignores_terminal_keys_without_an_input_key_equivalent() {
+        let event = Event::Key(ratatui::crossterm::event::KeyEvent::new(
+            TerminalKeyCode::F(1),
+            KeyModifiers::NONE,
+        ));
+
+        assert_eq!(translate_terminal_event(&event), None);
+    }
+}

--- a/src/app/terminal_input_translation.rs
+++ b/src/app/terminal_input_translation.rs
@@ -43,12 +43,10 @@ mod tests {
 
     #[test]
     fn translates_supported_terminal_key_and_modifiers() {
-        let event = Event::Key(
-            ratatui::crossterm::event::KeyEvent::new(
-                TerminalKeyCode::Char('x'),
-                KeyModifiers::SHIFT | KeyModifiers::CONTROL | KeyModifiers::ALT,
-            ),
-        );
+        let event = Event::Key(ratatui::crossterm::event::KeyEvent::new(
+            TerminalKeyCode::Char('x'),
+            KeyModifiers::SHIFT | KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
 
         assert_eq!(
             translate_terminal_event(&event),


### PR DESCRIPTION
## Summary

- Extract pure terminal event/key translation from `src/app/inputs.rs` into `terminal_input_translation`.
- Preserve supported-key, modifier, press-event, and unsupported-key behavior with focused unit tests.
- Keep `inputs.rs` as the routing/dispatch coordinator; modal routing and dispatch-family splitting are intentionally deferred.

## Changes

- Added `src/app/terminal_input_translation.rs` with pure translation and focused tests.
- Wired the module through `src/app.rs`.
- Replaced inline translation in `src/app/inputs.rs` with the module boundary.

## Testing

- [x] `git diff --check`
- [ ] Cargo tests — pending authorized Cargo validation
- [ ] `cargo fmt --check` — not run; Cargo/tooling execution is restricted for this slice
- [ ] Manual testing — not run; behavior-preserving extraction only

## Chain Context

Start: beta `5be229e`, with terminal translation embedded in `src/app/inputs.rs`.

End: terminal event/key translation is isolated behind a pure module; `inputs.rs` remains the routing and dispatch coordinator.

Dependency diagram:

```
beta 5be229e
    \--> 📍 this PR: pure terminal event/key translation
              \--> child 2: modal/context routing
                        \--> child 3: dispatch-family splitting
```

Out of scope: modal routing and dispatch-family splitting.

Closes #340