### PR TITLE
refactor(whatsrust): split event registration families

### DIFF
--- a/whatsrust/lib/connection_events_test.go
+++ b/whatsrust/lib/connection_events_test.go
@@ -27,13 +27,13 @@ func TestConnectionEventDispatchKeepsCallbackGuardAndKinds(t *testing.T) {
 }
 
 func TestConnectionEventDispatchLeavesMainHandlerAsRouter(t *testing.T) {
-	source, err := os.ReadFile("event_wiring.go")
+	source, err := os.ReadFile("event_connection_wiring.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	body := string(source)
-	if !strings.Contains(body, "dispatchConnectedEvent") {
-		t.Fatal("event wiring does not delegate connected events")
+	if !strings.Contains(body, "handleConnected(client.SendPresence, dispatchConnectedEvent, LOG_WARN)") {
+		t.Fatal("connection family does not delegate connected events")
 	}
 	if strings.Contains(body, "func emitLogoutResult(status uint8)") {
 		t.Fatal("logout result conversion remains in event wiring")

--- a/whatsrust/lib/event_connection_wiring.go
+++ b/whatsrust/lib/event_connection_wiring.go
@@ -1,0 +1,7 @@
+package main
+
+import "go.mau.fi/whatsmeow"
+
+func dispatchConnectionFamily(client *whatsmeow.Client) {
+	handleConnected(client.SendPresence, dispatchConnectedEvent, LOG_WARN)
+}

--- a/whatsrust/lib/event_dispatch.go
+++ b/whatsrust/lib/event_dispatch.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// dispatchEventFamily keeps registration orchestration separate from the
+// cohesive handlers for each event family.
+func dispatchEventFamily(rawEvt any, client *whatsmeow.Client, dispatchViewOnce func(types.MessageInfo, bool)) {
+	switch evt := rawEvt.(type) {
+	case *events.Connected:
+		dispatchConnectionFamily(client)
+	case *events.Presence:
+		dispatchPresenceFamily(evt, client)
+	case *events.MarkChatAsRead:
+		dispatchReadFamily(evt)
+	case *events.AppStateSyncComplete:
+		dispatchSyncCompleteFamily(evt)
+	case *events.Message:
+		dispatchMessageFamily(evt, dispatchViewOnce)
+	case *events.UndecryptableMessage:
+		dispatchUndecryptableMessage(evt, dispatchViewOnce)
+	case *events.Receipt:
+		dispatchReceiptFamily(evt, client)
+	case *events.HistorySync:
+		dispatchHistoryFamily(evt, client, dispatchViewOnce)
+	}
+}

--- a/whatsrust/lib/event_message_wiring.go
+++ b/whatsrust/lib/event_message_wiring.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func dispatchMessageFamily(evt *events.Message, dispatchViewOnce func(info types.MessageInfo, isSync bool)) {
+	// The message action router remains behind the canonical
+	// dispatchIncomingMessage boundary; this handler adds the view-once projection.
+	dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage, dispatchViewOnce)
+}

--- a/whatsrust/lib/event_presence_wiring.go
+++ b/whatsrust/lib/event_presence_wiring.go
@@ -1,0 +1,28 @@
+package main
+
+/*
+#include <stdlib.h>
+#include "callback_log_registration.h"
+
+static void callPresenceWiringHandler(PresenceHandler hdl, JID from, bool unavailable, int64_t lastSeen) {
+	hdl.callback(from, unavailable, lastSeen, hdl.user_data);
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func dispatchPresenceCallback(from string, unavailable bool, lastSeen int64) {
+	cFrom := C.CString(from)
+	defer C.free(unsafe.Pointer(cFrom))
+	C.callPresenceWiringHandler(presenceHandler, cFrom, C.bool(unavailable), C.int64_t(lastSeen))
+}
+
+func dispatchPresenceFamily(evt *events.Presence, client *whatsmeow.Client) {
+	dispatchPresenceEvent(evt, client.Store.LIDs.GetPNForLID, rawPresenceProbe.record, rawPresenceProbe.update, dispatchPresenceCallback)
+}

--- a/whatsrust/lib/event_read_wiring.go
+++ b/whatsrust/lib/event_read_wiring.go
@@ -1,0 +1,7 @@
+package main
+
+import "go.mau.fi/whatsmeow/types/events"
+
+func dispatchReadFamily(evt *events.MarkChatAsRead) {
+	dispatchMarkChatAsReadEvent(evt)
+}

--- a/whatsrust/lib/event_sync_wiring.go
+++ b/whatsrust/lib/event_sync_wiring.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func dispatchSyncCompleteFamily(evt *events.AppStateSyncComplete) {
+	dispatchAppStateSyncComplete(evt)
+}
+
+func dispatchHistoryFamily(evt *events.HistorySync, client *whatsmeow.Client, dispatchViewOnce func(types.MessageInfo, bool)) {
+	dispatchHistorySync(evt, client.DangerousInternals().StoreHistoricalMessageSecrets, client.ParseWebMessage, func(parsed *events.Message) {
+		dispatchIncomingMessage(parsed, dispatchMessageActionEvent, func(info types.MessageInfo, message *waE2E.Message, _ bool) {
+			HandleMessage(info, message, true)
+		}, dispatchViewOnce)
+	})
+}
+
+func dispatchReceiptFamily(evt *events.Receipt, client *whatsmeow.Client) {
+	if receipt, ok := receiptEventFromEventWithClient(client, evt); ok {
+		LOG_DEBUG("%#v was read by %s at %s", evt.MessageIDs, evt.SourceString(), evt.Timestamp)
+		dispatchReceiptEvent(receipt)
+	}
+}

--- a/whatsrust/lib/event_view_once_wiring.go
+++ b/whatsrust/lib/event_view_once_wiring.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"sync"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func dispatchUndecryptableMessage(evt *events.UndecryptableMessage, dispatchViewOnceUnavailable func(types.MessageInfo, bool)) {
+	if !evt.IsUnavailable || evt.UnavailableType != events.UnavailableTypeViewOnce {
+		return
+	}
+	dispatchViewOnceUnavailable(evt.Info, false)
+}
+
+type viewOnceUnavailableDispatcher struct {
+	mu       sync.Mutex
+	seen     map[string]struct{}
+	dispatch func(types.MessageInfo, bool)
+}
+
+func newViewOnceUnavailableDispatcher(dispatch func(types.MessageInfo, bool)) *viewOnceUnavailableDispatcher {
+	return &viewOnceUnavailableDispatcher{seen: make(map[string]struct{}), dispatch: dispatch}
+}
+
+func (dispatcher *viewOnceUnavailableDispatcher) dispatchOnce(info types.MessageInfo, isSync bool) {
+	if info.ID != "" {
+		dispatcher.mu.Lock()
+		_, alreadySeen := dispatcher.seen[info.ID]
+		if !alreadySeen {
+			dispatcher.seen[info.ID] = struct{}{}
+		}
+		dispatcher.mu.Unlock()
+		if alreadySeen {
+			return
+		}
+	}
+	dispatcher.dispatch(info, isSync)
+}

--- a/whatsrust/lib/event_wiring.go
+++ b/whatsrust/lib/event_wiring.go
@@ -1,67 +1,9 @@
 package main
 
 /*
-#include <stdlib.h>
 #include "callback_log_registration.h"
-
-static void callPresenceWiringHandler(PresenceHandler hdl, JID from, bool unavailable, int64_t lastSeen) {
-	hdl.callback(from, unavailable, lastSeen, hdl.user_data);
-}
 */
 import "C"
-
-import (
-	"sync"
-	"unsafe"
-
-	"go.mau.fi/whatsmeow/proto/waE2E"
-	"go.mau.fi/whatsmeow/types"
-	"go.mau.fi/whatsmeow/types/events"
-)
-
-func dispatchPresenceCallback(from string, unavailable bool, lastSeen int64) {
-	cFrom := C.CString(from)
-	defer C.free(unsafe.Pointer(cFrom))
-	C.callPresenceWiringHandler(presenceHandler, cFrom, C.bool(unavailable), C.int64_t(lastSeen))
-}
-
-func dispatchUndecryptableMessage(
-	evt *events.UndecryptableMessage,
-	dispatchViewOnceUnavailable func(types.MessageInfo, bool),
-) {
-	if !evt.IsUnavailable || evt.UnavailableType != events.UnavailableTypeViewOnce {
-		return
-	}
-	dispatchViewOnceUnavailable(evt.Info, false)
-}
-
-type viewOnceUnavailableDispatcher struct {
-	mu       sync.Mutex
-	seen     map[string]struct{}
-	dispatch func(types.MessageInfo, bool)
-}
-
-func newViewOnceUnavailableDispatcher(dispatch func(types.MessageInfo, bool)) *viewOnceUnavailableDispatcher {
-	return &viewOnceUnavailableDispatcher{
-		seen:     make(map[string]struct{}),
-		dispatch: dispatch,
-	}
-}
-
-func (dispatcher *viewOnceUnavailableDispatcher) dispatchOnce(info types.MessageInfo, isSync bool) {
-	if info.ID != "" {
-		dispatcher.mu.Lock()
-		_, alreadySeen := dispatcher.seen[info.ID]
-		if !alreadySeen {
-			dispatcher.seen[info.ID] = struct{}{}
-		}
-		dispatcher.mu.Unlock()
-		if alreadySeen {
-			return
-		}
-	}
-	dispatcher.dispatch(info, isSync)
-}
 
 func AddEventHandlers() {
 	lifecycleState.registerEventHandlers(func() {
@@ -74,33 +16,6 @@ func addEventHandlers() {
 	clientSnapshot := lifecycleState.clientSnapshot()
 	clientSnapshot.AddEventHandler(func(rawEvt any) {
 		messageActionCensusDiagnostic(rawEvt)
-		switch evt := rawEvt.(type) {
-		case *events.Connected:
-			handleConnected(clientSnapshot.SendPresence, dispatchConnectedEvent, LOG_WARN)
-		case *events.Presence:
-			dispatchPresenceEvent(evt, clientSnapshot.Store.LIDs.GetPNForLID, rawPresenceProbe.record, rawPresenceProbe.update, dispatchPresenceCallback)
-		case *events.MarkChatAsRead:
-			dispatchMarkChatAsReadEvent(evt)
-		case *events.AppStateSyncComplete:
-			dispatchAppStateSyncComplete(evt)
-		case *events.Message:
-			// The message action router remains behind the canonical
-			// dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage)
-			// boundary; this handler only adds the view-once projection.
-			dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage, viewOnceDispatcher.dispatchOnce)
-		case *events.UndecryptableMessage:
-			dispatchUndecryptableMessage(evt, viewOnceDispatcher.dispatchOnce)
-		case *events.Receipt:
-			if receipt, ok := receiptEventFromEventWithClient(clientSnapshot, evt); ok {
-				LOG_DEBUG("%#v was read by %s at %s", evt.MessageIDs, evt.SourceString(), evt.Timestamp)
-				dispatchReceiptEvent(receipt)
-			}
-		case *events.HistorySync:
-			dispatchHistorySync(evt, clientSnapshot.DangerousInternals().StoreHistoricalMessageSecrets, clientSnapshot.ParseWebMessage, func(parsed *events.Message) {
-				dispatchIncomingMessage(parsed, dispatchMessageActionEvent, func(info types.MessageInfo, message *waE2E.Message, _ bool) {
-					HandleMessage(info, message, true)
-				}, viewOnceDispatcher.dispatchOnce)
-			})
-		}
+		dispatchEventFamily(rawEvt, clientSnapshot, viewOnceDispatcher.dispatchOnce)
 	})
 }

--- a/whatsrust/lib/event_wiring_test.go
+++ b/whatsrust/lib/event_wiring_test.go
@@ -67,18 +67,30 @@ func TestEventWiringOwnsRegistrationAndDispatchCases(t *testing.T) {
 	for _, expected := range []string{
 		"func AddEventHandlers()",
 		"clientSnapshot.AddEventHandler(func(rawEvt any)",
-		"case *events.Connected:",
-		"case *events.Presence:",
-		"case *events.AppStateSyncComplete:",
-		"case *events.Message:",
-		"case *events.UndecryptableMessage:",
-		"case *events.Receipt:",
-		"case *events.HistorySync:",
-		"dispatchHistorySync(",
+		"messageActionCensusDiagnostic(rawEvt)",
+		"dispatchEventFamily(rawEvt, clientSnapshot, viewOnceDispatcher.dispatchOnce)",
 	} {
 		if !strings.Contains(body, expected) {
 			t.Fatalf("event wiring missing %q", expected)
 		}
+	}
+	if strings.Contains(body, "case *events.") {
+		t.Fatal("event registration still owns event-family cases")
+	}
+}
+
+func TestViewOnceUnavailableDispatcherDeduplicatesByMessageID(t *testing.T) {
+	dispatched := 0
+	dispatcher := newViewOnceUnavailableDispatcher(func(types.MessageInfo, bool) {
+		dispatched++
+	})
+	info := types.MessageInfo{ID: "same-view-once"}
+
+	dispatcher.dispatchOnce(info, false)
+	dispatcher.dispatchOnce(info, true)
+
+	if dispatched != 1 {
+		t.Fatalf("dispatch count = %d, want one", dispatched)
 	}
 }
 

--- a/whatsrust/lib/message_action_dispatch_test.go
+++ b/whatsrust/lib/message_action_dispatch_test.go
@@ -35,15 +35,15 @@ func TestMessageActionDispatchOwnsPayloadInCUntilSynchronousCallbackReturns(t *t
 }
 
 func TestMessageActionDispatchLeavesMessageRouterInMain(t *testing.T) {
-	source, err := os.ReadFile("event_wiring.go")
+	source, err := os.ReadFile("event_message_wiring.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	body := string(source)
-	if !strings.Contains(body, "dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage)") {
-		t.Fatal("event wiring no longer delegates message action dispatch")
+	if !strings.Contains(body, "dispatchIncomingMessage(evt, dispatchMessageActionEvent, HandleMessage, dispatchViewOnce)") {
+		t.Fatal("message family no longer delegates message action dispatch")
 	}
 	if strings.Contains(body, "func dispatchMessageActionEvent(action messageActionEvent)") {
-		t.Fatal("message action dispatch remains in event_wiring.go")
+		t.Fatal("message action dispatch remains in event_message_wiring.go")
 	}
 }


### PR DESCRIPTION
## Summary
- Keep `event_wiring.go` focused on lifecycle registration and the stable client snapshot.
- Extract connection, presence, read, message, view-once, receipt, and synchronization families into named wiring files/functions.
- Preserve event ordering, census diagnostics, callbacks, history-sync behavior, and view-once ID deduplication.

## Changes

| File | Change |
|------|--------|
| `whatsrust/lib/event_wiring.go` | Retain lifecycle registration orchestration only. |
| `whatsrust/lib/event_*_wiring.go` | Own cohesive event-family dispatch and callback/dedup boundaries. |
| `whatsrust/lib/event_wiring_test.go` | Verify the orchestration boundary and view-once deduplication. |
| `whatsrust/lib/*_events_test.go` | Update source-boundary assertions for extracted families. |

## Boundary

Parent PR #353 (`refactor/go-client-media-identity-callers`) remains the base. This slice stops at event-family wiring extraction; event conversion, event-family domain logic, and lifecycle internals remain in their existing owning files.

## Testing
- [x] `gofmt -w` on changed Go files
- [x] `go test ./...` from `whatsrust/lib`
- [x] `go vet ./...` from `whatsrust/lib`
- [x] `git diff --check`
- [x] No Cargo commands run

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:refactor` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Closes #354