### PR TITLE
refactor(chat-store): delegate cursor restoration to read state

### DIFF
--- a/src/app/chat_store/hydration.rs
+++ b/src/app/chat_store/hydration.rs
@@ -36,16 +36,7 @@ impl App<'_> {
             }
             Err(error) => log::error!("status cursor read failed: {error}"),
         }
-        for (chat, message_id, timestamp) in self.db_handler.read_cursors() {
-            self.timeline.insert(
-                chat,
-                super::super::unread_messages::ChatTimelineState {
-                    pending_new_messages: 0,
-                    last_read_message: Some(message_id),
-                    last_read_at: Some(timestamp),
-                },
-            );
-        }
+        self.restore_read_cursors();
 
         for action in self.db_handler.get_message_actions() {
             self.local_action_sequence = self.local_action_sequence.max(

--- a/src/app/chat_store/read_state.rs
+++ b/src/app/chat_store/read_state.rs
@@ -2,6 +2,19 @@ use super::super::App;
 use whatsrust as wr;
 
 impl App<'_> {
+    pub(super) fn restore_read_cursors(&mut self) {
+        for (chat, message_id, timestamp) in self.db_handler.read_cursors() {
+            self.timeline.insert(
+                chat,
+                super::super::unread_messages::ChatTimelineState {
+                    pending_new_messages: 0,
+                    last_read_message: Some(message_id),
+                    last_read_at: Some(timestamp),
+                },
+            );
+        }
+    }
+
     pub(super) fn is_viewing_latest_message(&self, chat: &wr::JID) -> bool {
         let latest = self
             .chat_messages

--- a/src/app/chat_store/tests.rs
+++ b/src/app/chat_store/tests.rs
@@ -37,7 +37,7 @@ fn receipt_coordination_has_a_dedicated_owner() {
 }
 
 #[test]
-fn read_state_policy_owns_read_transitions_without_cursor_restoration() {
+fn read_state_policy_owns_read_transitions_and_cursor_restoration() {
     let chat_store = include_str!("../chat_store.rs");
     let hydration = include_str!("hydration.rs");
     let read_state = include_str!("read_state.rs");
@@ -47,12 +47,51 @@ fn read_state_policy_owns_read_transitions_without_cursor_restoration() {
         "pub fn mark_chat_read_at_latest",
         "pub(crate) fn apply_remote_chat_read",
         "pub fn unread_boundary",
+        "pub(super) fn restore_read_cursors",
     ] {
         assert!(read_state.contains(method));
         assert!(!chat_store.contains(method));
     }
-    assert!(!read_state.contains("read_cursors"));
-    assert!(hydration.contains("db_handler.read_cursors"));
+    assert!(read_state.contains("db_handler.read_cursors"));
+    assert!(!hydration.contains("db_handler.read_cursors"));
+    assert!(hydration.contains("self.restore_read_cursors()"));
+}
+
+#[test]
+fn persisted_chat_cursor_restores_into_read_state() {
+    let directory = tempfile::tempdir().unwrap();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+    let message_id = wr::MessageId::from("read-message");
+    {
+        let app = TestApp::with_database(directory.path());
+        app.db_handler
+            .set_last_read_cursor(&chat, Some(message_id.clone()), 42);
+    }
+
+    let mut app = TestApp::with_database(directory.path());
+    app.restore_read_cursors();
+
+    assert_eq!(app.timeline[&chat].last_read_message, Some(message_id));
+    assert_eq!(app.timeline[&chat].last_read_at, Some(42));
+    assert_eq!(app.timeline[&chat].pending_new_messages, 0);
+}
+
+#[test]
+fn persisted_chat_cursor_survives_hydration_reload() {
+    let directory = tempfile::tempdir().unwrap();
+    let chat = wr::JID::from("chat@example.test".to_owned());
+    let message_id = wr::MessageId::from("read-message");
+    {
+        let app = TestApp::with_database(directory.path());
+        app.db_handler
+            .set_last_read_cursor(&chat, Some(message_id.clone()), 42);
+    }
+
+    let mut app = TestApp::with_database(directory.path());
+    app.load_data_from_db();
+
+    assert_eq!(app.timeline[&chat].last_read_message, Some(message_id));
+    assert_eq!(app.timeline[&chat].last_read_at, Some(42));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Move persisted chat cursor restoration into the read-state owner.
- Leave hydration responsible only for coordinating database loading.

## Changes

- Add `restore_read_cursors` to `read_state.rs`.
- Delegate cursor restoration from hydration.
- Add focused ownership and reload persistence coverage.

## Testing

- [x] Persisted cursor restoration regression
- [x] Chat-store test suite: 9 passed
- [x] Cursor transition and status regressions
- [x] `git diff --check`

## Chain Context

```text
beta
└── refactor/chat-store-srp (tracker)
    └── hydration (#363)
        └── storage (#367)
            └── receipts (#368)
                └── read-state (#369)
                    └── 📍 cursor restoration
```

**Start:** read-state policy is isolated.
**End:** persisted cursor restoration belongs to the same owner.
**Follow-up:** none for the `chat_store.rs` P0 boundary.
**Out of scope:** behavior, schema, UI, and bridge changes.

Closes #361
