### PR TITLE
refactor(whatsrust): route media identity callers through lifecycle

### DIFF
--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -26,6 +26,8 @@ func TestBridgeCallersUseLifecycleSnapshots(t *testing.T) {
 		"message_callback.go",
 		"receipt_events.go",
 		"message_action_secret_edit.go",
+		"file_message_payload.go",
+		"message_event_dispatch.go",
 	} {
 		source, err := os.ReadFile(file)
 		if err != nil {

--- a/whatsrust/lib/file_message_payload.go
+++ b/whatsrust/lib/file_message_payload.go
@@ -100,9 +100,10 @@ func emitImageMessage(cinfo C.MessageInfo, messageID string, image *waE2E.ImageM
 		return false
 	}
 	setMessageQuoteID(&cinfo, image.GetContextInfo())
+	clientSnapshot := lifecycleState.clientSnapshot()
 	ext := ExtensionByType(image.GetMimetype(), ".jpg")
 	filePath := fmt.Sprintf("imgs/%s%s", messageID, ext)
-	fileID := DownloadableMessageToFileId(client, image, filePath)
+	fileID := DownloadableMessageToFileId(clientSnapshot, image, filePath)
 	emitFileMessage(cinfo, FileTypeImage, filePath, fileID, captionWithMentionNames(image.GetCaption(), image.GetContextInfo(), cinfo), isSync)
 	return true
 }
@@ -113,9 +114,10 @@ func emitVideoMessage(cinfo C.MessageInfo, messageID string, video *waE2E.VideoM
 		return false
 	}
 	setMessageQuoteID(&cinfo, video.GetContextInfo())
+	clientSnapshot := lifecycleState.clientSnapshot()
 	ext := ExtensionByType(video.GetMimetype(), ".mp4")
 	filePath := fmt.Sprintf("videos/%s%s", messageID, ext)
-	fileID := DownloadableMessageToFileId(client, video, filePath)
+	fileID := DownloadableMessageToFileId(clientSnapshot, video, filePath)
 	if thumbnail := video.GetJPEGThumbnail(); len(thumbnail) > 0 {
 		thumbPath := strings.TrimSuffix(filePath, ext) + ".jpg"
 		fileID = AddThumbnailToFileId(fileID, thumbnail, thumbPath)
@@ -130,9 +132,10 @@ func emitAudioMessage(cinfo C.MessageInfo, messageID string, audio *waE2E.AudioM
 		return false
 	}
 	setMessageQuoteID(&cinfo, audio.GetContextInfo())
+	clientSnapshot := lifecycleState.clientSnapshot()
 	ext := ExtensionByType(audio.GetMimetype(), ".ogg")
 	filePath := fmt.Sprintf("audios/%s%s", messageID, ext)
-	fileID := DownloadableMessageToFileId(client, audio, filePath)
+	fileID := DownloadableMessageToFileId(clientSnapshot, audio, filePath)
 	emitFileMessage(cinfo, FileTypeAudio, filePath, fileID, "", isSync)
 	return true
 }
@@ -143,8 +146,9 @@ func emitDocumentMessage(cinfo C.MessageInfo, messageID string, document *waE2E.
 		return false
 	}
 	setMessageQuoteID(&cinfo, document.GetContextInfo())
+	clientSnapshot := lifecycleState.clientSnapshot()
 	filePath := fmt.Sprintf("docs/%s-%s", messageID, *document.FileName)
-	fileID := DownloadableMessageToFileId(client, document, filePath)
+	fileID := DownloadableMessageToFileId(clientSnapshot, document, filePath)
 	emitFileMessage(cinfo, FileTypeDocument, filePath, fileID, captionWithMentionNames(document.GetCaption(), document.GetContextInfo(), cinfo), isSync)
 	return true
 }
@@ -170,9 +174,10 @@ func emitStickerMessage(cinfo C.MessageInfo, messageID string, sticker *waE2E.St
 		return false
 	}
 	setMessageQuoteID(&cinfo, sticker.GetContextInfo())
+	clientSnapshot := lifecycleState.clientSnapshot()
 	ext := ExtensionByType(sticker.GetMimetype(), ".webp")
 	filePath := fmt.Sprintf("stickers/%s%s", messageID, ext)
-	fileID := DownloadableMessageToFileId(client, sticker, filePath)
+	fileID := DownloadableMessageToFileId(clientSnapshot, sticker, filePath)
 	emitFileMessage(cinfo, FileTypeSticker, filePath, fileID, "", isSync)
 	return true
 }

--- a/whatsrust/lib/mention_names.go
+++ b/whatsrust/lib/mention_names.go
@@ -123,11 +123,12 @@ func mentionJIDMatchesWithContext(ctx context.Context, left, right types.JID) bo
 	if left == right || left.ToNonAD() == right.ToNonAD() {
 		return true
 	}
-	if !isUserJID(left) || !isUserJID(right) || client == nil || client.Store == nil || client.Store.LIDs == nil {
+	clientSnapshot := lifecycleState.clientSnapshot()
+	if !isUserJID(left) || !isUserJID(right) || clientSnapshot == nil || clientSnapshot.Store == nil || clientSnapshot.Store.LIDs == nil {
 		return false
 	}
 
-	lids := client.Store.LIDs
+	lids := clientSnapshot.Store.LIDs
 	leftCanonical := left.ToNonAD()
 	rightCanonical := right.ToNonAD()
 	if leftCanonical.Server == types.HiddenUserServer {

--- a/whatsrust/lib/message_event_dispatch.go
+++ b/whatsrust/lib/message_event_dispatch.go
@@ -1,24 +1,29 @@
 package main
 
 import (
+	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 )
 
 func normalizeMessageInfo(info types.MessageInfo) types.MessageInfo {
+	return normalizeMessageInfoWithClient(lifecycleState.clientSnapshot(), info)
+}
+
+func normalizeMessageInfoWithClient(clientSnapshot *whatsmeow.Client, info types.MessageInfo) types.MessageInfo {
 	// Some history and DeviceSent events carry the sender identity while leaving
 	// IsFromMe unset. Resolve that source identity before canonicalization so the
 	// Rust side receives verified ownership for PN, LID, and device aliases.
-	if !info.IsFromMe && participantMatchesSelf(client, types.GroupParticipant{JID: info.Sender}) {
+	if !info.IsFromMe && participantMatchesSelf(clientSnapshot, types.GroupParticipant{JID: info.Sender}) {
 		info.IsFromMe = true
 	}
 	// Normalize chat and sender ids (LID→PN, broadcast→per-sender) so Rust sees canonical ids.
-	if normalizedChat := GetChatId(client, &info.Chat, &info.Sender); normalizedChat != "" {
+	if normalizedChat := GetChatId(clientSnapshot, &info.Chat, &info.Sender); normalizedChat != "" {
 		if jid, err := types.ParseJID(normalizedChat); err == nil {
 			info.Chat = jid
 		}
 	}
-	if normalizedSender := GetUserId(client, &info.Chat, &info.Sender); normalizedSender != "" {
+	if normalizedSender := GetUserId(clientSnapshot, &info.Chat, &info.Sender); normalizedSender != "" {
 		if jid, err := types.ParseJID(normalizedSender); err == nil {
 			info.Sender = jid
 		}


### PR DESCRIPTION
## Summary
- Routes file message media conversion, mention identity matching, and message identity normalization through lifecycle-owned client snapshots.
- Preserves existing media, mention, and canonicalization behavior while capturing one client snapshot per operation.
- Adds focused source-boundary coverage for the migrated callers.

## Changes

| File | Change |
|------|--------|
| `whatsrust/lib/file_message_payload.go` | Use lifecycle snapshots for image, video, audio, document, and sticker download identity. |
| `whatsrust/lib/mention_names.go` | Use a lifecycle snapshot for LID/PN mention matching. |
| `whatsrust/lib/message_event_dispatch.go` | Snapshot once before self-identity and chat/sender canonicalization. |
| `whatsrust/lib/client_lifecycle_test.go` | Include the media and event identity callers in the lifecycle boundary audit. |

## Chain Context

```text
parent PR #352 `refactor/go-client-event-callers`
    |
    +--> this PR `refactor/go-client-media-identity-callers`
```

- Start: parent PR #352, commit `9bd6cc6`.
- Current boundary: remaining direct global-client production reads in media payload, mention identity, and message event dispatch.
- Follow-up: none identified in the production audit; only `client_lifecycle.go` retains the global client storage/publication/reset boundary.

## Testing

- [x] `gofmt -w` on changed Go files
- [x] `go test ./...` from `whatsrust/lib`
- [x] `go vet ./...` from `whatsrust/lib`
- [x] `git diff --check`
- [x] No Cargo commands run, per request.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #262