### PR TITLE
refactor(whatsrust): centralize client session access

### DIFF
--- a/whatsrust/lib/client_lifecycle.go
+++ b/whatsrust/lib/client_lifecycle.go
@@ -28,9 +28,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// client remains package-owned because the other bridge actions use the same
-// client after this lifecycle boundary is crossed. The QR stream and handler
-// registration state live here so reconnect setup has one resettable owner.
+// client remains package-owned until the remaining bridge callers migrate to
+// clientSnapshot. Publication and reset are centralized in lifecycleState so
+// the migrated callers observe one synchronized lifecycle boundary.
 var client *whatsmeow.Client
 
 type clientLifecycleState struct {
@@ -59,6 +59,7 @@ func (state *clientLifecycleState) publishClient(newClient *whatsmeow.Client) {
 func (state *clientLifecycleState) reset() {
 	state.mu.Lock()
 	defer state.mu.Unlock()
+	client = nil
 	state.qrChan = nil
 	state.handlersRegistered = false
 }
@@ -103,7 +104,8 @@ func requestFullHistorySync() {
 //export C_Connect
 func C_Connect(handler C.QrCallback, data unsafe.Pointer) {
 	AddEventHandlers()
-	if client.Store.ID == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot.Store.ID == nil {
 		LOG_INFO(
 			"Pairing: DeviceProps require_full_sync=%t days_limit=%d size_mb=%d platform=%s",
 			store.DeviceProps.GetRequireFullSync(),
@@ -112,10 +114,10 @@ func C_Connect(handler C.QrCallback, data unsafe.Pointer) {
 			store.DeviceProps.GetPlatformType(),
 		)
 		lifecycleState.mu.Lock()
-		lifecycleState.qrChan, _ = client.GetQRChannel(context.Background())
+		lifecycleState.qrChan, _ = clientSnapshot.GetQRChannel(context.Background())
 		qrChannel := lifecycleState.qrChan
 		lifecycleState.mu.Unlock()
-		if err := client.Connect(); err != nil {
+		if err := clientSnapshot.Connect(); err != nil {
 			panic(err)
 		}
 
@@ -129,14 +131,15 @@ func C_Connect(handler C.QrCallback, data unsafe.Pointer) {
 		}
 		return
 	}
-	if err := client.Connect(); err != nil {
+	if err := clientSnapshot.Connect(); err != nil {
 		panic(err)
 	}
 }
 
 //export C_PairPhone
 func C_PairPhone(phone *C.char) *C.char {
-	code, err := client.PairPhone(context.Background(), C.GoString(phone), true, whatsmeow.PairClientChrome, "Chrome (Linux)")
+	clientSnapshot := lifecycleState.clientSnapshot()
+	code, err := clientSnapshot.PairPhone(context.Background(), C.GoString(phone), true, whatsmeow.PairClientChrome, "Chrome (Linux)")
 	if err != nil {
 		panic(err)
 	}
@@ -155,7 +158,8 @@ func C_FreePairPhoneResult(result *C.char) {
 
 //export C_Disconnect
 func C_Disconnect() {
-	client.Disconnect()
+	clientSnapshot := lifecycleState.clientSnapshot()
+	clientSnapshot.Disconnect()
 	clearAuthenticatedPushNameCache()
 }
 
@@ -178,11 +182,12 @@ func logoutStatusAfterRemoteFailure(localDeleteErr error) uint8 {
 //export C_Logout
 func C_Logout() C.uint8_t {
 	status := logoutStatusLoggedOut
-	if client == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil {
 		status = logoutStatusNotLoggedIn
 	} else {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		err := client.Logout(ctx)
+		err := clientSnapshot.Logout(ctx)
 		cancel()
 		switch {
 		case err == nil:
@@ -191,11 +196,11 @@ func C_Logout() C.uint8_t {
 			status = logoutStatusNotLoggedIn
 		default:
 			LOG_ERROR("Logout: remote revocation failed, clearing locally only: %v", err)
-			client.Disconnect()
-			if client.Store == nil {
+			clientSnapshot.Disconnect()
+			if clientSnapshot.Store == nil {
 				status = logoutStatusLocalOnly
 			} else {
-				localDeleteErr := client.Store.Delete(context.Background())
+				localDeleteErr := clientSnapshot.Store.Delete(context.Background())
 				if localDeleteErr != nil {
 					LOG_ERROR("Logout: failed to clear local store: %v", localDeleteErr)
 				}

--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -22,15 +22,22 @@ func TestClientLifecycleRegistrationIsIdempotent(t *testing.T) {
 
 func TestClientLifecycleResetClearsRegistrationAndQR(t *testing.T) {
 	qr := make(chan whatsmeow.QRChannelItem)
+	previous := client
+	t.Cleanup(func() { lifecycleState.publishClient(previous) })
+	testClient := &whatsmeow.Client{}
 	state := clientLifecycleState{
 		qrChan:             qr,
 		handlersRegistered: true,
 	}
+	state.publishClient(testClient)
 
 	state.reset()
 
 	if state.qrChan != nil {
 		t.Fatal("reset retained QR channel")
+	}
+	if state.clientSnapshot() != nil {
+		t.Fatal("reset retained client")
 	}
 	if state.handlersRegistered {
 		t.Fatal("reset retained handler registration")
@@ -50,6 +57,8 @@ func TestClientLifecycleClientSnapshotUsesLifecycleLock(t *testing.T) {
 
 func TestClientLifecyclePublicationIsSynchronized(t *testing.T) {
 	var state clientLifecycleState
+	previous := client
+	t.Cleanup(func() { lifecycleState.publishClient(previous) })
 	first, second := &whatsmeow.Client{}, &whatsmeow.Client{}
 	state.publishClient(first)
 
@@ -74,6 +83,8 @@ func TestClientLifecyclePublicationIsSynchronized(t *testing.T) {
 
 func TestClientLifecycleOperationKeepsOneSnapshot(t *testing.T) {
 	var state clientLifecycleState
+	previous := client
+	t.Cleanup(func() { lifecycleState.publishClient(previous) })
 	first, second := &whatsmeow.Client{}, &whatsmeow.Client{}
 	state.publishClient(first)
 	snapshotTaken := make(chan *whatsmeow.Client)
@@ -91,6 +102,28 @@ func TestClientLifecycleOperationKeepsOneSnapshot(t *testing.T) {
 	close(release)
 	if got := state.clientSnapshot(); got != second {
 		t.Fatalf("published client = %p, want %p", got, second)
+	}
+}
+
+func TestClientLifecycleReconnectPublishesReplacementSnapshot(t *testing.T) {
+	var state clientLifecycleState
+	previous := client
+	t.Cleanup(func() { lifecycleState.publishClient(previous) })
+	first, second := &whatsmeow.Client{}, &whatsmeow.Client{}
+
+	state.publishClient(first)
+	if got := state.clientSnapshot(); got != first {
+		t.Fatalf("initial client snapshot = %p, want %p", got, first)
+	}
+
+	state.reset()
+	if got := state.clientSnapshot(); got != nil {
+		t.Fatalf("snapshot after reset = %p, want nil", got)
+	}
+
+	state.publishClient(second)
+	if got := state.clientSnapshot(); got != second {
+		t.Fatalf("reconnect client snapshot = %p, want %p", got, second)
 	}
 }
 

--- a/whatsrust/lib/event_wiring.go
+++ b/whatsrust/lib/event_wiring.go
@@ -71,13 +71,14 @@ func AddEventHandlers() {
 
 func addEventHandlers() {
 	viewOnceDispatcher := newViewOnceUnavailableDispatcher(HandleViewOnceUnavailableMessage)
-	client.AddEventHandler(func(rawEvt any) {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	clientSnapshot.AddEventHandler(func(rawEvt any) {
 		messageActionCensusDiagnostic(rawEvt)
 		switch evt := rawEvt.(type) {
 		case *events.Connected:
-			handleConnected(client.SendPresence, dispatchConnectedEvent, LOG_WARN)
+			handleConnected(clientSnapshot.SendPresence, dispatchConnectedEvent, LOG_WARN)
 		case *events.Presence:
-			dispatchPresenceEvent(evt, client.Store.LIDs.GetPNForLID, rawPresenceProbe.record, rawPresenceProbe.update, dispatchPresenceCallback)
+			dispatchPresenceEvent(evt, clientSnapshot.Store.LIDs.GetPNForLID, rawPresenceProbe.record, rawPresenceProbe.update, dispatchPresenceCallback)
 		case *events.MarkChatAsRead:
 			dispatchMarkChatAsReadEvent(evt)
 		case *events.AppStateSyncComplete:
@@ -90,12 +91,12 @@ func addEventHandlers() {
 		case *events.UndecryptableMessage:
 			dispatchUndecryptableMessage(evt, viewOnceDispatcher.dispatchOnce)
 		case *events.Receipt:
-			if receipt, ok := receiptEventFromEventWithClient(client, evt); ok {
+			if receipt, ok := receiptEventFromEventWithClient(clientSnapshot, evt); ok {
 				LOG_DEBUG("%#v was read by %s at %s", evt.MessageIDs, evt.SourceString(), evt.Timestamp)
 				dispatchReceiptEvent(receipt)
 			}
 		case *events.HistorySync:
-			dispatchHistorySync(evt, client.DangerousInternals().StoreHistoricalMessageSecrets, client.ParseWebMessage, func(parsed *events.Message) {
+			dispatchHistorySync(evt, clientSnapshot.DangerousInternals().StoreHistoricalMessageSecrets, clientSnapshot.ParseWebMessage, func(parsed *events.Message) {
 				dispatchIncomingMessage(parsed, dispatchMessageActionEvent, func(info types.MessageInfo, message *waE2E.Message, _ bool) {
 					HandleMessage(info, message, true)
 				}, viewOnceDispatcher.dispatchOnce)

--- a/whatsrust/lib/event_wiring_test.go
+++ b/whatsrust/lib/event_wiring_test.go
@@ -66,7 +66,7 @@ func TestEventWiringOwnsRegistrationAndDispatchCases(t *testing.T) {
 	body := string(source)
 	for _, expected := range []string{
 		"func AddEventHandlers()",
-		"client.AddEventHandler(func(rawEvt any)",
+		"clientSnapshot.AddEventHandler(func(rawEvt any)",
 		"case *events.Connected:",
 		"case *events.Presence:",
 		"case *events.AppStateSyncComplete:",


### PR DESCRIPTION
## Summary

- Routes the initial lifecycle and event-wiring runtime callers through the synchronized client snapshot accessor.
- Keeps publication/reset ownership in the lifecycle state while preserving the existing cgo ABI and reconnect behavior.

## Changes

- Reset now clears the published client alongside QR and handler state.
- Connect, phone pairing, disconnect, logout, and event registration use one captured lifecycle snapshot.
- Added focused publication, reset, snapshot, and reconnect tests.

## Chain Context

- Start: beta `5be229e`, with lifecycle registration already established.
- Current slice: first chained Go session-access boundary; this PR is the review point.
- Follow-up: migrate the next coherent runtime caller family (outbound send/query/action/media consumers) without broad event-family splitting.
- Out of scope: Rust callers, Cargo verification, full event-family migration, and send/query/action/media migration.

## Testing

- [x] `cd whatsrust/lib && go test ./... -run 'TestClientLifecycle|TestEventWiring' -count=1`
- [x] `cd whatsrust/lib && go test ./... -count=1`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `git diff --check`
- [ ] Cargo checks (not run by request)
- [ ] Manual testing (not applicable; Go lifecycle boundary tests cover this slice)

Closes #262
