### PR TITLE
refactor(whatsrust): route outbound callers through lifecycle client

### DIFF
--- a/whatsrust/lib/forwarding_orchestration.go
+++ b/whatsrust/lib/forwarding_orchestration.go
@@ -37,14 +37,15 @@ func forwardMessages(sourceID, sourceChat, sourceSender string, sourceIsFromMe b
 	if err != nil {
 		return forwardingReport{failed: uint32(len(destinations)), failure: forwardFailureInvalidSource}
 	}
-	if client == nil || client.Store == nil || client.Store.ID == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || clientSnapshot.Store == nil || clientSnapshot.Store.ID == nil {
 		return forwardingReport{failed: uint32(len(request.destinations)), failure: forwardFailureSendFailed}
 	}
 	sourceMessage, failure := forwardSourceFromBytes(rawSource)
 	if failure != forwardFailureNone {
 		return forwardingReport{failed: uint32(len(request.destinations)), failure: failure}
 	}
-	sourceOwned := sourceOwnedByCurrentUser(sourceIsFromMe, request.sourceSender, *client.Store.ID)
+	sourceOwned := sourceOwnedByCurrentUser(sourceIsFromMe, request.sourceSender, *clientSnapshot.Store.ID)
 	report := forwardingReport{}
 	for _, destination := range request.destinations {
 		message, err := prepareForwardMessage(sourceMessage, sourceOwned)
@@ -52,14 +53,14 @@ func forwardMessages(sourceID, sourceChat, sourceSender string, sourceIsFromMe b
 			report.failed++
 			continue
 		}
-		response, err := client.SendMessage(context.Background(), destination, message)
+		response, err := clientSnapshot.SendMessage(context.Background(), destination, message)
 		if err != nil {
 			LOG_WARN("forward send failed: %v", err)
 			report.failed++
 			continue
 		}
 		report.succeeded++
-		HandleMessage(types.MessageInfo{MessageSource: types.MessageSource{Chat: destination, Sender: *client.Store.ID, IsFromMe: true}, ID: response.ID, Timestamp: response.Timestamp}, message, false)
+		HandleMessage(types.MessageInfo{MessageSource: types.MessageSource{Chat: destination, Sender: *clientSnapshot.Store.ID, IsFromMe: true}, ID: response.ID, Timestamp: response.Timestamp}, message, false)
 	}
 	return report
 }

--- a/whatsrust/lib/mention_parity_test.go
+++ b/whatsrust/lib/mention_parity_test.go
@@ -90,10 +90,10 @@ func TestNormalAndOptimisticProductionRoutesHaveWireAndCallbackParity(t *testing
 	otherLID := types.NewJID("222", types.HiddenUserServer)
 	selfLID := types.NewJID("444", types.HiddenUserServer)
 	client = &whatsmeow.Client{Store: &store.Device{
-		ID:       &self,
-		LID:      selfLID,
+		ID:  &self,
+		LID: selfLID,
 		Contacts: parityContactStore{contacts: map[types.JID]types.ContactInfo{
-			self: {FullName: "Álvaro"},
+			self:    {FullName: "Álvaro"},
 			otherPN: {FullName: "李雷"},
 		}},
 		LIDs: participantIdentityLIDStore{
@@ -117,7 +117,7 @@ func TestNormalAndOptimisticProductionRoutesHaveWireAndCallbackParity(t *testing
 
 	var sent []*waE2E.Message
 	var outputs []textCallbackOutput
-	requestSendMessage = func(_ context.Context, _ types.JID, message *waE2E.Message) (whatsmeow.SendResponse, error) {
+	requestSendMessage = func(_ *whatsmeow.Client, _ context.Context, _ types.JID, message *waE2E.Message) (whatsmeow.SendResponse, error) {
 		sent = append(sent, message)
 		return whatsmeow.SendResponse{ID: "server-1"}, nil
 	}

--- a/whatsrust/lib/message_actions.go
+++ b/whatsrust/lib/message_actions.go
@@ -35,16 +35,20 @@ func C_ReactToMessage(targetJID C.JID, destinationJID C.JID, senderJID C.JID, me
 		LOG_WARN("reaction rejected: %v", err)
 		return 1
 	}
-	message, err := buildOrdinaryReaction(client, request.target, request.sender, request.id, request.reaction)
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || clientSnapshot.Store == nil || clientSnapshot.Store.ID == nil {
+		return 1
+	}
+	message, err := buildOrdinaryReaction(clientSnapshot, request.target, request.sender, request.id, request.reaction)
 	if err != nil {
 		LOG_WARN("reaction rejected: %v", err)
 		return 1
 	}
-	if _, err := client.SendMessage(context.Background(), request.destination, message); err != nil {
+	if _, err := clientSnapshot.SendMessage(context.Background(), request.destination, message); err != nil {
 		LOG_WARN("reaction send failed: %v", err)
 		return 1
 	}
-	HandleMessage(types.MessageInfo{MessageSource: types.MessageSource{Chat: request.destination, Sender: *client.Store.ID, IsFromMe: true}}, message, false)
+	HandleMessage(types.MessageInfo{MessageSource: types.MessageSource{Chat: request.destination, Sender: *clientSnapshot.Store.ID, IsFromMe: true}}, message, false)
 	return 0
 }
 
@@ -57,12 +61,16 @@ func C_EditMessage(chatJID C.JID, messageID *C.char, replacement *C.char) C.uint
 	if err != nil {
 		return 1
 	}
-	message, err := buildOrdinaryEdit(client, chat, types.MessageID(C.GoString(messageID)), C.GoString(replacement))
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil {
+		return 1
+	}
+	message, err := buildOrdinaryEdit(clientSnapshot, chat, types.MessageID(C.GoString(messageID)), C.GoString(replacement))
 	if err != nil {
 		LOG_WARN("edit rejected: %v", err)
 		return 1
 	}
-	if _, err := client.SendMessage(context.Background(), chat, message); err != nil {
+	if _, err := clientSnapshot.SendMessage(context.Background(), chat, message); err != nil {
 		LOG_WARN("edit send failed: %v", err)
 		return 1
 	}
@@ -83,12 +91,16 @@ func C_RevokeMessage(chatJID C.JID, senderJID C.JID, messageID *C.char) C.uint8_
 		return 1
 	}
 	id := types.MessageID(C.GoString(messageID))
-	message, err := buildOrdinaryRevoke(client, chat, sender, id)
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil {
+		return 1
+	}
+	message, err := buildOrdinaryRevoke(clientSnapshot, chat, sender, id)
 	if err != nil {
 		LOG_WARN("revoke rejected: %v", err)
 		return 1
 	}
-	if _, err := client.SendMessage(context.Background(), chat, message); err != nil {
+	if _, err := clientSnapshot.SendMessage(context.Background(), chat, message); err != nil {
 		LOG_WARN("revoke send failed: %v", err)
 		return 1
 	}

--- a/whatsrust/lib/message_send.go
+++ b/whatsrust/lib/message_send.go
@@ -34,9 +34,9 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
-type sendMessageRequest func(context.Context, types.JID, *waE2E.Message) (whatsmeow.SendResponse, error)
+type sendMessageRequest func(*whatsmeow.Client, context.Context, types.JID, *waE2E.Message) (whatsmeow.SendResponse, error)
 
-var requestSendMessage sendMessageRequest = func(ctx context.Context, jid types.JID, message *waE2E.Message) (whatsmeow.SendResponse, error) {
+var requestSendMessage sendMessageRequest = func(client *whatsmeow.Client, ctx context.Context, jid types.JID, message *waE2E.Message) (whatsmeow.SendResponse, error) {
 	return client.SendMessage(ctx, jid, message)
 }
 
@@ -52,14 +52,14 @@ type textSendQuote struct {
 
 type textSendRequest struct {
 	messageType   uint8
-	chat         types.JID
-	text         string
+	chat          types.JID
+	text          string
 	mentionedJIDs []string
-	fileKind     uint8
-	filePath     string
-	caption      *string
-	quote        *textSendQuote
-	localSendID  uint64
+	fileKind      uint8
+	filePath      string
+	caption       *string
+	quote         *textSendQuote
+	localSendID   uint64
 }
 
 const optimisticTextSendTimeout = 5 * time.Second
@@ -71,6 +71,10 @@ func optimisticTextSendContext(parent context.Context, timeout time.Duration) (c
 // ContentToWaE2EMessage converts the public FFI payload into a WhatsApp
 // message. File construction remains delegated to the injectable builder.
 func ContentToWaE2EMessage(messageType C.uint8_t, messageContent unsafe.Pointer, contextInfo *waE2E.ContextInfo) *waE2E.Message {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil {
+		panic("WhatsApp client is unavailable")
+	}
 	switch messageType {
 	case C.uint8_t(MessageTypeText):
 		textMsg := (*C.SendTextMessage)(messageContent)
@@ -82,7 +86,7 @@ func ContentToWaE2EMessage(messageType C.uint8_t, messageContent unsafe.Pointer,
 			"",
 			nil,
 			contextInfo,
-			client.Upload,
+			clientSnapshot.Upload,
 		)
 
 	case C.uint8_t(MessageTypeFile):
@@ -102,7 +106,7 @@ func ContentToWaE2EMessage(messageType C.uint8_t, messageContent unsafe.Pointer,
 			filePath,
 			caption,
 			contextInfo,
-			client.Upload,
+			clientSnapshot.Upload,
 		)
 
 	default:
@@ -244,9 +248,9 @@ func textSendRequestFromC(cjid C.JID, messageType C.uint8_t, messageContent unsa
 		return textSendRequest{}, false
 	}
 	request := textSendRequest{
-		messageType:   uint8(messageType),
-		chat:          cToJid(cjid),
-		localSendID:   localSendID,
+		messageType: uint8(messageType),
+		chat:        cToJid(cjid),
+		localSendID: localSendID,
 	}
 	switch messageType {
 	case C.uint8_t(MessageTypeText):
@@ -289,7 +293,8 @@ func sendOptimisticTextRequest(request textSendRequest) uint8 {
 }
 
 func sendTextRequest(request textSendRequest) uint8 {
-	if client == nil || client.Store == nil || client.Store.ID == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || clientSnapshot.Store == nil || clientSnapshot.Store.ID == nil {
 		LOG_WARN("message send rejected: client or message is unavailable")
 		return 1
 	}
@@ -298,7 +303,7 @@ func sendTextRequest(request textSendRequest) uint8 {
 		contextInfo = quotedContextInfo(request.quote.stanzaID, request.quote.participant, request.quote.remoteJID)
 		contextInfo.QuotedMessage = request.quote.content
 	}
-	message := contentToWaE2EMessage(request.messageType, request.text, normalizeMentionedJIDs(request.mentionedJIDs), request.fileKind, request.filePath, request.caption, contextInfo, client.Upload)
+	message := contentToWaE2EMessage(request.messageType, request.text, normalizeMentionedJIDs(request.mentionedJIDs), request.fileKind, request.filePath, request.caption, contextInfo, clientSnapshot.Upload)
 
 	sendContext := context.Background()
 	if request.localSendID != 0 {
@@ -306,14 +311,14 @@ func sendTextRequest(request textSendRequest) uint8 {
 		sendContext, cancel = optimisticTextSendContext(sendContext, optimisticTextSendTimeout)
 		defer cancel()
 	}
-	sendResponse, err := requestSendMessage(sendContext, request.chat, message)
+	sendResponse, err := requestSendMessage(clientSnapshot, sendContext, request.chat, message)
 	if err != nil {
 		LOG_WARN("message send failed: %v", err)
 		return 1
 	}
 
 	messageInfo := types.MessageInfo{
-		MessageSource: types.MessageSource{Chat: request.chat, Sender: *client.Store.ID, IsFromMe: true},
+		MessageSource: types.MessageSource{Chat: request.chat, Sender: *clientSnapshot.Store.ID, IsFromMe: true},
 		ID:            sendResponse.ID,
 		Timestamp:     sendResponse.Timestamp,
 	}

--- a/whatsrust/lib/message_send_test.go
+++ b/whatsrust/lib/message_send_test.go
@@ -136,7 +136,7 @@ func TestOptimisticTextSendUsesRequestScopedCallbackInsteadOfGenericLocalState(t
 		"sendOptimisticTextRequest(request)",
 		"request.localSendID != 0",
 		"optimisticTextSentCallback(request.localSendID, messageInfo, message)",
-		"requestSendMessage(sendContext, request.chat, message)",
+		"requestSendMessage(clientSnapshot, sendContext, request.chat, message)",
 	} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("optimistic text send missing request-scoped fragment %q", fragment)
@@ -167,5 +167,17 @@ func TestOptimisticTextSendContextHonorsCancellation(t *testing.T) {
 	cancel()
 	if err := ctx.Err(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("cancelled context error = %v, want context canceled", err)
+	}
+}
+
+func TestOutboundSendCallersUseLifecycleClientSnapshots(t *testing.T) {
+	for _, file := range []string{"message_send.go", "message_actions.go", "forwarding_orchestration.go"} {
+		source, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(source), "lifecycleState.clientSnapshot()") {
+			t.Fatalf("%s does not capture a lifecycle client snapshot", file)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Routes outbound message sends, message actions, and forwarding through the lifecycle-owned client snapshot.
- Preserves the existing cgo entrypoints and callback behavior while preventing direct global-client reads in this caller family.
- Closes #262.

## Changes

- Captures one lifecycle client snapshot per outbound send/action/forward operation.
- Passes the captured client into the injectable message-send request boundary.
- Returns the existing failure status when the lifecycle client or required store identity is unavailable.
- Adds focused accessor coverage and updates the existing send parity test seam.

## Chain Context

```text
beta `5be229e`
    |
    +--> PR #344 `refactor/go-client-session-access`
              |
              +--> 📍 PR (this slice) `refactor/go-client-runtime-callers`
                         |
                         +--> next: remaining query/media callers, then event families
```

- Start: parent PR #344, commit `7a057e2`.
- Current boundary: `message_send.go`, `message_actions.go`, and `forwarding_orchestration.go`, plus focused tests.
- Follow-up: migrate the next cohesive query/media or remaining outbound caller family.
- Out of scope: event-family splitting, Rust callers, and Cargo verification.

## Testing

- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` applied to modified Go files
- [x] `git diff --check`
- [x] Manual testing not applicable; focused Go boundary tests cover this slice.

Closes #262
