### PR TITLE
refactor(whatsrust): route query callers through lifecycle client

### DIFF
--- a/whatsrust/lib/chat_settings_ffi.go
+++ b/whatsrust/lib/chat_settings_ffi.go
@@ -29,14 +29,15 @@ func chatSettingsPayloadToC(payload chatSettingsPayload) C.ChatSettings {
 
 //export C_GetChatSettings
 func C_GetChatSettings(cjid C.JID) C.ChatSettings {
+	clientSnapshot := lifecycleState.clientSnapshot()
 	ctx := context.Background()
 	jid := cToJid(cjid).ToNonAD()
 	settings, err := lookupChatSettings(
 		ctx,
 		jid,
-		client.Store.ChatSettings.GetChatSettings,
-		client.Store.LIDs.GetLIDForPN,
-		client.Store.LIDs.GetPNForLID,
+		clientSnapshot.Store.ChatSettings.GetChatSettings,
+		clientSnapshot.Store.LIDs.GetLIDForPN,
+		clientSnapshot.Store.LIDs.GetPNForLID,
 	)
 	if err != nil {
 		LOG_WARN("failed to get chat settings for %s: %v", jid, err)

--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -2,10 +2,34 @@ package main
 
 import (
 	"errors"
+	"os"
+	"strings"
 	"testing"
 
 	"go.mau.fi/whatsmeow"
 )
+
+func TestQueryAndMediaBridgeCallersUseLifecycleSnapshots(t *testing.T) {
+	for _, file := range []string{
+		"contacts.go",
+		"communities.go",
+		"group_info.go",
+		"group_participants.go",
+		"chat_settings_ffi.go",
+		"dm_resolution.go",
+		"mention_names.go",
+		"media_downloads.go",
+		"profile_picture.go",
+	} {
+		source, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(source), "lifecycleState.clientSnapshot()") {
+			t.Fatalf("%s does not use the lifecycle client snapshot", file)
+		}
+	}
+}
 
 func TestClientLifecycleRegistrationIsIdempotent(t *testing.T) {
 	var state clientLifecycleState

--- a/whatsrust/lib/communities.go
+++ b/whatsrust/lib/communities.go
@@ -125,7 +125,8 @@ func appendCommunityEntry(entries *[]communityEntry, indexes map[types.JID]int, 
 
 //export C_GetCommunities
 func C_GetCommunities() C.GetCommunitiesResult {
-	entries, err := lookupCommunityEntries(context.Background(), client)
+	clientSnapshot := lifecycleState.clientSnapshot()
+	entries, err := lookupCommunityEntries(context.Background(), clientSnapshot)
 	if err != nil {
 		LOG_WARN("Could not load communities: %v", err)
 		return C.GetCommunitiesResult{status: 1}

--- a/whatsrust/lib/contacts.go
+++ b/whatsrust/lib/contacts.go
@@ -60,7 +60,8 @@ func lookupContactEntries(ctx context.Context, bridgeClient *whatsmeow.Client) [
 }
 
 func lookupMentionContactEntries() []contactEntry {
-	entries, err := loadContactEntries(context.Background(), client)
+	clientSnapshot := lifecycleState.clientSnapshot()
+	entries, err := loadContactEntries(context.Background(), clientSnapshot)
 	if err != nil {
 		return nil
 	}
@@ -90,14 +91,15 @@ func loadContactEntries(ctx context.Context, bridgeClient *whatsmeow.Client) ([]
 
 //export C_GetContacts
 func C_GetContacts() C.GetContactsResult {
-	if client == nil || client.Store == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || clientSnapshot.Store == nil {
 		return contactEntriesToC(nil)
 	}
 	ctx := context.Background()
-	entries := lookupContactEntries(ctx, client)
+	entries := lookupContactEntries(ctx, clientSnapshot)
 
 	// Groups remain in this bridge wrapper; contacts.go owns only contact lookup.
-	groups, err := client.GetJoinedGroups(ctx)
+	groups, err := clientSnapshot.GetJoinedGroups(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/whatsrust/lib/dm_resolution.go
+++ b/whatsrust/lib/dm_resolution.go
@@ -35,8 +35,9 @@ func resolveDMChatID(client *whatsmeow.Client, jidText string, resolve dmChatIDR
 //
 //export C_ResolveDmChatId
 func C_ResolveDmChatId(cjid C.JID) *C.char {
-	value, ok := resolveDMChatID(client, C.GoString(cjid), func(jid types.JID) string {
-		return GetChatId(client, &jid, nil)
+	clientSnapshot := lifecycleState.clientSnapshot()
+	value, ok := resolveDMChatID(clientSnapshot, C.GoString(cjid), func(jid types.JID) string {
+		return GetChatId(clientSnapshot, &jid, nil)
 	})
 	if !ok {
 		return nil

--- a/whatsrust/lib/group_info.go
+++ b/whatsrust/lib/group_info.go
@@ -81,8 +81,9 @@ func C_GetGroupInfo(cjid C.JID) C.GroupInfoResult {
 	if cjid == nil {
 		return groupInfoResultToC(groupInfoClientUnavailable)
 	}
-	return groupInfoResultToC(fetchGroupInfo(client, cToJid(cjid).ToNonAD(), func(participant types.GroupParticipant) bool {
-		return participantMatchesSelf(client, participant)
+	clientSnapshot := lifecycleState.clientSnapshot()
+	return groupInfoResultToC(fetchGroupInfo(clientSnapshot, cToJid(cjid).ToNonAD(), func(participant types.GroupParticipant) bool {
+		return participantMatchesSelf(clientSnapshot, participant)
 	}))
 }
 

--- a/whatsrust/lib/group_participants.go
+++ b/whatsrust/lib/group_participants.go
@@ -28,19 +28,20 @@ import (
 
 //export C_GetGroupParticipants
 func C_GetGroupParticipants(cjid C.JID) C.GroupParticipantsResult {
-	if client == nil || cjid == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || cjid == nil {
 		return C.GroupParticipantsResult{}
 	}
-	info, err := client.GetGroupInfo(context.Background(), cToJid(cjid).ToNonAD())
+	info, err := clientSnapshot.GetGroupInfo(context.Background(), cToJid(cjid).ToNonAD())
 	if err != nil || info == nil {
 		return C.GroupParticipantsResult{}
 	}
 	entries := make([]groupParticipantEntry, 0, len(info.Participants))
 	var contacts store.ContactStore
 	var lids store.LIDStore
-	if client.Store != nil {
-		contacts = client.Store.Contacts
-		lids = client.Store.LIDs
+	if clientSnapshot.Store != nil {
+		contacts = clientSnapshot.Store.Contacts
+		lids = clientSnapshot.Store.LIDs
 	}
 	participants := deduplicateGroupParticipants(context.Background(), info.Participants, lids)
 	participants = excludeSelfGroupParticipants(context.Background(), participants)
@@ -68,13 +69,14 @@ func C_GetGroupParticipants(cjid C.JID) C.GroupParticipantsResult {
 }
 
 func groupParticipantName(ctx context.Context, participant types.GroupParticipant, contacts store.ContactStore) string {
+	clientSnapshot := lifecycleState.clientSnapshot()
 	var lids store.LIDStore
-	if client != nil && client.Store != nil {
-		lids = client.Store.LIDs
+	if clientSnapshot != nil && clientSnapshot.Store != nil {
+		lids = clientSnapshot.Store.LIDs
 	}
-	isSelf := participantMatchesSelf(client, participant)
+	isSelf := participantMatchesSelf(clientSnapshot, participant)
 	if isSelf {
-		if name := selfDisplayNameWithContacts(ctx, client, contacts); name != "" {
+		if name := selfDisplayNameWithContacts(ctx, clientSnapshot, contacts); name != "" {
 			return name
 		}
 	}
@@ -114,9 +116,10 @@ func currentUserPushName(client *whatsmeow.Client) string {
 }
 
 func excludeSelfGroupParticipants(ctx context.Context, participants []types.GroupParticipant) []types.GroupParticipant {
+	clientSnapshot := lifecycleState.clientSnapshot()
 	result := make([]types.GroupParticipant, 0, len(participants))
 	for _, participant := range participants {
-		if participantMatchesSelf(client, participant) {
+		if participantMatchesSelf(clientSnapshot, participant) {
 			continue
 		}
 		result = append(result, participant)

--- a/whatsrust/lib/mention_names.go
+++ b/whatsrust/lib/mention_names.go
@@ -158,32 +158,34 @@ func isUserJID(jid types.JID) bool {
 }
 
 func mentionEntriesForGroup(ctx context.Context, group types.JID, mentionedJIDs ...string) []contactEntry {
+	clientSnapshot := lifecycleState.clientSnapshot()
 	if group.Server != types.GroupServer {
 		return lookupMentionContactEntries()
 	}
-	if client == nil || client.Store == nil {
+	if clientSnapshot == nil || clientSnapshot.Store == nil {
 		return nil
 	}
-	info, err := client.GetGroupInfo(ctx, group.ToNonAD())
+	info, err := clientSnapshot.GetGroupInfo(ctx, group.ToNonAD())
 	if err != nil || info == nil {
 		return directMentionEntries(ctx, mentionedJIDs)
 	}
 	entries := make([]contactEntry, 0, len(info.Participants))
-	participants := deduplicateGroupParticipants(ctx, info.Participants, client.Store.LIDs)
+	participants := deduplicateGroupParticipants(ctx, info.Participants, clientSnapshot.Store.LIDs)
 	for _, participant := range participants {
-		name := groupParticipantName(ctx, participant, client.Store.Contacts)
-		for _, jid := range participantJIDs(ctx, participant, client.Store.LIDs) {
+		name := groupParticipantName(ctx, participant, clientSnapshot.Store.Contacts)
+		for _, jid := range participantJIDs(ctx, participant, clientSnapshot.Store.LIDs) {
 			entries = append(entries, contactEntry{jid: jid, name: name})
 		}
 	}
 	// The picker intentionally filters self, so add the authenticated identity
 	// explicitly for incoming mentions. The helper only returns verified aliases.
-	entries = append(entries, selfMentionEntries(ctx, client)...)
+	entries = append(entries, selfMentionEntries(ctx, clientSnapshot)...)
 	return entries
 }
 
 func directMentionEntries(ctx context.Context, mentionedJIDs []string) []contactEntry {
-	if client == nil || client.Store == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || clientSnapshot.Store == nil {
 		return nil
 	}
 	entries := make([]contactEntry, 0, len(mentionedJIDs))
@@ -194,15 +196,15 @@ func directMentionEntries(ctx context.Context, mentionedJIDs []string) []contact
 		}
 		aliases := mentionJIDAliases(ctx, jid)
 		name := ""
-		if participantMatchesSelf(client, types.GroupParticipant{JID: jid}) {
-			name = selfDisplayName(ctx, client)
+		if participantMatchesSelf(clientSnapshot, types.GroupParticipant{JID: jid}) {
+			name = selfDisplayName(ctx, clientSnapshot)
 		}
-		if client.Store.Contacts != nil {
+		if clientSnapshot.Store.Contacts != nil {
 			for _, alias := range aliases {
 				if name != "" {
 					break
 				}
-				contact, err := client.Store.Contacts.GetContact(ctx, alias)
+				contact, err := clientSnapshot.Store.Contacts.GetContact(ctx, alias)
 				if err != nil {
 					continue
 				}
@@ -222,10 +224,11 @@ func directMentionEntries(ctx context.Context, mentionedJIDs []string) []contact
 }
 
 func mentionJIDAliases(ctx context.Context, jid types.JID) []types.JID {
-	if client == nil || client.Store == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || clientSnapshot.Store == nil {
 		return []types.JID{jid, jid.ToNonAD()}
 	}
-	return participantJIDs(ctx, types.GroupParticipant{JID: jid}, client.Store.LIDs)
+	return participantJIDs(ctx, types.GroupParticipant{JID: jid}, clientSnapshot.Store.LIDs)
 }
 
 func appendMentionAliases(ctx context.Context, mentioned, contact types.JID) []types.JID {


### PR DESCRIPTION
## Summary

- Routes remaining query bridge operations through the lifecycle-owned client snapshot.
- Keeps query/media behavior and cgo boundaries unchanged while removing direct global-client reads from this slice.
- Closes #262.

## Changes

- Migrates contacts, communities, group info, group participants, chat settings, and DM resolution callers.
- Migrates mention lookup helpers that were still reading the package-global client.
- Adds focused source-boundary coverage for all query/media bridge modules.

## Chain Context

```text
parent PR #345 `refactor/go-client-runtime-callers`
    |
    +--> 📍 this PR `refactor/go-client-query-media-callers`
               |
               +--> next: remaining direct runtime/event-family callers
```

- Start: parent PR #345, commit `0b5407b`.
- Current boundary: query and mention lookup callers in `whatsrust/lib`; media callers were already lifecycle-routed and are covered by the boundary test.
- Follow-up: migrate remaining direct runtime/event-family callers without splitting event families in this PR.
- Out of scope: event-family splitting, Rust changes, and Cargo verification.

## Testing

- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` applied and verified with `gofmt -d`
- [x] `git diff --check`
- [ ] Cargo checks — not run by request
- [x] Manual testing not applicable; focused Go boundary tests cover this slice.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #262