### PR TITLE
fix(events): release history sync payloads

### DIFF
--- a/whatsrust/lib/sync_events.go
+++ b/whatsrust/lib/sync_events.go
@@ -128,6 +128,8 @@ func dispatchHistorySync(
 			kind: C.uint8_t(EventTypeChat),
 			data: unsafe.Pointer(payload),
 		})
+		C.free(unsafe.Pointer(payload.chat))
+		C.free(unsafe.Pointer(payload))
 
 		for _, syncMessage := range conversation.GetMessages() {
 			webMessageInfo := syncMessage.Message

--- a/whatsrust/lib/sync_events_test.go
+++ b/whatsrust/lib/sync_events_test.go
@@ -82,6 +82,8 @@ func TestHistorySyncDispatchKeepsProgressChatAndMessageOrdering(t *testing.T) {
 		"EventTypeSyncProgress",
 		"C.free(unsafe.Pointer(cpercent))",
 		"EventTypeChat",
+		"C.free(unsafe.Pointer(payload.chat))",
+		"C.free(unsafe.Pointer(payload))",
 		"conversation.GetMessages()",
 		"dispatchMessage(parsed)",
 	} {
@@ -91,5 +93,11 @@ func TestHistorySyncDispatchKeepsProgressChatAndMessageOrdering(t *testing.T) {
 	}
 	if strings.Index(body, "EventTypeSyncProgress") > strings.Index(body, "EventTypeChat") {
 		t.Fatal("sync progress must be emitted before chat lifecycle events")
+	}
+	chatCallbackIndex := strings.Index(body, "C.callSyncEventCallback(eventHandler, &C.Event{\n\t\t\tkind: C.uint8_t(EventTypeChat)")
+	chatCleanupIndex := strings.Index(body, "C.free(unsafe.Pointer(payload.chat))")
+	payloadCleanupIndex := strings.Index(body, "C.free(unsafe.Pointer(payload))")
+	if chatCallbackIndex < 0 || chatCleanupIndex < 0 || payloadCleanupIndex < 0 || chatCallbackIndex > chatCleanupIndex || chatCleanupIndex > payloadCleanupIndex {
+		t.Fatal("history chat callback payload allocations must be freed after the callback")
 	}
 }


### PR DESCRIPTION
Closes #375

## Summary
- release history-sync chat callback allocations after synchronous delivery
- verify callback and nested/outer cleanup ordering

## Changes
| File | Change |
|---|---|
| `whatsrust/lib/sync_events.go` | Free chat JID and event payload after callback return |
| `whatsrust/lib/sync_events_test.go` | Assert CHAT callback and cleanup ordering |

## Test plan
- [x] Focused history-sync test passed
- [x] Full Go test suite passed
- [x] `gofmt` and diff checks passed

## Checklist
- [x] Linked approved issue
- [x] Conventional commit
- [x] No generated or unrelated changes
