### PR TITLE
fix(whatsrust): prevent lifecycle registration deadlock

### DIFF
--- a/whatsrust/lib/client_lifecycle.go
+++ b/whatsrust/lib/client_lifecycle.go
@@ -37,6 +37,7 @@ type clientLifecycleState struct {
 	mu                 sync.Mutex
 	qrChan             <-chan whatsmeow.QRChannelItem
 	handlersRegistered bool
+	registrationDone   chan struct{}
 }
 
 var lifecycleState clientLifecycleState
@@ -58,20 +59,50 @@ func (state *clientLifecycleState) publishClient(newClient *whatsmeow.Client) {
 
 func (state *clientLifecycleState) reset() {
 	state.mu.Lock()
-	defer state.mu.Unlock()
+	for state.registrationDone != nil {
+		done := state.registrationDone
+		state.mu.Unlock()
+		<-done
+		state.mu.Lock()
+	}
 	client = nil
 	state.qrChan = nil
 	state.handlersRegistered = false
+	state.mu.Unlock()
 }
 
 func (state *clientLifecycleState) registerEventHandlers(register func()) {
 	state.mu.Lock()
-	defer state.mu.Unlock()
 	if state.handlersRegistered {
+		state.mu.Unlock()
 		return
 	}
+	if state.registrationDone != nil {
+		done := state.registrationDone
+		state.mu.Unlock()
+		<-done
+		state.registerEventHandlers(register)
+		return
+	}
+	done := make(chan struct{})
+	state.registrationDone = done
+	state.mu.Unlock()
+
+	registered := false
+	defer func() {
+		state.mu.Lock()
+		if state.registrationDone == done {
+			if registered {
+				state.handlersRegistered = true
+			}
+			state.registrationDone = nil
+			close(done)
+		}
+		state.mu.Unlock()
+	}()
+
 	register()
-	state.handlersRegistered = true
+	registered = true
 }
 
 //export C_NewClient

--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"go.mau.fi/whatsmeow"
 )
@@ -49,6 +51,89 @@ func TestClientLifecycleRegistrationIsIdempotent(t *testing.T) {
 
 	if registrations != 1 {
 		t.Fatalf("registrations = %d, want one", registrations)
+	}
+}
+
+func TestClientLifecycleRegistrationCallbackCanTakeClientSnapshot(t *testing.T) {
+	var state clientLifecycleState
+	done := make(chan struct{})
+
+	go func() {
+		state.registerEventHandlers(func() {
+			state.clientSnapshot()
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("registration callback deadlocked while taking a client snapshot")
+	}
+}
+
+func TestClientLifecycleRegistrationIsConcurrentAndOnceOnly(t *testing.T) {
+	var state clientLifecycleState
+	const callers = 16
+	var registrations int
+	var registrationsMu sync.Mutex
+	started := make(chan struct{})
+	release := make(chan struct{})
+	register := func() {
+		registrationsMu.Lock()
+		registrations++
+		registrationsMu.Unlock()
+		close(started)
+		<-release
+	}
+
+	var waiters sync.WaitGroup
+	waiters.Add(callers)
+	for range callers {
+		go func() {
+			defer waiters.Done()
+			state.registerEventHandlers(register)
+		}()
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("registration did not start")
+	}
+	close(release)
+	finished := make(chan struct{})
+	go func() {
+		waiters.Wait()
+		close(finished)
+	}()
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent registration did not complete")
+	}
+
+	registrationsMu.Lock()
+	defer registrationsMu.Unlock()
+	if registrations != 1 {
+		t.Fatalf("registrations = %d, want one", registrations)
+	}
+}
+
+func TestClientLifecycleRegistrationPanicCanRetry(t *testing.T) {
+	var state clientLifecycleState
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("registration panic was not propagated")
+			}
+		}()
+		state.registerEventHandlers(func() { panic("registration failed") })
+	}()
+
+	registrations := 0
+	state.registerEventHandlers(func() { registrations++ })
+	if registrations != 1 {
+		t.Fatalf("retry registrations = %d, want one", registrations)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix startup deadlock caused by invoking event-handler registration while holding the lifecycle mutex.
- Preserve once-only registration under concurrency and permit retry after a registration panic.

## Changes

- Coordinate registration attempts with a completion channel while executing callbacks outside `lifecycleState.mu`.
- Wait for in-flight registration during lifecycle reset.
- Add bounded callback re-entry, concurrent once-only, and panic-retry regression tests.

## Testing

- [x] `cd whatsrust/lib && go test ./...`
- [x] `cd whatsrust/lib && go test -race ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` and `git diff --check`
- [ ] Cargo checks not run per request.

Closes #359