### PR TITLE
refactor(whatsrust): route event callers through lifecycle client

### DIFF
--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -23,6 +23,9 @@ func TestBridgeCallersUseLifecycleSnapshots(t *testing.T) {
 		"presence.go",
 		"mark_as_read_ffi.go",
 		"chat_read_sync_ffi.go",
+		"message_callback.go",
+		"receipt_events.go",
+		"message_action_secret_edit.go",
 	} {
 		source, err := os.ReadFile(file)
 		if err != nil {

--- a/whatsrust/lib/message_action_secret_edit.go
+++ b/whatsrust/lib/message_action_secret_edit.go
@@ -16,7 +16,11 @@ import (
 type decryptSecretEncryptedMessageFunc func(context.Context, *events.Message) (*waE2E.Message, error)
 
 func decryptSecretEncryptedMessage(ctx context.Context, evt *events.Message) (*waE2E.Message, error) {
-	return client.DecryptSecretEncryptedMessage(ctx, evt)
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if clientSnapshot == nil {
+		return nil, fmt.Errorf("WhatsApp client is unavailable")
+	}
+	return clientSnapshot.DecryptSecretEncryptedMessage(ctx, evt)
 }
 
 func secretEditErrorClass(err error) string {

--- a/whatsrust/lib/message_callback.go
+++ b/whatsrust/lib/message_callback.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"unsafe"
 
+	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 )
@@ -50,12 +51,16 @@ type messageCallbackMetadata struct {
 }
 
 func messageCallbackMetadataFrom(info types.MessageInfo, msg *waE2E.Message) messageCallbackMetadata {
+	return messageCallbackMetadataFromWithClient(lifecycleState.clientSnapshot(), info, msg)
+}
+
+func messageCallbackMetadataFromWithClient(c *whatsmeow.Client, info types.MessageInfo, msg *waE2E.Message) messageCallbackMetadata {
 	return messageCallbackMetadata{
 		id:           info.ID,
 		chat:         info.Chat,
 		sender:       info.Sender,
 		pushName:     info.PushName,
-		mentionsSelf: messageMentionsSelf(msg),
+		mentionsSelf: messageMentionsSelfWithClient(c, msg),
 		timestamp:    info.Timestamp.Unix(),
 		isFromMe:     info.IsFromMe,
 		forwarding:   forwardingStateFromMessage(msg),
@@ -72,12 +77,13 @@ type messageCallback struct {
 func beginMessageCallback(info types.MessageInfo, msg *waE2E.Message, rawSource []byte) *messageCallback {
 	messageCallbackMu.Lock()
 	rememberAuthenticatedPushName(info)
+	clientSnapshot := lifecycleState.clientSnapshot()
 	callback := &messageCallback{locked: true}
 	if len(rawSource) > 0 {
 		callback.forwardData = C.CBytes(rawSource)
 	}
 	C.setActiveForwardSource((*C.uint8_t)(callback.forwardData), C.size_t(len(rawSource)))
-	metadata := messageCallbackMetadataFrom(info, msg)
+	metadata := messageCallbackMetadataFromWithClient(clientSnapshot, info, msg)
 	callback.info = C.MessageInfo{
 		id:              C.CString(metadata.id),
 		chat:            jidToC(metadata.chat),
@@ -95,13 +101,17 @@ func beginMessageCallback(info types.MessageInfo, msg *waE2E.Message, rawSource 
 }
 
 func messageMentionsSelf(msg *waE2E.Message) bool {
-	if client == nil || client.Store == nil || msg == nil {
+	return messageMentionsSelfWithClient(lifecycleState.clientSnapshot(), msg)
+}
+
+func messageMentionsSelfWithClient(c *whatsmeow.Client, msg *waE2E.Message) bool {
+	if c == nil || c.Store == nil || msg == nil {
 		return false
 	}
 	for _, contextInfo := range messageContextInfos(msg) {
 		for _, mentioned := range contextInfo.GetMentionedJID() {
 			jid, err := types.ParseJID(mentioned)
-			if err == nil && participantMatchesSelf(client, types.GroupParticipant{JID: jid}) {
+			if err == nil && participantMatchesSelf(c, types.GroupParticipant{JID: jid}) {
 				return true
 			}
 		}

--- a/whatsrust/lib/receipt_events.go
+++ b/whatsrust/lib/receipt_events.go
@@ -92,7 +92,7 @@ func receiptEventFromEventWithClient(c *whatsmeow.Client, event *events.Receipt)
 }
 
 func receiptEventFromEvent(event *events.Receipt) (receiptEvent, bool) {
-	return receiptEventFromEventWithClient(client, event)
+	return receiptEventFromEventWithClient(lifecycleState.clientSnapshot(), event)
 }
 
 func receiptKind(kind types.ReceiptType) uint8 {


### PR DESCRIPTION
## Summary

- Routes message callbacks, receipt conversion, and secret-message edit decryption through lifecycle-owned client snapshots.
- Preserves callback metadata, receipt canonicalization, and encrypted-edit behavior, including unavailable-client handling.
- Extends focused source-boundary coverage without splitting event registration families.

## Changes

| File | Change |
|------|--------|
| `whatsrust/lib/message_callback.go` | Capture one lifecycle client snapshot for callback metadata and self-mention evaluation. |
| `whatsrust/lib/receipt_events.go` | Snapshot the lifecycle client before receipt canonicalization. |
| `whatsrust/lib/message_action_secret_edit.go` | Snapshot the lifecycle client before secret edit decryption and fail closed when unavailable. |
| `whatsrust/lib/client_lifecycle_test.go` | Cover the three event callers in the lifecycle snapshot boundary test. |

## Chain Context

```text
parent PR #349 `refactor/go-client-read-presence-callers`
    |
    +--> this PR `refactor/go-client-event-callers`
```

- Start: parent PR #349, commit `3e07be9`.
- Current boundary: remaining message callback, receipt, and secret-edit event callers.
- Follow-up: production direct global-client reads reported in the audit; event registration families remain together.

## Testing

- [x] `gofmt -d` on changed Go files
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] No Cargo commands run, per request.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #262
