### PR TITLE
refactor(app): extract modal input routing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,7 @@ pub mod events;
 pub mod file_picker_input;
 pub mod input_mapping;
 pub mod input_reader;
+pub mod input_router;
 pub mod inputs;
 pub mod leader_menu;
 pub mod log_toggle;

--- a/src/app/input_mapping.rs
+++ b/src/app/input_mapping.rs
@@ -66,7 +66,7 @@ pub(crate) fn share_picker_action(key: &Key) -> Option<AppAction> {
 pub(crate) fn reaction_picker_action(key: &Key) -> Option<AppAction> {
     Some(match key.code {
         KeyCode::Char('h') | KeyCode::Left => AppAction::ReactionPrev,
-        KeyCode::Char('l') | KeyCode::Right => AppAction::ReactionNext,
+        KeyCode::Char('l') | KeyCode::Right | KeyCode::Down => AppAction::ReactionNext,
         KeyCode::Enter => AppAction::ConfirmReaction,
         KeyCode::Esc => AppAction::CancelReaction,
         _ => return None,

--- a/src/app/input_router.rs
+++ b/src/app/input_router.rs
@@ -106,10 +106,7 @@ pub(crate) fn route_context_key(
     if focus_pane == FocusPane::ChatList && community_detail && *key == Key::k(KeyCode::Esc) {
         return None;
     }
-    if focus_pane == FocusPane::SectionRail
-        && rail_on_logout
-        && *key == Key::k(KeyCode::Enter)
-    {
+    if focus_pane == FocusPane::SectionRail && rail_on_logout && *key == Key::k(KeyCode::Enter) {
         return None;
     }
     if *key == Key::k(KeyCode::Enter) {
@@ -130,7 +127,13 @@ mod tests {
     #[test]
     fn status_enter_precedes_generic_enter() {
         assert_eq!(
-            route_context_key(&Key::k(KeyCode::Enter), FocusPane::Conversation, Section::Status, false, false),
+            route_context_key(
+                &Key::k(KeyCode::Enter),
+                FocusPane::Conversation,
+                Section::Status,
+                false,
+                false
+            ),
             Some(AppAction::ViewMessage)
         );
     }
@@ -138,15 +141,27 @@ mod tests {
     #[test]
     fn generic_enter_maps_to_the_focused_pane() {
         assert_eq!(
-            route_context_key(&Key::k(KeyCode::Enter), FocusPane::ChatList, Section::Chats, false, false),
+            route_context_key(
+                &Key::k(KeyCode::Enter),
+                FocusPane::ChatList,
+                Section::Chats,
+                false,
+                false
+            ),
             Some(AppAction::OpenChat)
         );
     }
 
     #[test]
     fn picker_routes_only_supported_keys() {
-        assert_eq!(route_modal_key(&Key::k(KeyCode::Down), ModalContext::ReactionPicker), InputRoute::Action(AppAction::ReactionNext));
-        assert_eq!(route_modal_key(&Key::k(KeyCode::Tab), ModalContext::ReactionPicker), InputRoute::Ignore);
+        assert_eq!(
+            route_modal_key(&Key::k(KeyCode::Down), ModalContext::ReactionPicker),
+            InputRoute::Action(AppAction::ReactionNext)
+        );
+        assert_eq!(
+            route_modal_key(&Key::k(KeyCode::Tab), ModalContext::ReactionPicker),
+            InputRoute::Ignore
+        );
     }
 
     #[test]

--- a/src/app/input_router.rs
+++ b/src/app/input_router.rs
@@ -1,0 +1,166 @@
+use crate::app::actions::{AppAction, FocusPane, Section};
+use crate::app::contextual_actions::{ContextualAction, ContextualMenuRow, RowStyle};
+use crate::app::contextual_routing::route_contextual_key;
+use crate::app::input_mapping::{
+    attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
+    message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
+};
+use crate::input_key::{Key, KeyCode};
+use crate::keybindings::matches_leader_binding;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum InputRoute {
+    Action(AppAction),
+    DismissLeader,
+    DismissContextual,
+    ActivateLeader,
+    ActivateContextualShortcut(ContextualAction),
+    ActivateContextualSelection,
+    MoveLeader(isize),
+    MoveContextual(isize),
+    Ignore,
+}
+
+pub(crate) enum ModalContext<'a> {
+    ShortcutPopup,
+    Leader(&'a [crate::app::leader_menu::LeaderMenuRow]),
+    Contextual(&'a [ContextualMenuRow]),
+    AttachmentViewer,
+    UrlPicker,
+    FilePickerSearch,
+    FilePickerNavigation,
+    SharePicker,
+    ReactionPicker,
+    MessageMenu,
+}
+
+pub(crate) fn route_modal_key(key: &Key, context: ModalContext<'_>) -> InputRoute {
+    match context {
+        ModalContext::ShortcutPopup => {
+            if *key == Key::k(KeyCode::Esc) || *key == Key::c('?') {
+                InputRoute::DismissLeader
+            } else {
+                InputRoute::Ignore
+            }
+        }
+        ModalContext::Leader(rows) => {
+            if *key == Key::k(KeyCode::Esc) {
+                InputRoute::DismissLeader
+            } else if *key == Key::k(KeyCode::Enter) {
+                InputRoute::ActivateLeader
+            } else if *key == Key::k(KeyCode::Char('j')) || *key == Key::k(KeyCode::Down) {
+                InputRoute::MoveLeader(1)
+            } else if *key == Key::k(KeyCode::Char('k')) || *key == Key::k(KeyCode::Up) {
+                InputRoute::MoveLeader(-1)
+            } else if rows.iter().any(|row| {
+                row.row_style == RowStyle::Enabled && matches_leader_binding(key, &row.key)
+            }) {
+                InputRoute::ActivateLeader
+            } else {
+                InputRoute::Ignore
+            }
+        }
+        ModalContext::Contextual(rows) => {
+            if *key == Key::k(KeyCode::Esc) {
+                InputRoute::DismissContextual
+            } else if *key == Key::k(KeyCode::Enter) {
+                InputRoute::ActivateContextualSelection
+            } else if *key == Key::k(KeyCode::Char('j')) || *key == Key::k(KeyCode::Down) {
+                InputRoute::MoveContextual(1)
+            } else if *key == Key::k(KeyCode::Char('k')) || *key == Key::k(KeyCode::Up) {
+                InputRoute::MoveContextual(-1)
+            } else if let Some(action) = route_contextual_key(rows, key) {
+                InputRoute::ActivateContextualShortcut(action)
+            } else {
+                InputRoute::Ignore
+            }
+        }
+        ModalContext::AttachmentViewer => mapped(attachment_viewer_action(key)),
+        ModalContext::UrlPicker => mapped(url_picker_action(key)),
+        ModalContext::FilePickerSearch => mapped(file_picker_search_action(key)),
+        ModalContext::FilePickerNavigation => mapped(file_picker_navigation_action(key)),
+        ModalContext::SharePicker => mapped(share_picker_action(key)),
+        ModalContext::ReactionPicker => mapped(reaction_picker_action(key)),
+        ModalContext::MessageMenu => mapped(message_menu_action(key)),
+    }
+}
+
+fn mapped(action: Option<AppAction>) -> InputRoute {
+    action.map_or(InputRoute::Ignore, InputRoute::Action)
+}
+
+pub(crate) fn route_context_key(
+    key: &Key,
+    focus_pane: FocusPane,
+    selected_section: Section,
+    community_detail: bool,
+    rail_on_logout: bool,
+) -> Option<AppAction> {
+    if focus_pane == FocusPane::Conversation && selected_section == Section::Status {
+        return match key.code {
+            KeyCode::Esc => Some(AppAction::CloseStatusPane),
+            KeyCode::Enter => Some(AppAction::ViewMessage),
+            _ => None,
+        };
+    }
+    if focus_pane == FocusPane::ChatList && community_detail && *key == Key::k(KeyCode::Esc) {
+        return None;
+    }
+    if focus_pane == FocusPane::SectionRail
+        && rail_on_logout
+        && *key == Key::k(KeyCode::Enter)
+    {
+        return None;
+    }
+    if *key == Key::k(KeyCode::Enter) {
+        return Some(match focus_pane {
+            FocusPane::SectionRail => AppAction::FocusPane(FocusPane::ChatList),
+            FocusPane::ChatList => AppAction::OpenChat,
+            FocusPane::Conversation => AppAction::OpenContextualActions,
+        });
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::actions::Section;
+
+    #[test]
+    fn status_enter_precedes_generic_enter() {
+        assert_eq!(
+            route_context_key(&Key::k(KeyCode::Enter), FocusPane::Conversation, Section::Status, false, false),
+            Some(AppAction::ViewMessage)
+        );
+    }
+
+    #[test]
+    fn generic_enter_maps_to_the_focused_pane() {
+        assert_eq!(
+            route_context_key(&Key::k(KeyCode::Enter), FocusPane::ChatList, Section::Chats, false, false),
+            Some(AppAction::OpenChat)
+        );
+    }
+
+    #[test]
+    fn picker_routes_only_supported_keys() {
+        assert_eq!(route_modal_key(&Key::k(KeyCode::Down), ModalContext::ReactionPicker), InputRoute::Action(AppAction::ReactionNext));
+        assert_eq!(route_modal_key(&Key::k(KeyCode::Tab), ModalContext::ReactionPicker), InputRoute::Ignore);
+    }
+
+    #[test]
+    fn contextual_enter_preserves_selected_row_activation() {
+        let rows = [ContextualMenuRow {
+            action_token: ContextualAction::Quit,
+            display_label: "Quit",
+            display_shortcut: 'q',
+            row_style: RowStyle::Enabled,
+            reason: None,
+        }];
+        assert_eq!(
+            route_modal_key(&Key::k(KeyCode::Enter), ModalContext::Contextual(&rows)),
+            InputRoute::ActivateContextualSelection
+        );
+    }
+}

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -79,7 +79,10 @@ impl App<'_> {
                 self.dispatch_action(AppAction::ToggleLogs);
             } else if self.handle_composer_input(key.clone()) {
             } else if self.shortcut_popup {
-                if matches!(route_modal_key(&key, ModalContext::ShortcutPopup), InputRoute::DismissLeader) {
+                if matches!(
+                    route_modal_key(&key, ModalContext::ShortcutPopup),
+                    InputRoute::DismissLeader
+                ) {
                     self.shortcut_popup = false;
                 }
             } else if self.leader_menu.is_some() {
@@ -118,7 +121,9 @@ impl App<'_> {
                     _ => {}
                 }
             } else if self.attachment_viewer.is_some() {
-                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::AttachmentViewer) {
+                if let InputRoute::Action(action) =
+                    route_modal_key(&key, ModalContext::AttachmentViewer)
+                {
                     self.dispatch_action(action);
                 }
             } else if self.url_picker.is_some() {
@@ -129,25 +134,33 @@ impl App<'_> {
                 // Search mode: the keyboard buffer owns every key except the
                 // explicit exits, so `h/j/k/l` build the filter instead of
                 // moving. Esc leaves search mode back to navigation.
-                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::FilePickerSearch) {
+                if let InputRoute::Action(action) =
+                    route_modal_key(&key, ModalContext::FilePickerSearch)
+                {
                     self.dispatch_action(action);
                 }
             } else if self.file_picker.is_some() {
                 // Navigation mode. `h/l` move across the tree, `Enter` commits
                 // (files under the cursor, or every `Space`-selected file).
-                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::FilePickerNavigation) {
+                if let InputRoute::Action(action) =
+                    route_modal_key(&key, ModalContext::FilePickerNavigation)
+                {
                     self.dispatch_action(action);
                 }
             } else if self.share_picker.is_some() {
-                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::SharePicker) {
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::SharePicker)
+                {
                     self.dispatch_action(action);
                 }
             } else if self.reaction_picker.is_some() {
-                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::ReactionPicker) {
+                if let InputRoute::Action(action) =
+                    route_modal_key(&key, ModalContext::ReactionPicker)
+                {
                     self.dispatch_action(action);
                 }
             } else if self.message_menu.is_some() {
-                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::MessageMenu) {
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::MessageMenu)
+                {
                     self.dispatch_action(action);
                 }
             } else if self.focus_pane == FocusPane::Conversation
@@ -155,9 +168,9 @@ impl App<'_> {
             {
                 // Read-only status view: Esc returns to the contact list and
                 // Enter opens the fullscreen viewer on a media status.
-                if let Some(action) = route_context_key(
-                    &key, self.focus_pane, self.selected_section, false, false,
-                ) {
+                if let Some(action) =
+                    route_context_key(&key, self.focus_pane, self.selected_section, false, false)
+                {
                     self.dispatch_action(action);
                 } else {
                     match self.kh.resolve(key.clone()) {

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -6,11 +6,7 @@ use crate::app::actions::{
 };
 pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
 pub use crate::app::composer_input_paste::apply_clipboard_paste;
-use crate::app::contextual_routing::route_contextual_key;
-use crate::app::input_mapping::{
-    attachment_viewer_action, file_picker_navigation_action, file_picker_search_action,
-    message_menu_action, reaction_picker_action, share_picker_action, url_picker_action,
-};
+use crate::app::input_router::{InputRoute, ModalContext, route_context_key, route_modal_key};
 use crate::app::leader_menu::{LeaderMenuContext, build_leader_menu};
 use crate::app::log_toggle::is_toggle_logs_key;
 use crate::app::status_input::status_view_allows;
@@ -83,88 +79,86 @@ impl App<'_> {
                 self.dispatch_action(AppAction::ToggleLogs);
             } else if self.handle_composer_input(key.clone()) {
             } else if self.shortcut_popup {
-                if key == Key::k(KeyCode::Esc) || key == Key::c('?') {
+                if matches!(route_modal_key(&key, ModalContext::ShortcutPopup), InputRoute::DismissLeader) {
                     self.shortcut_popup = false;
                 }
             } else if self.leader_menu.is_some() {
-                if key == Key::k(KeyCode::Esc) {
-                    self.leader_menu = None;
-                    self.kh.key_buffer.clear();
-                    self.kh.key_sequence_active = false;
-                } else if key == Key::k(KeyCode::Enter) {
-                    self.activate_leader_selection();
-                } else if key == Key::k(KeyCode::Char('j')) || key == Key::k(KeyCode::Down) {
-                    self.move_leader_menu(1);
-                } else if key == Key::k(KeyCode::Char('k')) || key == Key::k(KeyCode::Up) {
-                    self.move_leader_menu(-1);
-                } else {
-                    self.activate_leader_key(key);
+                let route = route_modal_key(
+                    &key,
+                    ModalContext::Leader(&self.leader_menu.as_ref().unwrap().0),
+                );
+                match route {
+                    InputRoute::DismissLeader => {
+                        self.leader_menu = None;
+                        self.kh.key_buffer.clear();
+                        self.kh.key_sequence_active = false;
+                    }
+                    InputRoute::ActivateLeader => {
+                        if key == Key::k(KeyCode::Enter) {
+                            self.activate_leader_selection();
+                        } else {
+                            self.activate_leader_key(key);
+                        }
+                    }
+                    InputRoute::MoveLeader(delta) => self.move_leader_menu(delta),
+                    _ => {}
                 }
             } else if self.contextual_menu.is_some() {
-                if key == Key::k(KeyCode::Esc) {
-                    self.contextual_menu = None;
-                } else if key == Key::k(KeyCode::Enter) {
-                    self.activate_contextual_action();
-                } else if key == Key::k(KeyCode::Char('j')) || key == Key::k(KeyCode::Down) {
-                    self.move_contextual_menu(1);
-                } else if key == Key::k(KeyCode::Char('k')) || key == Key::k(KeyCode::Up) {
-                    self.move_contextual_menu(-1);
-                } else if let Some(action) = self
-                    .contextual_menu
-                    .as_ref()
-                    .and_then(|(rows, _)| route_contextual_key(rows, &key))
-                {
-                    self.activate_contextual_shortcut(action);
+                let route = route_modal_key(
+                    &key,
+                    ModalContext::Contextual(&self.contextual_menu.as_ref().unwrap().0),
+                );
+                match route {
+                    InputRoute::DismissContextual => self.contextual_menu = None,
+                    InputRoute::ActivateContextualSelection => self.activate_contextual_action(),
+                    InputRoute::ActivateContextualShortcut(action) => {
+                        self.activate_contextual_shortcut(action)
+                    }
+                    InputRoute::MoveContextual(delta) => self.move_contextual_menu(delta),
+                    _ => {}
                 }
             } else if self.attachment_viewer.is_some() {
-                let Some(action) = attachment_viewer_action(&key) else {
-                    return;
-                };
-                self.dispatch_action(action);
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::AttachmentViewer) {
+                    self.dispatch_action(action);
+                }
             } else if self.url_picker.is_some() {
-                let Some(action) = url_picker_action(&key) else {
-                    return;
-                };
-                self.dispatch_action(action);
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::UrlPicker) {
+                    self.dispatch_action(action);
+                }
             } else if self.file_picker.is_some() && self.file_picker.as_ref().unwrap().searching {
                 // Search mode: the keyboard buffer owns every key except the
                 // explicit exits, so `h/j/k/l` build the filter instead of
                 // moving. Esc leaves search mode back to navigation.
-                let Some(action) = file_picker_search_action(&key) else {
-                    return;
-                };
-                self.dispatch_action(action);
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::FilePickerSearch) {
+                    self.dispatch_action(action);
+                }
             } else if self.file_picker.is_some() {
                 // Navigation mode. `h/l` move across the tree, `Enter` commits
                 // (files under the cursor, or every `Space`-selected file).
-                let Some(action) = file_picker_navigation_action(&key) else {
-                    return;
-                };
-                self.dispatch_action(action);
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::FilePickerNavigation) {
+                    self.dispatch_action(action);
+                }
             } else if self.share_picker.is_some() {
-                let Some(action) = share_picker_action(&key) else {
-                    return;
-                };
-                self.dispatch_action(action);
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::SharePicker) {
+                    self.dispatch_action(action);
+                }
             } else if self.reaction_picker.is_some() {
-                let Some(action) = reaction_picker_action(&key) else {
-                    return;
-                };
-                self.dispatch_action(action);
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::ReactionPicker) {
+                    self.dispatch_action(action);
+                }
             } else if self.message_menu.is_some() {
-                let Some(action) = message_menu_action(&key) else {
-                    return;
-                };
-                self.dispatch_action(action);
+                if let InputRoute::Action(action) = route_modal_key(&key, ModalContext::MessageMenu) {
+                    self.dispatch_action(action);
+                }
             } else if self.focus_pane == FocusPane::Conversation
                 && self.selected_section == Section::Status
             {
                 // Read-only status view: Esc returns to the contact list and
                 // Enter opens the fullscreen viewer on a media status.
-                if key == Key::k(KeyCode::Esc) {
-                    self.dispatch_action(AppAction::CloseStatusPane);
-                } else if key == Key::k(KeyCode::Enter) {
-                    self.dispatch_action(AppAction::ViewMessage);
+                if let Some(action) = route_context_key(
+                    &key, self.focus_pane, self.selected_section, false, false,
+                ) {
+                    self.dispatch_action(action);
                 } else {
                     match self.kh.resolve(key.clone()) {
                         SequenceResolution::Complete(action) => self.dispatch_action(action),
@@ -183,15 +177,22 @@ impl App<'_> {
                 && key == Key::k(KeyCode::Enter)
             {
                 self.begin_logout_confirmation();
+            } else if let Some(action) = route_context_key(
+                &key,
+                self.focus_pane,
+                self.selected_section,
+                self.community_detail.is_some(),
+                self.rail_on_logout,
+            ) {
+                self.dispatch_action(action);
             } else if key == Key::k(KeyCode::Enter) {
-                match self.focus_pane {
-                    FocusPane::SectionRail => {
-                        self.dispatch_action(AppAction::FocusPane(FocusPane::ChatList))
-                    }
-                    FocusPane::ChatList => self.dispatch_action(AppAction::OpenChat),
-                    FocusPane::Conversation => {
-                        self.dispatch_action(AppAction::OpenContextualActions)
-                    }
+                if self.focus_pane == FocusPane::ChatList
+                    && self.community_detail.is_some()
+                    && key == Key::k(KeyCode::Enter)
+                {
+                    self.dispatch_action(AppAction::OpenChat);
+                } else if self.focus_pane == FocusPane::SectionRail && self.rail_on_logout {
+                    self.begin_logout_confirmation();
                 }
             } else {
                 match self.kh.resolve(key.clone()) {


### PR DESCRIPTION
## Summary

- Extract modal/context precedence and key-to-`AppAction` routing from `src/app/inputs.rs`.
- Preserve dispatch as the domain side-effect boundary and keep dispatch-family splitting out of this slice.
- Add focused precedence and modal routing tests.

## Changes

- Added `src/app/input_router.rs` with modal and focused-context routing outcomes.
- Replaced duplicated precedence branches in `src/app/inputs.rs` with the router boundary.
- Wired the router module through `src/app.rs`.

## Testing

- [x] `git diff --check`
- [ ] `cargo test -- --test-threads=1` — pending orchestrator Cargo validation
- [ ] `cargo fmt --check` — not run; Cargo/tooling execution is restricted for this slice
- [ ] Manual testing — not run; behavior-preserving extraction with focused unit tests

## Chain Context

Start: PR #341 (`refactor/rust-input-key-translation`), where terminal translation is already isolated.

End: modal/context precedence and routing are isolated behind `input_router`; `dispatch_action` remains the domain side-effect boundary.

Dependency diagram:

```
PR #341: terminal event/key translation
    \--> 📍 this PR: modal/context routing
              \--> child 3: dispatch-family splitting
```

Out of scope: dispatch-family splitting and domain side-effect extraction.

Closes #342