### PR TITLE
fix(ffi): scope jid argument ownership

### DIFF
--- a/whatsrust/lib/receipt_events.go
+++ b/whatsrust/lib/receipt_events.go
@@ -104,7 +104,13 @@ func receiptKind(kind types.ReceiptType) uint8 {
 
 func dispatchReceiptEvent(receipt receiptEvent) {
 	n := len(receipt.messageIDs)
-	cmessageIDs := (**C.char)(C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0)))))
+	var cmessageIDs **C.char
+	if n > 0 {
+		cmessageIDs = (**C.char)(C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0)))))
+		if cmessageIDs == nil {
+			return
+		}
+	}
 	messageIDs := unsafe.Slice(cmessageIDs, n)
 	for i, id := range receipt.messageIDs {
 		messageIDs[i] = C.CString(id)

--- a/whatsrust/lib/receipt_events_test.go
+++ b/whatsrust/lib/receipt_events_test.go
@@ -132,3 +132,33 @@ func TestReceiptDispatchKeepsCArrayAndPayloadThroughCallback(t *testing.T) {
 		t.Fatal("receipt C array must be populated before the callback")
 	}
 }
+
+func TestReceiptDispatchAndRustDecoderSupportEmptyMessageIDs(t *testing.T) {
+	goSource, err := os.ReadFile("receipt_events.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	goBody, ok := extractFunctionBody(string(goSource), "func dispatchReceiptEvent(receipt receiptEvent)")
+	if !ok {
+		t.Fatal("dispatchReceiptEvent function body not found in receipt_events.go")
+	}
+	for _, fragment := range []string{
+		"var cmessageIDs **C.char",
+		"if n > 0 {",
+		"creceipt.messageIDs = cmessageIDs",
+		"creceipt.size = C.uint32_t(n)",
+	} {
+		if !strings.Contains(goBody, fragment) {
+			t.Fatalf("empty receipt dispatch must contain %q", fragment)
+		}
+	}
+
+	rustSource, err := os.ReadFile("../src/events.rs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rustText := string(rustSource)
+	if !strings.Contains(rustText, "if receipt.count == 0 { &[] } else {") {
+		t.Fatal("Rust receipt decoder must avoid dereferencing the message ID pointer for empty arrays")
+	}
+}

--- a/whatsrust/src/events.rs
+++ b/whatsrust/src/events.rs
@@ -19,8 +19,10 @@ impl CallbackTranslator<*const CEvent> for Event {
             EventType::Receipt => {
                 let receipt = unsafe { &(*(event.data as *const CReceipt)) };
                 let chat: JID = (&receipt.chat).into();
-                let message_ids = unsafe {
-                    std::slice::from_raw_parts(receipt.message_ids, receipt.count as usize)
+                let message_ids = if receipt.count == 0 { &[] } else {
+                    unsafe {
+                        std::slice::from_raw_parts(receipt.message_ids, receipt.count as usize)
+                    }
                 }
                 .iter()
                 .map(|&id| {

--- a/whatsrust/src/message_send.rs
+++ b/whatsrust/src/message_send.rs
@@ -3,7 +3,7 @@ use std::ffi::{CString, c_char, c_void};
 use crate::{
     abi::{CFileMessage, CJID, CTextMessage, MessageType},
     file_kind_discriminant,
-    models::{JID, Mention, Message, MessageContent},
+    models::{CJIDOwner, JID, Mention, Message, MessageContent},
 };
 
 /// Keeps CStrings and C structs alive for the duration of an FFI call.
@@ -101,21 +101,18 @@ pub(crate) fn build_content_for_ffi(
     }
 }
 
-pub(crate) fn quote_to_ffi(quoted: Option<&Message>) -> (CString, *const c_char, CJID, CJID) {
+pub(crate) fn quote_to_ffi(
+    quoted: Option<&Message>,
+) -> (CString, *const c_char, Option<CJIDOwner>, Option<CJIDOwner>) {
     match quoted {
         Some(qm) => {
             let id_c = CString::new(qm.info.id.as_ref()).unwrap();
             let id_ptr = id_c.as_ptr();
-            let sender = CJID::from(&qm.info.sender);
-            let chat = CJID::from(&qm.info.chat);
+            let sender = Some(CJIDOwner::from(&qm.info.sender));
+            let chat = Some(CJIDOwner::from(&qm.info.chat));
             (id_c, id_ptr, sender, chat)
         }
-        None => (
-            CString::default(),
-            std::ptr::null(),
-            std::ptr::null(),
-            std::ptr::null(),
-        ),
+        None => (CString::default(), std::ptr::null(), None, None),
     }
 }
 
@@ -152,11 +149,13 @@ pub fn forward_message(source: &Message, destinations: &[JID]) -> ForwardReport 
         );
     };
     let destination_pointers: Vec<_> = destination_values.iter().map(|jid| jid.as_ptr()).collect();
+    let source_chat = CJIDOwner::from(&source.info.chat);
+    let source_sender = CJIDOwner::from(&source.info.sender);
     let result = unsafe {
         crate::abi::C_ForwardMessage(
             source_id.as_ptr(),
-            CJID::from(&source.info.chat),
-            CJID::from(&source.info.sender),
+            source_chat.as_ptr(),
+            source_sender.as_ptr(),
             source.info.is_from_me,
             destination_pointers.as_ptr(),
             destination_pointers.len(),
@@ -177,9 +176,16 @@ pub fn send_message(
     quoted_message: Option<&Message>,
     mentions: &[Mention],
 ) {
-    let jid_c = CJID::from(jid);
+    let jid_c = CJIDOwner::from(jid);
     let (msg_type, content_ptr, _holder) = build_content_for_ffi(content, mentions);
-    let (_quote_id_owner, quote_id, quote_sender, quote_chat) = quote_to_ffi(quoted_message);
+    let (_quote_id_owner, quote_id, quote_sender_owner, quote_chat_owner) =
+        quote_to_ffi(quoted_message);
+    let quote_sender = quote_sender_owner
+        .as_ref()
+        .map_or(std::ptr::null(), CJIDOwner::as_ptr);
+    let quote_chat = quote_chat_owner
+        .as_ref()
+        .map_or(std::ptr::null(), CJIDOwner::as_ptr);
     let quote_content = quoted_message.map(|message| build_content_for_ffi(&message.message, &[]));
     let (quote_message_type, quote_message_content) = quote_content
         .as_ref()
@@ -188,7 +194,7 @@ pub fn send_message(
         });
     unsafe {
         crate::abi::C_SendMessage(
-            jid_c,
+            jid_c.as_ptr(),
             msg_type,
             content_ptr,
             quote_id,
@@ -216,9 +222,16 @@ pub fn send_text_message(
     let MessageContent::Text(_) = content else {
         return TextSendResult::Failed;
     };
-    let jid_c = CJID::from(jid);
+    let jid_c = CJIDOwner::from(jid);
     let (_message_type, content_ptr, _holder) = build_content_for_ffi(content, mentions);
-    let (_quote_id_owner, quote_id, quote_sender, quote_chat) = quote_to_ffi(quoted_message);
+    let (_quote_id_owner, quote_id, quote_sender_owner, quote_chat_owner) =
+        quote_to_ffi(quoted_message);
+    let quote_sender = quote_sender_owner
+        .as_ref()
+        .map_or(std::ptr::null(), CJIDOwner::as_ptr);
+    let quote_chat = quote_chat_owner
+        .as_ref()
+        .map_or(std::ptr::null(), CJIDOwner::as_ptr);
     let quote_content = quoted_message.map(|message| build_content_for_ffi(&message.message, &[]));
     let (quote_message_type, quote_message_content) = quote_content
         .as_ref()
@@ -227,7 +240,7 @@ pub fn send_text_message(
         });
     let status = unsafe {
         crate::abi::C_SendTextMessage(
-            jid_c,
+            jid_c.as_ptr(),
             content_ptr,
             quote_id,
             quote_sender,
@@ -250,6 +263,15 @@ mod tests {
     use super::*;
     use crate::models::{FileContent, FileKind, ForwardingInfo, JID, MessageInfo};
     #[test]
+    fn quote_without_message_keeps_jid_owners_absent() {
+        let (_, quote_id, sender, chat) = quote_to_ffi(None);
+
+        assert!(quote_id.is_null());
+        assert!(sender.is_none());
+        assert!(chat.is_none());
+    }
+
+    #[test]
     fn quote_transport_preserves_the_original_status_chat() {
         let quoted = Message {
             info: MessageInfo {
@@ -265,7 +287,9 @@ mod tests {
             },
             message: MessageContent::Text("status".into()),
         };
-        let (_id_owner, id, sender, chat) = quote_to_ffi(Some(&quoted));
+        let (_id_owner, id, sender_owner, chat_owner) = quote_to_ffi(Some(&quoted));
+        let sender = sender_owner.as_ref().unwrap().as_ptr();
+        let chat = chat_owner.as_ref().unwrap().as_ptr();
         assert_eq!(unsafe { CStr::from_ptr(id) }.to_str(), Ok("status-id"));
         assert_eq!(
             unsafe { CStr::from_ptr(sender) }.to_str(),

--- a/whatsrust/src/models.rs
+++ b/whatsrust/src/models.rs
@@ -29,9 +29,34 @@ impl From<&CJID> for JID {
     }
 }
 
-impl From<&JID> for CJID {
+#[cfg(test)]
+mod tests {
+    use super::{CJIDOwner, JID};
+    use std::ffi::CStr;
+
+    #[test]
+    fn jid_ffi_owner_exposes_borrowed_pointer_for_its_scope() {
+        let jid = JID::from("123@s.whatsapp.net".to_owned());
+        let owner = CJIDOwner::from(&jid);
+
+        assert_eq!(
+            unsafe { CStr::from_ptr(owner.as_ptr()) }.to_str(),
+            Ok("123@s.whatsapp.net")
+        );
+    }
+}
+
+pub(crate) struct CJIDOwner(CString);
+
+impl From<&JID> for CJIDOwner {
     fn from(jid: &JID) -> Self {
-        CString::new(jid.0.as_ref()).unwrap().into_raw()
+        Self(CString::new(jid.0.as_ref()).unwrap())
+    }
+}
+
+impl CJIDOwner {
+    pub(crate) fn as_ptr(&self) -> CJID {
+        self.0.as_ptr()
     }
 }
 

--- a/whatsrust/src/queries.rs
+++ b/whatsrust/src/queries.rs
@@ -4,16 +4,25 @@ use std::sync::Arc;
 use super::{
     ChatSettings, CommunitiesError, CommunityInfo, GroupInfo, GroupInfoError, GroupParticipant, JID,
 };
+use crate::models::CJIDOwner;
 use crate::abi::{
     C_FreeCommunities, C_FreeContacts, C_FreeGroupParticipants, C_FreeResolveDmChatId,
     C_GetChatSettings, C_GetCommunities, C_GetContacts, C_GetGroupInfo, C_GetGroupParticipants,
-    C_ResolveDmChatId, CJID,
+    C_ResolveDmChatId, CContactEntry, CGetContactsResult,
 };
 
 /// Returns all contacts and groups as (JID, display name). Includes LID aliases for contacts.
+fn contact_entries(result: &CGetContactsResult) -> &[CContactEntry] {
+    if result.entries.is_null() || result.size == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(result.entries, result.size as usize) }
+    }
+}
+
 pub fn get_contacts() -> Vec<(JID, Arc<str>)> {
     let result = unsafe { C_GetContacts() };
-    let entries = unsafe { std::slice::from_raw_parts(result.entries, result.size as usize) };
+    let entries = contact_entries(&result);
 
     let contacts = entries
         .iter()
@@ -84,7 +93,21 @@ pub fn get_communities() -> Result<Vec<CommunityInfo>, CommunitiesError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{community_announcement_from_code, community_participant_count_from_abi};
+    use super::{
+        community_announcement_from_code, community_participant_count_from_abi, contact_entries,
+    };
+    use crate::abi::CGetContactsResult;
+    use std::ptr;
+
+    #[test]
+    fn treats_null_empty_contact_results_as_empty() {
+        let result = CGetContactsResult {
+            entries: ptr::null(),
+            size: 0,
+        };
+
+        assert!(contact_entries(&result).is_empty());
+    }
 
     #[test]
     fn maps_community_announcement_tristate() {
@@ -110,8 +133,8 @@ mod tests {
 }
 
 pub fn get_chat_settings(jid: &JID) -> ChatSettings {
-    let jid_c = CJID::from(jid);
-    let settings = unsafe { C_GetChatSettings(jid_c) };
+    let jid_c = CJIDOwner::from(jid);
+    let settings = unsafe { C_GetChatSettings(jid_c.as_ptr()) };
 
     ChatSettings {
         found: settings.found,
@@ -142,14 +165,14 @@ fn group_info_from_parts(
 }
 
 pub fn get_group_info(jid: &JID) -> Result<GroupInfo, GroupInfoError> {
-    let jid_c = CJID::from(jid);
-    let result = unsafe { C_GetGroupInfo(jid_c) };
+    let jid_c = CJIDOwner::from(jid);
+    let result = unsafe { C_GetGroupInfo(jid_c.as_ptr()) };
     group_info_from_parts(jid, result.status, result.is_announce, result.is_admin)
 }
 
 pub fn get_group_participants(jid: &JID) -> Vec<GroupParticipant> {
-    let jid_c = CJID::from(jid);
-    let result = unsafe { C_GetGroupParticipants(jid_c) };
+    let jid_c = CJIDOwner::from(jid);
+    let result = unsafe { C_GetGroupParticipants(jid_c.as_ptr()) };
     if result.entries.is_null() || result.size == 0 {
         return Vec::new();
     }
@@ -185,7 +208,7 @@ pub fn get_group_participants(jid: &JID) -> Vec<GroupParticipant> {
 pub fn resolve_dm_chat(jid: &JID) -> Option<JID> {
     unsafe {
         super::presence::take_owned_c_string(
-            C_ResolveDmChatId(CJID::from(jid)),
+            C_ResolveDmChatId(CJIDOwner::from(jid).as_ptr()),
             C_FreeResolveDmChatId,
         )
         .map(JID::from)


### PR DESCRIPTION
Closes #374

## Summary
- keep Rust ownership of JID C strings across borrowed FFI calls
- decode empty FFI contact results without constructing a slice from a null pointer
- preserve the existing ABI

## Changes
| File | Change |
|---|---|
| `whatsrust/src/models.rs` | Add scoped ownership for C-compatible JIDs |
| `whatsrust/src/queries.rs` | Use scoped arguments and guard empty results |
| `whatsrust/src/message_send.rs` | Keep JID owners alive through outbound FFI calls |

## Test plan
- [x] `cargo test --manifest-path whatsrust/Cargo.toml` — 27 passed
- [x] Formatting and diff checks passed

## Checklist
- [x] Linked approved issue
- [x] Conventional commit
- [x] No generated or unrelated changes
