### PR TITLE
refactor(app): extract picker and viewer action dispatch

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 pub mod actions;
+pub mod action_dispatch;
 pub mod attachment_viewer;
 pub mod bootstrap;
 pub mod chat_navigation;

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,8 +6,8 @@ use std::{
     sync::Mutex,
 };
 
-pub mod actions;
 pub mod action_dispatch;
+pub mod actions;
 pub mod attachment_viewer;
 pub mod bootstrap;
 pub mod chat_navigation;

--- a/src/app/action_dispatch.rs
+++ b/src/app/action_dispatch.rs
@@ -1,0 +1,100 @@
+use crate::app::App;
+use crate::app::actions::AppAction;
+
+impl App<'_> {
+    pub(crate) fn dispatch_picker_viewer_action(
+        &mut self,
+        action: AppAction,
+    ) -> Result<(), AppAction> {
+        match action {
+            AppAction::DownloadMessage => self.plan_selected_media_launch(),
+            AppAction::ViewMessage => self.open_attachment_viewer(),
+            AppAction::ViewerNext => self.navigate_viewer(1),
+            AppAction::ViewerPrevious => self.navigate_viewer(-1),
+            AppAction::ViewerZoomIn => {
+                self.viewer_zoom = self.viewer_zoom.saturating_add(25).min(400);
+                self.viewer_preview = None;
+            }
+            AppAction::ViewerZoomOut => {
+                self.viewer_zoom = self.viewer_zoom.saturating_sub(25).max(25);
+                self.viewer_preview = None;
+            }
+            AppAction::ViewerOpenExternal => self.plan_viewer_media_launch(),
+            AppAction::CloseAttachmentViewer => {
+                self.attachment_viewer = None;
+                self.viewer_preview = None;
+            }
+            AppAction::CloseStatusPane => self.focus_pane = crate::app::actions::FocusPane::ChatList,
+            AppAction::OpenMessageMenu => self.open_message_menu(),
+            AppAction::MenuNext => self.move_menu(1),
+            AppAction::MenuPrevious => self.move_menu(-1),
+            AppAction::ConfirmMessageMenu => self.confirm_message_menu(),
+            AppAction::CancelMessageMenu => {
+                self.message_menu = None;
+                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
+            }
+            AppAction::SharePickerPrevious => self.move_share_picker(-1),
+            AppAction::SharePickerNext => self.move_share_picker(1),
+            AppAction::ToggleShareRecipient => self.toggle_share_recipient(),
+            AppAction::ConfirmShare => self.confirm_share(),
+            AppAction::CancelShare => {
+                self.share_picker = None;
+                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
+            }
+            AppAction::ShareSearchBackspace => self.share_search_backspace(),
+            AppAction::ShareSearchCharacter(character) => self.share_search_character(character),
+            action @ (AppAction::ReactionPrev
+            | AppAction::ReactionNext
+            | AppAction::ConfirmReaction
+            | AppAction::CancelReaction) => self.dispatch_reaction_picker_action(action),
+            AppAction::UrlPickerPrevious => self.move_url_picker(-1),
+            AppAction::UrlPickerNext => self.move_url_picker(1),
+            AppAction::ConfirmUrlPicker => self.confirm_url_picker(),
+            AppAction::CancelUrlPicker => {
+                self.url_picker = None;
+                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
+            }
+            action @ (AppAction::AttachFile
+            | AppAction::FilePickerPrevious
+            | AppAction::FilePickerNext
+            | AppAction::FilePickerParent
+            | AppAction::FilePickerDescend
+            | AppAction::FilePickerToggle
+            | AppAction::FilePickerConfirm
+            | AppAction::FilePickerEnterSearch
+            | AppAction::FilePickerEndSearch
+            | AppAction::FilePickerBackspace
+            | AppAction::FilePickerCharacter(_)
+            | AppAction::CancelFilePicker) => self.dispatch_file_picker_action(action),
+            other => return Err(other),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::actions::FocusPane;
+    use crate::app::test_support::TestApp;
+
+    #[test]
+    fn viewer_zoom_actions_are_handled_by_the_picker_viewer_family() {
+        let mut app = TestApp::new();
+
+        app.dispatch_action(AppAction::ViewerZoomIn);
+        assert_eq!(app.viewer_zoom, 125);
+        app.dispatch_action(AppAction::ViewerZoomOut);
+        assert_eq!(app.viewer_zoom, 100);
+    }
+
+    #[test]
+    fn closing_status_pane_returns_focus_to_chat_list() {
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::Conversation;
+
+        app.dispatch_action(AppAction::CloseStatusPane);
+
+        assert_eq!(app.focus_pane, FocusPane::ChatList);
+    }
+}

--- a/src/app/action_dispatch.rs
+++ b/src/app/action_dispatch.rs
@@ -24,7 +24,9 @@ impl App<'_> {
                 self.attachment_viewer = None;
                 self.viewer_preview = None;
             }
-            AppAction::CloseStatusPane => self.focus_pane = crate::app::actions::FocusPane::ChatList,
+            AppAction::CloseStatusPane => {
+                self.focus_pane = crate::app::actions::FocusPane::ChatList
+            }
             AppAction::OpenMessageMenu => self.open_message_menu(),
             AppAction::MenuNext => self.move_menu(1),
             AppAction::MenuPrevious => self.move_menu(-1),

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -277,6 +277,11 @@ impl App<'_> {
             return;
         }
 
+        let action = match self.dispatch_picker_viewer_action(action) {
+            Ok(()) => return,
+            Err(action) => action,
+        };
+
         match action {
             AppAction::Quit => {
                 self.db_handler.stop();
@@ -406,67 +411,6 @@ impl App<'_> {
                 }
             }
             AppAction::OpenMessage => self.open_selected_url(),
-            AppAction::DownloadMessage => self.plan_selected_media_launch(),
-            AppAction::ViewMessage => self.open_attachment_viewer(),
-            AppAction::ViewerNext => self.navigate_viewer(1),
-            AppAction::ViewerPrevious => self.navigate_viewer(-1),
-            AppAction::ViewerZoomIn => {
-                self.viewer_zoom = self.viewer_zoom.saturating_add(25).min(400);
-                self.viewer_preview = None;
-            }
-            AppAction::ViewerZoomOut => {
-                self.viewer_zoom = self.viewer_zoom.saturating_sub(25).max(25);
-                self.viewer_preview = None;
-            }
-            AppAction::ViewerOpenExternal => self.plan_viewer_media_launch(),
-            AppAction::CloseAttachmentViewer => {
-                self.attachment_viewer = None;
-                self.viewer_preview = None;
-            }
-            AppAction::CloseStatusPane => {
-                self.focus_pane = FocusPane::ChatList;
-            }
-            AppAction::OpenMessageMenu => self.open_message_menu(),
-            AppAction::MenuNext => self.move_menu(1),
-            AppAction::MenuPrevious => self.move_menu(-1),
-            AppAction::ConfirmMessageMenu => self.confirm_message_menu(),
-            AppAction::CancelMessageMenu => {
-                self.message_menu = None;
-                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
-            }
-            AppAction::SharePickerPrevious => self.move_share_picker(-1),
-            AppAction::SharePickerNext => self.move_share_picker(1),
-            AppAction::ToggleShareRecipient => self.toggle_share_recipient(),
-            AppAction::ConfirmShare => self.confirm_share(),
-            AppAction::CancelShare => {
-                self.share_picker = None;
-                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
-            }
-            AppAction::ShareSearchBackspace => self.share_search_backspace(),
-            AppAction::ShareSearchCharacter(character) => self.share_search_character(character),
-            action @ (AppAction::ReactionPrev
-            | AppAction::ReactionNext
-            | AppAction::ConfirmReaction
-            | AppAction::CancelReaction) => self.dispatch_reaction_picker_action(action),
-            AppAction::UrlPickerPrevious => self.move_url_picker(-1),
-            AppAction::UrlPickerNext => self.move_url_picker(1),
-            AppAction::ConfirmUrlPicker => self.confirm_url_picker(),
-            AppAction::CancelUrlPicker => {
-                self.url_picker = None;
-                self.action_notice = Some(crate::app::actions::ActionNotice::Cancelled);
-            }
-            action @ (AppAction::AttachFile
-            | AppAction::FilePickerPrevious
-            | AppAction::FilePickerNext
-            | AppAction::FilePickerParent
-            | AppAction::FilePickerDescend
-            | AppAction::FilePickerToggle
-            | AppAction::FilePickerConfirm
-            | AppAction::FilePickerEnterSearch
-            | AppAction::FilePickerEndSearch
-            | AppAction::FilePickerBackspace
-            | AppAction::FilePickerCharacter(_)
-            | AppAction::CancelFilePicker) => self.dispatch_file_picker_action(action),
             AppAction::GoToReference => {
                 if !self.follow_selected_reference() {
                     self.unavailable("Reference is not available");

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -277,12 +277,51 @@ impl App<'_> {
             return;
         }
 
-        let action = match self.dispatch_picker_viewer_action(action) {
-            Ok(()) => return,
-            Err(action) => action,
-        };
-
         match action {
+            action @ (AppAction::DownloadMessage
+            | AppAction::ViewMessage
+            | AppAction::ViewerNext
+            | AppAction::ViewerPrevious
+            | AppAction::ViewerZoomIn
+            | AppAction::ViewerZoomOut
+            | AppAction::ViewerOpenExternal
+            | AppAction::CloseAttachmentViewer
+            | AppAction::CloseStatusPane
+            | AppAction::OpenMessageMenu
+            | AppAction::MenuNext
+            | AppAction::MenuPrevious
+            | AppAction::ConfirmMessageMenu
+            | AppAction::CancelMessageMenu
+            | AppAction::SharePickerPrevious
+            | AppAction::SharePickerNext
+            | AppAction::ToggleShareRecipient
+            | AppAction::ConfirmShare
+            | AppAction::CancelShare
+            | AppAction::ShareSearchBackspace
+            | AppAction::ShareSearchCharacter(_)
+            | AppAction::ReactionPrev
+            | AppAction::ReactionNext
+            | AppAction::ConfirmReaction
+            | AppAction::CancelReaction
+            | AppAction::UrlPickerPrevious
+            | AppAction::UrlPickerNext
+            | AppAction::ConfirmUrlPicker
+            | AppAction::CancelUrlPicker
+            | AppAction::AttachFile
+            | AppAction::FilePickerPrevious
+            | AppAction::FilePickerNext
+            | AppAction::FilePickerParent
+            | AppAction::FilePickerDescend
+            | AppAction::FilePickerToggle
+            | AppAction::FilePickerConfirm
+            | AppAction::FilePickerEnterSearch
+            | AppAction::FilePickerEndSearch
+            | AppAction::FilePickerBackspace
+            | AppAction::FilePickerCharacter(_)
+            | AppAction::CancelFilePicker) => {
+                self.dispatch_picker_viewer_action(action)
+                    .expect("picker/viewer action family must be handled by its dispatcher");
+            }
             AppAction::Quit => {
                 self.db_handler.stop();
                 self.should_quit = true;


### PR DESCRIPTION
## Summary

- Extract the picker, message-menu, file-picker, URL-picker, reaction-picker, and attachment-viewer branches from dispatch_action.
- Keep dispatch_action as the policy gate and orchestration entry point while the extracted family owns its action effects.
- Add focused tests for viewer zoom and status-pane closure.

## Changes

- Add src/app/action_dispatch.rs with the picker/viewer action-family handler and tests.
- Register the new module in src/app.rs.
- Delegate picker/viewer actions from src/app/inputs.rs without changing behavior.

## Chain Context

- Parent: PR #343 / refactor/rust-input-context-routing
- Current: 📍 picker/viewer action dispatch
- Follow-up: lifecycle/settings and navigation/conversation action families
- Dependency: this PR must merge after the context-routing parent and before the remaining dispatch families.

```text
PR #343 (context routing)
        |
        v
📍 this PR (picker/viewer dispatch)
        |
        v
follow-up dispatch families
```

## Boundary

Start: dispatch_action contains all action effects after input context routing.
End: picker/viewer action effects live in action_dispatch.rs; dispatch_action retains guards and remaining families.

## Testing

- [x] git diff --check
- [ ] Cargo tests — pending orchestrator
- [ ] cargo fmt --check — pending orchestrator
- [ ] Manual testing — pending orchestrator

Closes #346