### PR TITLE
fix(lifecycle): make logout nonblocking

### DIFF
--- a/whatsrust/lib/client_lifecycle.go
+++ b/whatsrust/lib/client_lifecycle.go
@@ -33,11 +33,21 @@ import (
 // the migrated callers observe one synchronized lifecycle boundary.
 var client *whatsmeow.Client
 
+type logoutReservation struct {
+	client     *whatsmeow.Client
+	generation uint64
+	done       chan struct{}
+}
+
 type clientLifecycleState struct {
-	mu                 sync.Mutex
-	qrChan             <-chan whatsmeow.QRChannelItem
-	handlersRegistered bool
-	registrationDone   chan struct{}
+	mu                   sync.Mutex
+	qrChan               <-chan whatsmeow.QRChannelItem
+	handlersRegistered   bool
+	registrationDone     chan struct{}
+	logoutDone           chan struct{}
+	logoutGeneration     uint64
+	logoutCallbackActive bool
+	resetInProgress      bool
 }
 
 var lifecycleState clientLifecycleState
@@ -59,6 +69,14 @@ func (state *clientLifecycleState) publishClient(newClient *whatsmeow.Client) {
 
 func (state *clientLifecycleState) reset() {
 	state.mu.Lock()
+	state.resetInProgress = true
+	state.logoutGeneration++
+	for state.logoutDone != nil {
+		done := state.logoutDone
+		state.mu.Unlock()
+		<-done
+		state.mu.Lock()
+	}
 	for state.registrationDone != nil {
 		done := state.registrationDone
 		state.mu.Unlock()
@@ -68,6 +86,43 @@ func (state *clientLifecycleState) reset() {
 	client = nil
 	state.qrChan = nil
 	state.handlersRegistered = false
+	state.resetInProgress = false
+	state.mu.Unlock()
+}
+
+func (state *clientLifecycleState) beginLogout() (logoutReservation, bool) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	reservation := logoutReservation{client: client}
+	if reservation.client == nil || state.logoutDone != nil || state.logoutCallbackActive || state.resetInProgress {
+		return reservation, false
+	}
+	reservation.generation = state.logoutGeneration
+	reservation.done = make(chan struct{})
+	state.logoutDone = reservation.done
+	return reservation, true
+}
+
+func (state *clientLifecycleState) completeLogout(done chan struct{}, generation uint64) bool {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	if state.logoutDone != done {
+		return false
+	}
+	state.logoutDone = nil
+	close(done)
+	if state.logoutGeneration != generation {
+		return false
+	}
+	state.logoutCallbackActive = true
+	return true
+}
+
+func (state *clientLifecycleState) finishLogoutCallback() {
+	state.mu.Lock()
+	state.logoutCallbackActive = false
 	state.mu.Unlock()
 }
 
@@ -210,36 +265,106 @@ func logoutStatusAfterRemoteFailure(localDeleteErr error) uint8 {
 	return logoutStatusLocalOnly
 }
 
+type logoutOperation struct {
+	timeout         time.Duration
+	remoteLogout    func(context.Context, *whatsmeow.Client) error
+	onRemoteFailure func(*whatsmeow.Client, error) uint8
+	emit            func(uint8)
+	state           *clientLifecycleState
+}
+
+func (operation logoutOperation) start(clientSnapshot *whatsmeow.Client) {
+	if operation.state != nil {
+		reservation, ok := operation.state.beginLogout()
+		if !ok {
+			return
+		}
+		operation.startWithReservation(reservation)
+		return
+	}
+	go operation.run(clientSnapshot, nil)
+}
+
+func (operation logoutOperation) startWithReservation(reservation logoutReservation) {
+	go operation.run(reservation.client, &reservation)
+}
+
+func (operation logoutOperation) run(clientSnapshot *whatsmeow.Client, reservation *logoutReservation) {
+	ctx, cancel := context.WithTimeout(context.Background(), operation.timeout)
+	defer cancel()
+
+	remoteResult := make(chan error, 1)
+	go func() {
+		remoteResult <- operation.remoteLogout(ctx, clientSnapshot)
+	}()
+
+	var err error
+	select {
+	case err = <-remoteResult:
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+	status := logoutStatusLoggedOut
+	switch {
+	case err == nil:
+		status = logoutStatusLoggedOut
+	case errors.Is(err, whatsmeow.ErrNotLoggedIn):
+		status = logoutStatusNotLoggedIn
+	default:
+		status = operation.onRemoteFailure(clientSnapshot, err)
+	}
+	if reservation != nil {
+		if !operation.state.completeLogout(reservation.done, reservation.generation) {
+			return
+		}
+		defer operation.state.finishLogoutCallback()
+	}
+	operation.emit(status)
+}
+
+const logoutStoreDeleteTimeout = 5 * time.Second
+
+func deleteLogoutStore(deleteStore func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), logoutStoreDeleteTimeout)
+	defer cancel()
+	return deleteStore(ctx)
+}
+
+func localLogoutAfterRemoteFailure(clientSnapshot *whatsmeow.Client, err error) uint8 {
+	LOG_ERROR("Logout: remote revocation failed, clearing locally only: %v", err)
+	clientSnapshot.Disconnect()
+	if clientSnapshot.Store == nil {
+		return logoutStatusLocalOnly
+	}
+	localDeleteErr := deleteLogoutStore(clientSnapshot.Store.Delete)
+	if localDeleteErr != nil {
+		LOG_ERROR("Logout: failed to clear local store: %v", localDeleteErr)
+	}
+	return logoutStatusAfterRemoteFailure(localDeleteErr)
+}
+
 //export C_Logout
 func C_Logout() C.uint8_t {
-	status := logoutStatusLoggedOut
-	clientSnapshot := lifecycleState.clientSnapshot()
-	if clientSnapshot == nil {
-		status = logoutStatusNotLoggedIn
-	} else {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		err := clientSnapshot.Logout(ctx)
-		cancel()
-		switch {
-		case err == nil:
-			status = logoutStatusLoggedOut
-		case errors.Is(err, whatsmeow.ErrNotLoggedIn):
-			status = logoutStatusNotLoggedIn
-		default:
-			LOG_ERROR("Logout: remote revocation failed, clearing locally only: %v", err)
-			clientSnapshot.Disconnect()
-			if clientSnapshot.Store == nil {
-				status = logoutStatusLocalOnly
-			} else {
-				localDeleteErr := clientSnapshot.Store.Delete(context.Background())
-				if localDeleteErr != nil {
-					LOG_ERROR("Logout: failed to clear local store: %v", localDeleteErr)
-				}
-				status = logoutStatusAfterRemoteFailure(localDeleteErr)
-			}
-		}
+	reservation, started := lifecycleState.beginLogout()
+	if reservation.client == nil {
+		clearAuthenticatedPushNameCache()
+		emitLogoutResult(logoutStatusNotLoggedIn)
+		return C.uint8_t(logoutStatusNotLoggedIn)
 	}
-	clearAuthenticatedPushNameCache()
-	emitLogoutResult(status)
-	return C.uint8_t(status)
+	if !started {
+		return C.uint8_t(logoutStatusLoggedOut)
+	}
+
+	logoutOperation{
+		timeout:         20 * time.Second,
+		remoteLogout:    func(ctx context.Context, client *whatsmeow.Client) error { return client.Logout(ctx) },
+		onRemoteFailure: localLogoutAfterRemoteFailure,
+		state:           &lifecycleState,
+		emit: func(status uint8) {
+			clearAuthenticatedPushNameCache()
+			emitLogoutResult(status)
+		},
+	}.startWithReservation(reservation)
+
+	return C.uint8_t(logoutStatusLoggedOut)
 }

--- a/whatsrust/lib/client_lifecycle_test.go
+++ b/whatsrust/lib/client_lifecycle_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -241,6 +242,216 @@ func TestClientLifecycleReconnectPublishesReplacementSnapshot(t *testing.T) {
 	state.publishClient(second)
 	if got := state.clientSnapshot(); got != second {
 		t.Fatalf("reconnect client snapshot = %p, want %p", got, second)
+	}
+}
+
+func TestLogoutOperationIsNonBlockingAndEmitsOneTerminalResult(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		remoteErr  error
+		wantStatus uint8
+	}{
+		{name: "success", wantStatus: logoutStatusLoggedOut},
+		{name: "error", remoteErr: errors.New("remote unavailable"), wantStatus: logoutStatusLocalOnly},
+		{name: "timeout", remoteErr: context.DeadlineExceeded, wantStatus: logoutStatusLocalOnly},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			started := make(chan struct{})
+			finished := make(chan struct{})
+			emitted := make(chan uint8, 2)
+			operation := logoutOperation{
+				timeout: 20 * time.Millisecond,
+				remoteLogout: func(ctx context.Context, _ *whatsmeow.Client) error {
+					close(started)
+					if testCase.remoteErr == context.DeadlineExceeded {
+						<-ctx.Done()
+						return ctx.Err()
+					}
+					return testCase.remoteErr
+				},
+				onRemoteFailure: func(_ *whatsmeow.Client, _ error) uint8 {
+					return logoutStatusLocalOnly
+				},
+				emit: func(status uint8) {
+					emitted <- status
+					close(finished)
+				},
+			}
+			operation.start(&whatsmeow.Client{})
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("logout operation did not start")
+			}
+			select {
+			case <-finished:
+			case <-time.After(time.Second):
+				t.Fatal("logout operation did not finish")
+			}
+			if got := <-emitted; got != testCase.wantStatus {
+				t.Fatalf("terminal status = %d, want %d", got, testCase.wantStatus)
+			}
+			select {
+			case extra := <-emitted:
+				t.Fatalf("received duplicate terminal status %d", extra)
+			case <-time.After(50 * time.Millisecond):
+			}
+		})
+	}
+}
+func TestLogoutStoreDeleteUsesBoundedContext(t *testing.T) {
+	called := make(chan context.Context, 1)
+	deleteErr := errors.New("delete stopped")
+	got := deleteLogoutStore(func(ctx context.Context) error {
+		called <- ctx
+		return deleteErr
+	})
+	if !errors.Is(got, deleteErr) {
+		t.Fatalf("delete error = %v, want %v", got, deleteErr)
+	}
+	select {
+	case ctx := <-called:
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("logout store delete context has no deadline")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("logout store delete was not called")
+	}
+}
+func TestClientLifecycleAllowsOnlyOneLogoutInFlight(t *testing.T) {
+	var state clientLifecycleState
+	previous := client
+	t.Cleanup(func() { state.publishClient(previous) })
+	firstClient := &whatsmeow.Client{}
+	state.publishClient(firstClient)
+	first, ok := state.beginLogout()
+	if !ok {
+		t.Fatal("first logout did not start")
+	}
+	second, ok := state.beginLogout()
+	if ok {
+		t.Fatal("second logout started while the first was in flight")
+	}
+	if second.client != firstClient {
+		t.Fatalf("second logout client = %p, want %p", second.client, firstClient)
+	}
+	if !state.completeLogout(first.done, first.generation) {
+		t.Fatal("first logout completion was rejected")
+	}
+	third, ok := state.beginLogout()
+	if ok {
+		t.Fatal("logout started while the terminal callback was in flight")
+	}
+	if third.client != firstClient {
+		t.Fatalf("terminal-callback logout client = %p, want %p", third.client, firstClient)
+	}
+	state.finishLogoutCallback()
+}
+func waitForLifecycleCondition(t *testing.T, state *clientLifecycleState, condition func() bool, message string) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		state.mu.Lock()
+		ready := condition()
+		state.mu.Unlock()
+		if ready {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal(message)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+func TestClientLifecycleResetWaitsForLogoutAndSuppressesStaleResult(t *testing.T) {
+	var state clientLifecycleState
+	previous := client
+	t.Cleanup(func() { state.publishClient(previous) })
+	clientSnapshot := &whatsmeow.Client{}
+	state.publishClient(clientSnapshot)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	emitted := make(chan struct{}, 1)
+	operation := logoutOperation{
+		timeout: time.Second,
+		state:   &state,
+		emit:    func(uint8) { emitted <- struct{}{} },
+		remoteLogout: func(context.Context, *whatsmeow.Client) error {
+			close(started)
+			<-release
+			return nil
+		},
+	}
+	operation.start(clientSnapshot)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("logout operation did not start")
+	}
+	state.registrationDone = make(chan struct{})
+	resetDone := make(chan struct{})
+	go func() {
+		state.reset()
+		close(resetDone)
+	}()
+	waitForLifecycleCondition(t, &state, func() bool { return state.logoutGeneration != 0 && state.logoutDone != nil }, "reset did not wait for logout")
+	close(release)
+	waitForLifecycleCondition(t, &state, func() bool { return state.logoutDone == nil }, "logout did not complete")
+	admitted, admissionStarted := state.beginLogout()
+	if admissionStarted || admitted.client != clientSnapshot {
+		t.Fatalf("reset admitted logout for client %p, started=%t", admitted.client, admissionStarted)
+	}
+	close(state.registrationDone)
+	state.mu.Lock()
+	state.registrationDone = nil
+	state.mu.Unlock()
+	select {
+	case <-resetDone:
+	case <-time.After(time.Second):
+		t.Fatal("reset did not complete after logout")
+	}
+	select {
+	case <-emitted:
+		t.Fatal("stale logout result was emitted after reset")
+	default:
+	}
+}
+func TestClientLifecycleLogoutCompletionClearsBeforeSynchronousCallback(t *testing.T) {
+	var state clientLifecycleState
+	previous := client
+	t.Cleanup(func() { state.publishClient(previous) })
+	clientSnapshot := &whatsmeow.Client{}
+	state.publishClient(clientSnapshot)
+	started := make(chan struct{})
+	callbackDone := make(chan struct{})
+	operation := logoutOperation{
+		timeout: time.Second,
+		state:   &state,
+		remoteLogout: func(context.Context, *whatsmeow.Client) error {
+			close(started)
+			return nil
+		},
+		emit: func(uint8) {
+			state.reset()
+			close(callbackDone)
+		},
+	}
+	logout, ok := state.beginLogout()
+	if !ok {
+		t.Fatal("logout did not start")
+	}
+	operation.startWithReservation(logout)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("logout operation did not start")
+	}
+	select {
+	case <-callbackDone:
+	case <-time.After(time.Second):
+		t.Fatal("synchronous logout callback deadlocked reset")
 	}
 }
 

--- a/whatsrust/src/lifecycle.rs
+++ b/whatsrust/src/lifecycle.rs
@@ -24,10 +24,9 @@ pub fn disconnect() {
 }
 
 pub fn logout() {
-    // Performs a deterministic local sign-out on the Go side (disconnect +
-    // clear the persisted device). The result arrives via Event::LogoutResult
-    // so the app can remove the DB file and quit. No network round-trip, so
-    // the UI never blocks.
+    // Initiates logout on the Go side. The remote companion-device removal
+    // runs asynchronously; Event::LogoutResult reports the terminal outcome
+    // and drives the app's local cleanup.
     unsafe { C_Logout() };
 }
 


### PR DESCRIPTION
Closes #376

## Summary
- initiate remote logout without blocking the UI caller
- enforce single-flight result delivery and bounded cleanup
- coordinate reset generations to suppress stale results safely

## Changes
| File | Change |
|---|---|
| `whatsrust/lib/client_lifecycle.go` | Add asynchronous logout lifecycle and reset barriers |
| `whatsrust/lib/client_lifecycle_test.go` | Cover success, failure, timeout, reset, callbacks, and concurrency |

## Test plan
- [x] Focused lifecycle tests passed
- [x] Reset interleaving test passed 100 consecutive runs
- [x] Full Go tests and race tests passed
- [x] `gofmt` and diff checks passed

## Review workload
Exactly 400 changed lines; no size exception required.

## Checklist
- [x] Linked approved issue
- [x] Conventional commit
- [x] No generated or unrelated changes
