### PR TITLE
docs(lifecycle): describe asynchronous logout

### DIFF
--- a/whatsrust/src/lifecycle.rs
+++ b/whatsrust/src/lifecycle.rs
@@ -24,10 +24,9 @@ pub fn disconnect() {
 }
 
 pub fn logout() {
-    // Performs a deterministic local sign-out on the Go side (disconnect +
-    // clear the persisted device). The result arrives via Event::LogoutResult
-    // so the app can remove the DB file and quit. No network round-trip, so
-    // the UI never blocks.
+    // Initiates logout on the Go side. The remote companion-device removal
+    // runs asynchronously; Event::LogoutResult reports the terminal outcome
+    // and drives the app's local cleanup.
     unsafe { C_Logout() };
 }
 


### PR DESCRIPTION
Closes #376

## Summary
- document that logout initiates asynchronous remote removal
- clarify that terminal `LogoutResult` drives local cleanup

## Chain context
```text
#379 fix/nonblocking-logout
  └── 📍 fix/logout-rust-contract
```

**Base:** `fix/nonblocking-logout`  
**Depends on:** #379  
**Follow-up:** combined beta validation after both PRs pass.

## Changes
| File | Change |
|---|---|
| `whatsrust/src/lifecycle.rs` | Correct the Rust logout contract documentation |

## Test plan
- [x] Focused Rust logout tests — 4 passed
- [x] Structural readback and diff checks passed
