### PR TITLE
refactor(whatsrust): route presence and read callers through lifecycle client

### DIFF
--- a/whatsrust/lib/chat_read_sync_ffi.go
+++ b/whatsrust/lib/chat_read_sync_ffi.go
@@ -129,7 +129,8 @@ func sendChatReadSync(ctx context.Context, chat, messageID string, timestamp int
 //
 //export C_MarkChatReadSync
 func C_MarkChatReadSync(chatJID *C.char, messageID *C.char, timestamp C.longlong, fromMe C.bool, participantJID C.JID) C.int {
-	if client == nil || chatJID == nil || messageID == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || chatJID == nil || messageID == nil {
 		return 1
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -141,7 +142,7 @@ func C_MarkChatReadSync(chatJID *C.char, messageID *C.char, timestamp C.longlong
 	return markReadResult(func() error {
 		return sendChatReadSync(ctx, C.GoString(chatJID), C.GoString(messageID), int64(timestamp), bool(fromMe), participant,
 			func(ctx context.Context, patch appstate.PatchInfo) error {
-				return client.SendAppState(ctx, patch)
+				return clientSnapshot.SendAppState(ctx, patch)
 			})
 	})
 }

--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -9,7 +9,7 @@ import (
 	"go.mau.fi/whatsmeow"
 )
 
-func TestQueryAndMediaBridgeCallersUseLifecycleSnapshots(t *testing.T) {
+func TestBridgeCallersUseLifecycleSnapshots(t *testing.T) {
 	for _, file := range []string{
 		"contacts.go",
 		"communities.go",
@@ -20,6 +20,9 @@ func TestQueryAndMediaBridgeCallersUseLifecycleSnapshots(t *testing.T) {
 		"mention_names.go",
 		"media_downloads.go",
 		"profile_picture.go",
+		"presence.go",
+		"mark_as_read_ffi.go",
+		"chat_read_sync_ffi.go",
 	} {
 		source, err := os.ReadFile(file)
 		if err != nil {

--- a/whatsrust/lib/mark_as_read_ffi.go
+++ b/whatsrust/lib/mark_as_read_ffi.go
@@ -23,7 +23,8 @@ func markMessageAsRead(msgID string, chat, sender types.JID, markRead markAsRead
 
 //export C_MarkAsRead
 func C_MarkAsRead(msgID *C.char, chatJID C.JID, senderJID C.JID) C.int {
-	if client == nil || msgID == nil || chatJID == nil || senderJID == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil || msgID == nil || chatJID == nil || senderJID == nil {
 		return 1
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -38,7 +39,7 @@ func C_MarkAsRead(msgID *C.char, chatJID C.JID, senderJID C.JID) C.int {
 	}
 
 	return markReadResult(func() error {
-		return client.MarkRead(ctx, []types.MessageID{C.GoString(msgID)}, time.Now(), chat, sender)
+		return clientSnapshot.MarkRead(ctx, []types.MessageID{C.GoString(msgID)}, time.Now(), chat, sender)
 	})
 }
 

--- a/whatsrust/lib/presence.go
+++ b/whatsrust/lib/presence.go
@@ -40,10 +40,11 @@ const (
 //export C_SubscribePresence
 func C_SubscribePresence(cjid C.JID) C.uint8_t {
 	jid := cToJid(cjid)
-	if client == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil {
 		return C.uint8_t(subscribePresenceRejected)
 	}
-	result := subscribePresence(jid, client.SubscribePresence)
+	result := subscribePresence(jid, clientSnapshot.SubscribePresence)
 	if result == subscribePresenceNoPrivacyToken {
 		LOG_WARN("Failed to subscribe to presence: no privacy token")
 	} else if result == subscribePresenceRejected {


### PR DESCRIPTION
## Summary

- Routes presence subscriptions and mark-as-read bridges through the lifecycle-owned client snapshot.
- Preserves nil-client status behavior, operation-level client capture, and existing cgo boundaries.
- Keeps event-family internals and Rust code out of scope.

## Changes

| File | Change |
|------|--------|
| `whatsrust/lib/presence.go` | Snapshot the lifecycle client before subscribing to presence. |
| `whatsrust/lib/mark_as_read_ffi.go` | Snapshot the lifecycle client for message mark-as-read. |
| `whatsrust/lib/chat_read_sync_ffi.go` | Snapshot the lifecycle client for chat read app-state sync. |
| `whatsrust/lib/client_lifecycle_test.go` | Extend focused source-boundary coverage to these callers. |

## Chain Context

```text
parent PR #348 `refactor/go-client-query-media-callers`
    |
    +--> this PR `refactor/go-client-read-presence-callers`
```

- Start: parent PR #348, commit `96235a5`.
- Current boundary: remaining coherent presence subscription and read synchronization callers.
- Follow-up: remaining direct runtime/event-family callers without touching event-family internals in this PR.

## Testing

- [x] `gofmt` applied and verified with `gofmt -d`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] No Cargo commands run, per request.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #262