### PR TITLE
refactor(app): extract lifecycle settings action dispatch

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -34,6 +34,7 @@ pub mod input_reader;
 pub mod input_router;
 pub mod inputs;
 pub mod leader_menu;
+pub mod lifecycle_settings_dispatch;
 pub mod log_toggle;
 pub mod logout;
 pub mod media_cache;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -1,9 +1,7 @@
 use ratatui::crossterm::event::Event;
 
 use crate::app::App;
-use crate::app::actions::{
-    AppAction, ConversationMode, FocusPane, Section, focus_after,
-};
+use crate::app::actions::{AppAction, ConversationMode, FocusPane, Section, focus_after};
 pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
 pub use crate::app::composer_input_paste::apply_clipboard_paste;
 use crate::app::input_router::{InputRoute, ModalContext, route_context_key, route_modal_key};

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -2,7 +2,7 @@ use ratatui::crossterm::event::Event;
 
 use crate::app::App;
 use crate::app::actions::{
-    AppAction, ConversationMode, FocusPane, Section, focus_after, focus_after_visibility_change,
+    AppAction, ConversationMode, FocusPane, Section, focus_after,
 };
 pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
 pub use crate::app::composer_input_paste::apply_clipboard_paste;
@@ -322,37 +322,17 @@ impl App<'_> {
                 self.dispatch_picker_viewer_action(action)
                     .expect("picker/viewer action family must be handled by its dispatcher");
             }
-            AppAction::Quit => {
-                self.db_handler.stop();
-                self.should_quit = true;
-            }
-            AppAction::Logout => self.begin_logout_confirmation(),
-            AppAction::ToggleLogs => self.toggle_logs(),
-            AppAction::ToggleSectionRail => {
-                self.pane_visibility.section_rail = !self.pane_visibility.section_rail;
-                self.focus_pane =
-                    focus_after_visibility_change(self.focus_pane, self.pane_visibility);
-            }
-            AppAction::ToggleChatList => {
-                self.pane_visibility.chat_list = !self.pane_visibility.chat_list;
-                self.focus_pane =
-                    focus_after_visibility_change(self.focus_pane, self.pane_visibility);
-            }
-            AppAction::FocusPane(pane) => {
-                let visible = match pane {
-                    FocusPane::SectionRail => self.pane_visibility.section_rail,
-                    FocusPane::ChatList => self.pane_visibility.chat_list,
-                    FocusPane::Conversation => true,
-                };
-                if visible {
-                    self.focus_pane = pane;
-                }
-            }
-            AppAction::OpenContextualActions => self.open_contextual_actions(),
-            AppAction::ToggleShortcutPopup => self.shortcut_popup = !self.shortcut_popup,
-            AppAction::ToggleComposerDirection => self.toggle_composer_direction(),
-            AppAction::PlannedLeaderAction(label) => {
-                self.unavailable(&format!("{label}: not implemented"))
+            action @ (AppAction::Quit
+            | AppAction::Logout
+            | AppAction::ToggleLogs
+            | AppAction::ToggleSectionRail
+            | AppAction::ToggleChatList
+            | AppAction::FocusPane(_)
+            | AppAction::ToggleShortcutPopup
+            | AppAction::ToggleComposerDirection
+            | AppAction::PlannedLeaderAction(_)) => {
+                self.dispatch_lifecycle_settings_action(action)
+                    .expect("lifecycle/settings action family must be handled by its dispatcher");
             }
             AppAction::FocusNext | AppAction::FocusPrevious => {}
             AppAction::SelectNext => self.select_next(),

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -326,6 +326,7 @@ impl App<'_> {
             | AppAction::ToggleSectionRail
             | AppAction::ToggleChatList
             | AppAction::FocusPane(_)
+            | AppAction::OpenContextualActions
             | AppAction::ToggleShortcutPopup
             | AppAction::ToggleComposerDirection
             | AppAction::PlannedLeaderAction(_)) => {

--- a/src/app/lifecycle_settings_dispatch.rs
+++ b/src/app/lifecycle_settings_dispatch.rs
@@ -33,6 +33,7 @@ impl App<'_> {
                     self.focus_pane = pane;
                 }
             }
+            AppAction::OpenContextualActions => self.open_contextual_actions(),
             AppAction::ToggleShortcutPopup => self.shortcut_popup = !self.shortcut_popup,
             AppAction::ToggleComposerDirection => self.toggle_composer_direction(),
             AppAction::PlannedLeaderAction(label) => {
@@ -52,6 +53,7 @@ mod tests {
     #[test]
     fn hidden_pane_toggle_moves_focus_to_visible_pane() {
         let mut app = TestApp::new();
+        app.pane_visibility.section_rail = false;
         app.focus_pane = FocusPane::ChatList;
 
         app.dispatch_action(AppAction::ToggleChatList);

--- a/src/app/lifecycle_settings_dispatch.rs
+++ b/src/app/lifecycle_settings_dispatch.rs
@@ -1,0 +1,71 @@
+use crate::app::App;
+use crate::app::actions::{AppAction, FocusPane, focus_after_visibility_change};
+
+impl App<'_> {
+    pub(crate) fn dispatch_lifecycle_settings_action(
+        &mut self,
+        action: AppAction,
+    ) -> Result<(), AppAction> {
+        match action {
+            AppAction::Quit => {
+                self.db_handler.stop();
+                self.should_quit = true;
+            }
+            AppAction::Logout => self.begin_logout_confirmation(),
+            AppAction::ToggleLogs => self.toggle_logs(),
+            AppAction::ToggleSectionRail => {
+                self.pane_visibility.section_rail = !self.pane_visibility.section_rail;
+                self.focus_pane =
+                    focus_after_visibility_change(self.focus_pane, self.pane_visibility);
+            }
+            AppAction::ToggleChatList => {
+                self.pane_visibility.chat_list = !self.pane_visibility.chat_list;
+                self.focus_pane =
+                    focus_after_visibility_change(self.focus_pane, self.pane_visibility);
+            }
+            AppAction::FocusPane(pane) => {
+                let visible = match pane {
+                    FocusPane::SectionRail => self.pane_visibility.section_rail,
+                    FocusPane::ChatList => self.pane_visibility.chat_list,
+                    FocusPane::Conversation => true,
+                };
+                if visible {
+                    self.focus_pane = pane;
+                }
+            }
+            AppAction::ToggleShortcutPopup => self.shortcut_popup = !self.shortcut_popup,
+            AppAction::ToggleComposerDirection => self.toggle_composer_direction(),
+            AppAction::PlannedLeaderAction(label) => {
+                self.unavailable(&format!("{label}: not implemented"))
+            }
+            other => return Err(other),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_support::TestApp;
+
+    #[test]
+    fn hidden_pane_toggle_moves_focus_to_visible_pane() {
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::ChatList;
+
+        app.dispatch_action(AppAction::ToggleChatList);
+
+        assert!(!app.pane_visibility.chat_list);
+        assert_eq!(app.focus_pane, FocusPane::Conversation);
+    }
+
+    #[test]
+    fn shortcut_popup_toggle_is_handled_by_lifecycle_settings_family() {
+        let mut app = TestApp::new();
+
+        app.dispatch_action(AppAction::ToggleShortcutPopup);
+
+        assert!(app.shortcut_popup);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract lifecycle and settings action effects from `src/app/inputs.rs` into a cohesive handler.
- Preserve the existing dispatch guards, state transitions, and exhaustive delegation behavior.

## Changes

- Add `src/app/lifecycle_settings_dispatch.rs` for quit, logout, log visibility, pane visibility/focus, shortcut popup, composer direction, and planned leader-action handling.
- Register the handler and delegate its explicit action family from `dispatch_action`.
- Add focused tests for hidden-pane focus fallback and shortcut popup toggling.

## Chain Context

- Parent: PR #347 / `refactor/rust-input-dispatch-families`
- Current: 📍 lifecycle/settings action dispatch
- Follow-up: navigation/conversation action dispatch, the final remaining family in `inputs.rs`
- Dependency: this child targets the parent branch and must merge after PR #347.

```text
PR #347 (picker/viewer dispatch)
        |
        v
📍 this PR (lifecycle/settings dispatch)
        |
        v
follow-up (navigation/conversation dispatch)
```

## Boundary

Start: `dispatch_action` retains policy guards and all action effects after picker/viewer delegation.
End: lifecycle/settings effects live in `lifecycle_settings_dispatch.rs`; `inputs.rs` retains navigation/conversation actions as the final dispatch family.

## Testing

- [x] `git diff --check`
- [ ] `cargo test -- --test-threads=1` (not run per task constraint)
- [ ] `cd whatsrust/lib && go test ./...` (not run per task constraint)
- [ ] `cargo fmt --check` (not run per task constraint)
- [ ] Manual testing (not run per task constraint)

Closes #350