### PR TITLE
refactor(bridge): extract download file ID codec

### DIFF
--- a/whatsrust/lib/download_file_id.go
+++ b/whatsrust/lib/download_file_id.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+
+	"go.mau.fi/whatsmeow"
+)
+
+type downloadableMessageWithLength interface {
+	whatsmeow.DownloadableMessage
+	GetFileLength() uint64
+}
+
+type downloadableMessageWithSizeBytes interface {
+	whatsmeow.DownloadableMessage
+	GetFileSizeBytes() uint64
+}
+
+func getSize(msg whatsmeow.DownloadableMessage) int {
+	switch sized := msg.(type) {
+	case downloadableMessageWithLength:
+		return int(sized.GetFileLength())
+	case downloadableMessageWithSizeBytes:
+		return int(sized.GetFileSizeBytes())
+	default:
+		return -1
+	}
+}
+
+var downloadInfoVersion = 1 // bump version upon any struct change
+
+type DownloadInfo struct {
+	Version int `json:"Version_int"`
+	// Url        string `json:"Url_string"`
+	DirectPath string `json:"DirectPath_string"`
+
+	TargetPath string              `json:"TargetPath_string"`
+	MediaKey   []byte              `json:"MediaKey_arraybyte"`
+	MediaType  whatsmeow.MediaType `json:"MediaType_MediaType"`
+	Size       int                 `json:"Size_int"`
+
+	FileEncSha256 []byte `json:"FileEncSha256_arraybyte"`
+	FileSha256    []byte `json:"FileSha256_arraybyte"`
+
+	// Optional video thumbnail sidecar
+	ThumbnailData       []byte `json:"ThumbnailData_arraybyte,omitempty"`
+	ThumbnailTargetPath string `json:"ThumbnailTargetPath_string,omitempty"`
+}
+
+func marshalDownloadInfo(info DownloadInfo) ([]byte, error) {
+	return json.Marshal(info)
+}
+
+func unmarshalDownloadInfo(fileID []byte) (DownloadInfo, error) {
+	var info DownloadInfo
+	err := json.Unmarshal(fileID, &info)
+	return info, err
+}
+
+// AddThumbnailToFileId embeds JPEG thumbnail data into an existing fileId
+// so DownloadFromFileId can save it as a sidecar alongside the media file.
+func AddThumbnailToFileId(fileId string, thumbnailData []byte, thumbTargetPath string) string {
+	if len(thumbnailData) == 0 || thumbTargetPath == "" {
+		return fileId
+	}
+	info, err := unmarshalDownloadInfo([]byte(fileId))
+	if err != nil {
+		return fileId
+	}
+	info.ThumbnailData = thumbnailData
+	info.ThumbnailTargetPath = thumbTargetPath
+	bytes, err := marshalDownloadInfo(info)
+	if err != nil {
+		return fileId
+	}
+	return string(bytes)
+}
+
+func DownloadableMessageToFileId(client *whatsmeow.Client, msg whatsmeow.DownloadableMessage, targetPath string) string {
+	var info DownloadInfo
+	info.Version = downloadInfoVersion
+
+	info.TargetPath = targetPath
+	info.MediaKey = msg.GetMediaKey()
+	info.Size = getSize(msg)
+	info.FileEncSha256 = msg.GetFileEncSHA256()
+	info.FileSha256 = msg.GetFileSHA256()
+	info.DirectPath = msg.GetDirectPath()
+
+	info.MediaType = whatsmeow.GetMediaType(msg)
+	if len(info.MediaType) == 0 {
+		return ""
+	}
+
+	bytes, err := marshalDownloadInfo(info)
+	if err != nil {
+		return ""
+	}
+
+	return string(bytes)
+}
+
+func FileIdToDownloadInfo(fileId string) (DownloadInfo, error) {
+	info, err := unmarshalDownloadInfo([]byte(fileId))
+	if err != nil {
+		return info, err
+	}
+	if info.Version != downloadInfoVersion {
+		return info, err
+	}
+	return info, nil
+}

--- a/whatsrust/lib/download_file_id_test.go
+++ b/whatsrust/lib/download_file_id_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+)
+
+func TestDownloadInfoEncodingPreservesWireMetadata(t *testing.T) {
+	want := DownloadInfo{
+		Version:             downloadInfoVersion,
+		DirectPath:          "/v/t62/media",
+		TargetPath:          "videos/message.mp4",
+		MediaKey:            []byte("media-key"),
+		MediaType:           whatsmeow.MediaVideo,
+		Size:                42,
+		FileEncSha256:       []byte("encrypted-hash"),
+		FileSha256:          []byte("plain-hash"),
+		ThumbnailData:       []byte("thumbnail"),
+		ThumbnailTargetPath: "videos/message.jpg",
+	}
+
+	encoded, err := marshalDownloadInfo(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := unmarshalDownloadInfo(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != want.Version || got.DirectPath != want.DirectPath || got.TargetPath != want.TargetPath || got.MediaType != want.MediaType || got.Size != want.Size || got.ThumbnailTargetPath != want.ThumbnailTargetPath || !bytes.Equal(got.MediaKey, want.MediaKey) || !bytes.Equal(got.FileEncSha256, want.FileEncSha256) || !bytes.Equal(got.FileSha256, want.FileSha256) || !bytes.Equal(got.ThumbnailData, want.ThumbnailData) {
+		t.Fatalf("decoded metadata = %#v, want %#v", got, want)
+	}
+}
+
+func TestAddThumbnailToFileIdLeavesInvalidOrEmptyInputsUntouched(t *testing.T) {
+	for _, fileID := range []string{"not-json", `{"Version_int":1}`} {
+		if got := AddThumbnailToFileId(fileID, nil, "video.jpg"); got != fileID {
+			t.Fatalf("file ID %q changed to %q", fileID, got)
+		}
+	}
+	if got := AddThumbnailToFileId("not-json", []byte("thumbnail"), "video.jpg"); got != "not-json" {
+		t.Fatalf("invalid file ID changed to %q", got)
+	}
+}
+
+func TestAddThumbnailToFileIdEmbedsSidecarMetadata(t *testing.T) {
+	fileID, err := marshalDownloadInfo(DownloadInfo{Version: downloadInfoVersion, TargetPath: "video.mp4"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	withThumbnail := AddThumbnailToFileId(string(fileID), []byte("thumbnail"), "video.jpg")
+	got, err := FileIdToDownloadInfo(withThumbnail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got.ThumbnailData, []byte("thumbnail")) || got.ThumbnailTargetPath != "video.jpg" {
+		t.Fatalf("thumbnail metadata = %#v", got)
+	}
+}

--- a/whatsrust/lib/lib.go
+++ b/whatsrust/lib/lib.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -34,91 +33,6 @@ var mediaTypeToMMSType = map[whatsmeow.MediaType]string{
 	MediaLinkThumbnail: "thumbnail-link",
 }
 
-type downloadableMessageWithLength interface {
-	whatsmeow.DownloadableMessage
-	GetFileLength() uint64
-}
-
-type downloadableMessageWithSizeBytes interface {
-	whatsmeow.DownloadableMessage
-	GetFileSizeBytes() uint64
-}
-
-func getSize(msg whatsmeow.DownloadableMessage) int {
-	switch sized := msg.(type) {
-	case downloadableMessageWithLength:
-		return int(sized.GetFileLength())
-	case downloadableMessageWithSizeBytes:
-		return int(sized.GetFileSizeBytes())
-	default:
-		return -1
-	}
-}
-
-var downloadInfoVersion = 1 // bump version upon any struct change
-type DownloadInfo struct {
-	Version int `json:"Version_int"`
-	// Url        string `json:"Url_string"`
-	DirectPath string `json:"DirectPath_string"`
-
-	TargetPath string              `json:"TargetPath_string"`
-	MediaKey   []byte              `json:"MediaKey_arraybyte"`
-	MediaType  whatsmeow.MediaType `json:"MediaType_MediaType"`
-	Size       int                 `json:"Size_int"`
-
-	FileEncSha256 []byte `json:"FileEncSha256_arraybyte"`
-	FileSha256    []byte `json:"FileSha256_arraybyte"`
-
-	// Optional video thumbnail sidecar
-	ThumbnailData       []byte `json:"ThumbnailData_arraybyte,omitempty"`
-	ThumbnailTargetPath string `json:"ThumbnailTargetPath_string,omitempty"`
-}
-
-// AddThumbnailToFileId embeds JPEG thumbnail data into an existing fileId
-// so DownloadFromFileId can save it as a sidecar alongside the media file.
-func AddThumbnailToFileId(fileId string, thumbnailData []byte, thumbTargetPath string) string {
-	if len(thumbnailData) == 0 || thumbTargetPath == "" {
-		return fileId
-	}
-	var info DownloadInfo
-	if err := json.Unmarshal([]byte(fileId), &info); err != nil {
-		return fileId
-	}
-	info.ThumbnailData = thumbnailData
-	info.ThumbnailTargetPath = thumbTargetPath
-	bytes, err := json.Marshal(info)
-	if err != nil {
-		return fileId
-	}
-	return string(bytes)
-}
-
-func DownloadableMessageToFileId(client *whatsmeow.Client, msg whatsmeow.DownloadableMessage, targetPath string) string {
-	var info DownloadInfo
-	info.Version = downloadInfoVersion
-
-	info.TargetPath = targetPath
-	info.MediaKey = msg.GetMediaKey()
-	info.Size = getSize(msg)
-	info.FileEncSha256 = msg.GetFileEncSHA256()
-	info.FileSha256 = msg.GetFileSHA256()
-	info.DirectPath = msg.GetDirectPath()
-
-	info.MediaType = whatsmeow.GetMediaType(msg)
-	if len(info.MediaType) == 0 {
-		return ""
-	}
-
-	bytes, err := json.Marshal(info)
-	if err != nil {
-		return ""
-	}
-
-	str := string(bytes)
-
-	return str
-}
-
 const (
 	FileStatusNone = iota - 1
 	FileStatusDownloaded
@@ -137,17 +51,6 @@ func DownloadFromFileInfo(client *whatsmeow.Client, info DownloadInfo) ([]byte, 
 		mediaTypeToMMSType[info.MediaType],
 		false,
 	)
-}
-func FileIdToDownloadInfo(fileId string) (DownloadInfo, error) {
-	var info DownloadInfo
-	err := json.Unmarshal([]byte(fileId), &info)
-	if err != nil {
-		return info, err
-	}
-	if info.Version != downloadInfoVersion {
-		return info, err
-	}
-	return info, nil
 }
 func DownloadFromFileId(client *whatsmeow.Client, fileId string, basePath string) int {
 	if client == nil {


### PR DESCRIPTION
## Summary

- Extract download metadata serialization and compatibility handling from the legacy facade.
- Preserve existing download behavior and public Go bridge contracts.

## Changes

- Add the file-ID codec and focused compatibility tests.\n- Remove codec ownership from `lib.go`.

## Testing

- [x] Focused Go tests for this responsibility
- [x] `cd whatsrust/lib && go test -count=1 ./...`
- [x] `cd whatsrust/lib && go vet ./...`
- [x] `gofmt` check
- [x] `git diff --check`
- [ ] Manual testing not required for behavior-preserving extraction

## Chain Context

```text
beta\n└── refactor/go-download-srp (tracker)\n    └── 📍 refactor/go-download-srp-file-id\n        └── refactor/go-download-srp-storage\n            └── refactor/go-download-srp-media
```

**Start:** previous branch shown above.
**End:** one download responsibility has a dedicated owner.
**Follow-up:** the next child branch in the diagram.
**Out of scope:** ABI, serialized format, network semantics, and filesystem behavior changes.

Closes #362
