### PR TITLE
refactor(app): extract navigation conversation dispatch

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -46,6 +46,7 @@ pub mod message_interactions;
 pub mod message_menu;
 pub mod message_navigation;
 pub mod message_opening;
+pub mod navigation_conversation_dispatch;
 pub mod notifications;
 pub mod optimistic_text_send;
 pub mod preferences;

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -1,7 +1,7 @@
 use ratatui::crossterm::event::Event;
 
 use crate::app::App;
-use crate::app::actions::{AppAction, ConversationMode, FocusPane, Section, focus_after};
+use crate::app::actions::{AppAction, FocusPane, Section, focus_after};
 pub use crate::app::composer_input_mapping::composer_action_for_editing_key;
 pub use crate::app::composer_input_paste::apply_clipboard_paste;
 use crate::app::input_router::{InputRoute, ModalContext, route_context_key, route_modal_key};
@@ -333,108 +333,28 @@ impl App<'_> {
                 self.dispatch_lifecycle_settings_action(action)
                     .expect("lifecycle/settings action family must be handled by its dispatcher");
             }
-            AppAction::FocusNext | AppAction::FocusPrevious => {}
-            AppAction::SelectNext => self.select_next(),
-            AppAction::SelectPrevious => self.select_previous(),
-            AppAction::JumpTop => self.jump_top(),
-            AppAction::JumpBottom => self.jump_bottom(),
-            AppAction::HalfPageDown => self.half_page_down(),
-            AppAction::HalfPageUp => self.half_page_up(),
-            AppAction::InsertMode => {
-                if self.focus_pane == FocusPane::Conversation && !self.composer_blocked() {
-                    self.conversation_mode = ConversationMode::ComposerEditing;
-                }
-            }
-            AppAction::CopyMessage => self.copy_selected_text(),
-            AppAction::ReplyMessage => {
-                if self.selected_section == Section::Status {
-                    self.reply_to_status();
-                } else {
-                    self.reply_to_selected();
-                }
-            }
-            AppAction::ReplyPrivately => self.reply_privately(),
-            AppAction::ShareMessage => self.open_share_picker(),
-            AppAction::ReactMessage => {
-                if self.selected_section == Section::Status {
-                    self.heart_selected_status();
-                } else {
-                    self.open_reaction_picker();
-                }
-            }
-            AppAction::DeleteMessage => self.delete_selected_message(),
-            AppAction::EditMessage => self.start_message_edit(),
-            AppAction::OpenChat => {
-                if self.selected_section == Section::Status {
-                    let opened = self.selected_status_contact().is_some();
-                    if opened {
-                        self.open_selected_status();
-                        self.focus_pane = FocusPane::Conversation;
-                        if self.status_message_count() > 0 {
-                            self.message_list_state.select(Some(0));
-                        }
-                    }
-                } else if self.selected_section == Section::Communities
-                    && self.community_detail.is_none()
-                {
-                    match self
-                        .community_navigation_rows()
-                        .into_iter()
-                        .filter(|row| !matches!(row, crate::app::CommunityNavigationRow::Separator))
-                        .nth(self.chat_list_state.selected().unwrap_or_default())
-                    {
-                        Some(crate::app::CommunityNavigationRow::Root(jid))
-                        | Some(crate::app::CommunityNavigationRow::ViewAll(jid)) => {
-                            self.open_community_detail(jid);
-                        }
-                        Some(crate::app::CommunityNavigationRow::Group(jid))
-                        | Some(crate::app::CommunityNavigationRow::Announcement(jid)) => {
-                            self.open_chat_by_jid(jid);
-                            self.focus_pane = FocusPane::Conversation;
-                        }
-                        Some(crate::app::CommunityNavigationRow::Separator) => {}
-                        None => {}
-                    }
-                } else if let Some(root) = self.selected_community_contact() {
-                    let unread = self
-                        .communities
-                        .iter()
-                        .find(|node| node.jid == root)
-                        .map(|node| {
-                            node.linked_groups
-                                .iter()
-                                .filter(|jid| self.pending_new_messages(jid) > 0)
-                                .cloned()
-                                .collect::<Vec<_>>()
-                        })
-                        .unwrap_or_default();
-                    if unread.len() == 1 {
-                        self.open_chat_by_jid(unread[0].clone());
-                        self.focus_pane = FocusPane::Conversation;
-                        if self.message_count() > 0 {
-                            self.message_list_state.select(Some(0));
-                        }
-                    } else {
-                        self.open_community_detail(root);
-                    }
-                } else {
-                    let opened = self.get_selected_chat().is_some();
-                    self.open_selected_chat();
-                    if opened {
-                        self.focus_pane = FocusPane::Conversation;
-                        if self.message_count() > 0 {
-                            self.message_list_state.select(Some(0));
-                        }
-                    }
-                }
-            }
-            AppAction::OpenMessage => self.open_selected_url(),
-            AppAction::GoToReference => {
-                if !self.follow_selected_reference() {
-                    self.unavailable("Reference is not available");
-                }
-            }
-            AppAction::Composer(action) => self.dispatch_composer_action(action),
+            action @ (AppAction::FocusNext
+            | AppAction::FocusPrevious
+            | AppAction::SelectNext
+            | AppAction::SelectPrevious
+            | AppAction::JumpTop
+            | AppAction::JumpBottom
+            | AppAction::HalfPageDown
+            | AppAction::HalfPageUp
+            | AppAction::InsertMode
+            | AppAction::CopyMessage
+            | AppAction::ReplyMessage
+            | AppAction::ReplyPrivately
+            | AppAction::ShareMessage
+            | AppAction::ReactMessage
+            | AppAction::DeleteMessage
+            | AppAction::EditMessage
+            | AppAction::OpenChat
+            | AppAction::OpenMessage
+            | AppAction::GoToReference
+            | AppAction::Composer(_)) => self
+                .dispatch_navigation_conversation_action(action)
+                .expect("navigation/conversation action family must be handled by its dispatcher"),
         }
     }
 

--- a/src/app/navigation_conversation_dispatch.rs
+++ b/src/app/navigation_conversation_dispatch.rs
@@ -1,0 +1,192 @@
+use crate::app::App;
+use crate::app::actions::{AppAction, ConversationMode, FocusPane, Section};
+
+impl App<'_> {
+    pub(crate) fn dispatch_navigation_conversation_action(
+        &mut self,
+        action: AppAction,
+    ) -> Result<(), AppAction> {
+        match action {
+            AppAction::FocusNext | AppAction::FocusPrevious => {}
+            AppAction::SelectNext => self.select_next(),
+            AppAction::SelectPrevious => self.select_previous(),
+            AppAction::JumpTop => self.jump_top(),
+            AppAction::JumpBottom => self.jump_bottom(),
+            AppAction::HalfPageDown => self.half_page_down(),
+            AppAction::HalfPageUp => self.half_page_up(),
+            AppAction::InsertMode => {
+                if self.focus_pane == FocusPane::Conversation && !self.composer_blocked() {
+                    self.conversation_mode = ConversationMode::ComposerEditing;
+                }
+            }
+            AppAction::CopyMessage => self.copy_selected_text(),
+            AppAction::ReplyMessage => {
+                if self.selected_section == Section::Status {
+                    self.reply_to_status();
+                } else {
+                    self.reply_to_selected();
+                }
+            }
+            AppAction::ReplyPrivately => self.reply_privately(),
+            AppAction::ShareMessage => self.open_share_picker(),
+            AppAction::ReactMessage => {
+                if self.selected_section == Section::Status {
+                    self.heart_selected_status();
+                } else {
+                    self.open_reaction_picker();
+                }
+            }
+            AppAction::DeleteMessage => self.delete_selected_message(),
+            AppAction::EditMessage => self.start_message_edit(),
+            AppAction::OpenChat => {
+                if self.selected_section == Section::Status {
+                    let opened = self.selected_status_contact().is_some();
+                    if opened {
+                        self.open_selected_status();
+                        self.focus_pane = FocusPane::Conversation;
+                        if self.status_message_count() > 0 {
+                            self.message_list_state.select(Some(0));
+                        }
+                    }
+                } else if self.selected_section == Section::Communities
+                    && self.community_detail.is_none()
+                {
+                    match self
+                        .community_navigation_rows()
+                        .into_iter()
+                        .filter(|row| !matches!(row, crate::app::CommunityNavigationRow::Separator))
+                        .nth(self.chat_list_state.selected().unwrap_or_default())
+                    {
+                        Some(crate::app::CommunityNavigationRow::Root(jid))
+                        | Some(crate::app::CommunityNavigationRow::ViewAll(jid)) => {
+                            self.open_community_detail(jid);
+                        }
+                        Some(crate::app::CommunityNavigationRow::Group(jid))
+                        | Some(crate::app::CommunityNavigationRow::Announcement(jid)) => {
+                            self.open_chat_by_jid(jid);
+                            self.focus_pane = FocusPane::Conversation;
+                        }
+                        Some(crate::app::CommunityNavigationRow::Separator) => {}
+                        None => {}
+                    }
+                } else if let Some(root) = self.selected_community_contact() {
+                    let unread = self
+                        .communities
+                        .iter()
+                        .find(|node| node.jid == root)
+                        .map(|node| {
+                            node.linked_groups
+                                .iter()
+                                .filter(|jid| self.pending_new_messages(jid) > 0)
+                                .cloned()
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default();
+                    if unread.len() == 1 {
+                        self.open_chat_by_jid(unread[0].clone());
+                        self.focus_pane = FocusPane::Conversation;
+                        if self.message_count() > 0 {
+                            self.message_list_state.select(Some(0));
+                        }
+                    } else {
+                        self.open_community_detail(root);
+                    }
+                } else {
+                    let opened = self.get_selected_chat().is_some();
+                    self.open_selected_chat();
+                    if opened {
+                        self.focus_pane = FocusPane::Conversation;
+                        if self.message_count() > 0 {
+                            self.message_list_state.select(Some(0));
+                        }
+                    }
+                }
+            }
+            AppAction::OpenMessage => self.open_selected_url(),
+            AppAction::GoToReference => {
+                if !self.follow_selected_reference() {
+                    self.unavailable("Reference is not available");
+                }
+            }
+            AppAction::Composer(action) => self.dispatch_composer_action(action),
+            action @ (AppAction::Quit
+            | AppAction::Logout
+            | AppAction::ToggleLogs
+            | AppAction::ToggleSectionRail
+            | AppAction::ToggleChatList
+            | AppAction::FocusPane(_)
+            | AppAction::OpenContextualActions
+            | AppAction::ToggleShortcutPopup
+            | AppAction::ToggleComposerDirection
+            | AppAction::PlannedLeaderAction(_)
+            | AppAction::ViewMessage
+            | AppAction::DownloadMessage
+            | AppAction::ViewerNext
+            | AppAction::ViewerPrevious
+            | AppAction::ViewerZoomIn
+            | AppAction::ViewerZoomOut
+            | AppAction::ViewerOpenExternal
+            | AppAction::CloseAttachmentViewer
+            | AppAction::CloseStatusPane
+            | AppAction::OpenMessageMenu
+            | AppAction::MenuNext
+            | AppAction::MenuPrevious
+            | AppAction::ConfirmMessageMenu
+            | AppAction::CancelMessageMenu
+            | AppAction::ReactionPrev
+            | AppAction::ReactionNext
+            | AppAction::ConfirmReaction
+            | AppAction::CancelReaction
+            | AppAction::SharePickerPrevious
+            | AppAction::SharePickerNext
+            | AppAction::ToggleShareRecipient
+            | AppAction::ConfirmShare
+            | AppAction::CancelShare
+            | AppAction::ShareSearchBackspace
+            | AppAction::ShareSearchCharacter(_)
+            | AppAction::UrlPickerPrevious
+            | AppAction::UrlPickerNext
+            | AppAction::ConfirmUrlPicker
+            | AppAction::CancelUrlPicker
+            | AppAction::AttachFile
+            | AppAction::FilePickerPrevious
+            | AppAction::FilePickerNext
+            | AppAction::FilePickerParent
+            | AppAction::FilePickerDescend
+            | AppAction::FilePickerToggle
+            | AppAction::FilePickerConfirm
+            | AppAction::FilePickerEnterSearch
+            | AppAction::FilePickerEndSearch
+            | AppAction::FilePickerBackspace
+            | AppAction::FilePickerCharacter(_)
+            | AppAction::CancelFilePicker) => return Err(action),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_support::TestApp;
+
+    #[test]
+    fn insert_mode_is_handled_by_navigation_conversation_dispatch() {
+        let mut app = TestApp::new();
+        app.focus_pane = FocusPane::Conversation;
+
+        app.dispatch_action(AppAction::InsertMode);
+
+        assert_eq!(app.conversation_mode, ConversationMode::ComposerEditing);
+    }
+
+    #[test]
+    fn lifecycle_actions_are_returned_to_their_dispatcher() {
+        let mut app = TestApp::new();
+
+        assert_eq!(
+            app.dispatch_navigation_conversation_action(AppAction::ToggleLogs),
+            Err(AppAction::ToggleLogs)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Extract navigation and conversation `AppAction` execution from `src/app/inputs.rs` into a cohesive dispatcher.
- Keep terminal input orchestration, policy guards, focus coordination, and exhaustive family routing in `inputs.rs`.

## Changes

- Add `src/app/navigation_conversation_dispatch.rs` for navigation, message, chat-opening, reference, and composer action effects.
- Delegate the explicit remaining action family from `dispatch_action`.
- Add focused tests for composer entry and dispatcher-family boundaries.

## Chain Context

- Parent: PR #351 / `refactor/rust-input-lifecycle-dispatch`
- Current: 📍 navigation/conversation action dispatch
- Dependency: targets the parent branch and must merge after PR #351.
- This completes the Rust inputs SRP dispatch-family chain.

```text
PR #347 (picker/viewer dispatch)
        |
        v
PR #351 (lifecycle/settings dispatch)
        |
        v
📍 this PR (navigation/conversation dispatch)
```

## Boundary

Start: `dispatch_action` retains focus/policy coordination and explicit routing of all `AppAction` families.
End: navigation/conversation effects live in `navigation_conversation_dispatch.rs`; `inputs.rs` owns terminal input orchestration/routing coordination plus delegation.

## Testing

- [x] `git diff --check`
- [ ] `cargo test -- --test-threads=1` (not run per task constraint)
- [ ] `cd whatsrust/lib && go test ./...` (not run per task constraint)
- [ ] `cargo fmt --check` (not run per task constraint)
- [ ] Manual testing (not run per task constraint)

Closes #356