### PR TITLE
fix(media): own callback payload allocations

### DIFF
--- a/whatsrust/lib/file_message_payload.go
+++ b/whatsrust/lib/file_message_payload.go
@@ -37,6 +37,13 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+func fileMessageCaption(caption string) *C.char {
+	if caption == "" {
+		return nil
+	}
+	return C.CString(caption)
+}
+
 func emitFileMessage(cinfo C.MessageInfo, kind uint8, filePath, fileID, caption string, isSync bool) {
 	cfileID := C.CString(fileID)
 	defer C.free(unsafe.Pointer(cfileID))
@@ -44,10 +51,7 @@ func emitFileMessage(cinfo C.MessageInfo, kind uint8, filePath, fileID, caption 
 	cpath := C.CString(filePath)
 	defer C.free(unsafe.Pointer(cpath))
 
-	ccaption := C.CString(caption)
-	if caption == "" {
-		ccaption = nil
-	}
+	ccaption := fileMessageCaption(caption)
 	defer C.free(unsafe.Pointer(ccaption))
 
 	content := (*C.FileMessage)(C.malloc(C.sizeof_FileMessage))
@@ -94,26 +98,26 @@ func buildFileMessageMentionRanges(ranges []mentionRange) (unsafe.Pointer, *C.Me
 	return memory, mentionRanges, mentionRangeCount
 }
 
-func emitImageMessage(cinfo C.MessageInfo, messageID string, image *waE2E.ImageMessage, isSync bool) bool {
+func emitImageMessage(callback *messageCallback, messageID string, image *waE2E.ImageMessage, isSync bool) bool {
 	if image == nil {
 		LOG_ERROR("ImageMessage is nil")
 		return false
 	}
-	setMessageQuoteID(&cinfo, image.GetContextInfo())
+	callback.setQuoteIDFromContext(image.GetContextInfo())
 	clientSnapshot := lifecycleState.clientSnapshot()
 	ext := ExtensionByType(image.GetMimetype(), ".jpg")
 	filePath := fmt.Sprintf("imgs/%s%s", messageID, ext)
 	fileID := DownloadableMessageToFileId(clientSnapshot, image, filePath)
-	emitFileMessage(cinfo, FileTypeImage, filePath, fileID, captionWithMentionNames(image.GetCaption(), image.GetContextInfo(), cinfo), isSync)
+	emitFileMessage(callback.info, FileTypeImage, filePath, fileID, captionWithMentionNames(image.GetCaption(), image.GetContextInfo(), callback.info), isSync)
 	return true
 }
 
-func emitVideoMessage(cinfo C.MessageInfo, messageID string, video *waE2E.VideoMessage, isSync bool) bool {
+func emitVideoMessage(callback *messageCallback, messageID string, video *waE2E.VideoMessage, isSync bool) bool {
 	if video == nil {
 		LOG_ERROR("VideoMessage is nil")
 		return false
 	}
-	setMessageQuoteID(&cinfo, video.GetContextInfo())
+	callback.setQuoteIDFromContext(video.GetContextInfo())
 	clientSnapshot := lifecycleState.clientSnapshot()
 	ext := ExtensionByType(video.GetMimetype(), ".mp4")
 	filePath := fmt.Sprintf("videos/%s%s", messageID, ext)
@@ -122,34 +126,34 @@ func emitVideoMessage(cinfo C.MessageInfo, messageID string, video *waE2E.VideoM
 		thumbPath := strings.TrimSuffix(filePath, ext) + ".jpg"
 		fileID = AddThumbnailToFileId(fileID, thumbnail, thumbPath)
 	}
-	emitFileMessage(cinfo, FileTypeVideo, filePath, fileID, captionWithMentionNames(video.GetCaption(), video.GetContextInfo(), cinfo), isSync)
+	emitFileMessage(callback.info, FileTypeVideo, filePath, fileID, captionWithMentionNames(video.GetCaption(), video.GetContextInfo(), callback.info), isSync)
 	return true
 }
 
-func emitAudioMessage(cinfo C.MessageInfo, messageID string, audio *waE2E.AudioMessage, isSync bool) bool {
+func emitAudioMessage(callback *messageCallback, messageID string, audio *waE2E.AudioMessage, isSync bool) bool {
 	if audio == nil {
 		LOG_ERROR("AudioMessage is nil")
 		return false
 	}
-	setMessageQuoteID(&cinfo, audio.GetContextInfo())
+	callback.setQuoteIDFromContext(audio.GetContextInfo())
 	clientSnapshot := lifecycleState.clientSnapshot()
 	ext := ExtensionByType(audio.GetMimetype(), ".ogg")
 	filePath := fmt.Sprintf("audios/%s%s", messageID, ext)
 	fileID := DownloadableMessageToFileId(clientSnapshot, audio, filePath)
-	emitFileMessage(cinfo, FileTypeAudio, filePath, fileID, "", isSync)
+	emitFileMessage(callback.info, FileTypeAudio, filePath, fileID, "", isSync)
 	return true
 }
 
-func emitDocumentMessage(cinfo C.MessageInfo, messageID string, document *waE2E.DocumentMessage, isSync bool) bool {
+func emitDocumentMessage(callback *messageCallback, messageID string, document *waE2E.DocumentMessage, isSync bool) bool {
 	if document == nil {
 		LOG_ERROR("DocumentMessage is nil")
 		return false
 	}
-	setMessageQuoteID(&cinfo, document.GetContextInfo())
+	callback.setQuoteIDFromContext(document.GetContextInfo())
 	clientSnapshot := lifecycleState.clientSnapshot()
 	filePath := fmt.Sprintf("docs/%s-%s", messageID, *document.FileName)
 	fileID := DownloadableMessageToFileId(clientSnapshot, document, filePath)
-	emitFileMessage(cinfo, FileTypeDocument, filePath, fileID, captionWithMentionNames(document.GetCaption(), document.GetContextInfo(), cinfo), isSync)
+	emitFileMessage(callback.info, FileTypeDocument, filePath, fileID, captionWithMentionNames(document.GetCaption(), document.GetContextInfo(), callback.info), isSync)
 	return true
 }
 
@@ -168,22 +172,16 @@ func captionWithMentionNames(caption string, contextInfo *waE2E.ContextInfo, cin
 	)
 }
 
-func emitStickerMessage(cinfo C.MessageInfo, messageID string, sticker *waE2E.StickerMessage, isSync bool) bool {
+func emitStickerMessage(callback *messageCallback, messageID string, sticker *waE2E.StickerMessage, isSync bool) bool {
 	if sticker == nil {
 		LOG_ERROR("StickerMessage is nil")
 		return false
 	}
-	setMessageQuoteID(&cinfo, sticker.GetContextInfo())
+	callback.setQuoteIDFromContext(sticker.GetContextInfo())
 	clientSnapshot := lifecycleState.clientSnapshot()
 	ext := ExtensionByType(sticker.GetMimetype(), ".webp")
 	filePath := fmt.Sprintf("stickers/%s%s", messageID, ext)
 	fileID := DownloadableMessageToFileId(clientSnapshot, sticker, filePath)
-	emitFileMessage(cinfo, FileTypeSticker, filePath, fileID, "", isSync)
+	emitFileMessage(callback.info, FileTypeSticker, filePath, fileID, "", isSync)
 	return true
-}
-
-func setMessageQuoteID(cinfo *C.MessageInfo, contextInfo *waE2E.ContextInfo) {
-	if contextInfo != nil && contextInfo.GetStanzaID() != "" {
-		cinfo.quoteID = C.CString(contextInfo.GetStanzaID())
-	}
 }

--- a/whatsrust/lib/file_message_payload_test.go
+++ b/whatsrust/lib/file_message_payload_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestFileMessageCaptionSkipsAllocationForEmptyCaptions(t *testing.T) {
+	if caption := fileMessageCaption(""); caption != nil {
+		t.Fatal("empty file captions must not allocate C memory")
+	}
+}
+
+func TestQuotedMediaCallbackOwnsQuoteIDUntilCallbackClose(t *testing.T) {
+	callback := beginMessageCallback(types.MessageInfo{}, &waE2E.Message{}, nil)
+	callback.setQuoteIDFromContext(&waE2E.ContextInfo{StanzaID: proto.String("quoted-message")})
+	if callback.info.quoteID == nil {
+		t.Fatal("quoted media must transfer its quote ID to the callback owner")
+	}
+
+	callback.close()
+	if callback.info.quoteID != nil {
+		t.Fatal("callback-owned quote ID was not released after the synchronous callback returned")
+	}
+}
+
+func TestMediaCallbackClearsQuoteIDWhenMediaIsNotQuoted(t *testing.T) {
+	callback := beginMessageCallback(types.MessageInfo{}, &waE2E.Message{}, nil)
+	defer callback.close()
+	callback.setQuoteIDFromContext(&waE2E.ContextInfo{StanzaID: proto.String("quoted-message")})
+	callback.setQuoteIDFromContext(nil)
+	if callback.info.quoteID != nil {
+		t.Fatal("unquoted media must not inherit a prior media quote ID")
+	}
+}
+
+func TestMediaEmittersUseTheCallbackQuoteIDOwner(t *testing.T) {
+	source := string(mustRead(t, "file_message_payload.go"))
+	for _, emitter := range []string{
+		"emitImageMessage(callback *messageCallback",
+		"emitVideoMessage(callback *messageCallback",
+		"emitAudioMessage(callback *messageCallback",
+		"emitDocumentMessage(callback *messageCallback",
+		"emitStickerMessage(callback *messageCallback",
+		"callback.setQuoteIDFromContext(",
+	} {
+		if !strings.Contains(source, emitter) {
+			t.Fatalf("media callback quote ID ownership is missing: %q", emitter)
+		}
+	}
+}

--- a/whatsrust/lib/message_callback.go
+++ b/whatsrust/lib/message_callback.go
@@ -147,7 +147,22 @@ func messageCallbackPushName(callback *messageCallback) string {
 }
 
 func (callback *messageCallback) setQuoteID(id string) {
+	callback.clearQuoteID()
 	callback.info.quoteID = C.CString(id)
+}
+
+func (callback *messageCallback) setQuoteIDFromContext(contextInfo *waE2E.ContextInfo) {
+	callback.clearQuoteID()
+	if contextInfo != nil && contextInfo.GetStanzaID() != "" {
+		callback.info.quoteID = C.CString(contextInfo.GetStanzaID())
+	}
+}
+
+func (callback *messageCallback) clearQuoteID() {
+	if callback.info.quoteID != nil {
+		C.free(unsafe.Pointer(callback.info.quoteID))
+		callback.info.quoteID = nil
+	}
 }
 
 func (callback *messageCallback) close() {

--- a/whatsrust/lib/message_handling.go
+++ b/whatsrust/lib/message_handling.go
@@ -49,27 +49,27 @@ func HandleMessage(info types.MessageInfo, msg *waE2E.Message, isSync bool) {
 		emitTextMessage(cinfo, text, isSync)
 	}
 	if msg.ImageMessage != nil {
-		if !emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync) {
+		if !emitImageMessage(callback, info.ID, msg.GetImageMessage(), isSync) {
 			return
 		}
 	}
 	if msg.VideoMessage != nil {
-		if !emitVideoMessage(cinfo, info.ID, msg.GetVideoMessage(), isSync) {
+		if !emitVideoMessage(callback, info.ID, msg.GetVideoMessage(), isSync) {
 			return
 		}
 	}
 	if msg.AudioMessage != nil {
-		if !emitAudioMessage(cinfo, info.ID, msg.GetAudioMessage(), isSync) {
+		if !emitAudioMessage(callback, info.ID, msg.GetAudioMessage(), isSync) {
 			return
 		}
 	}
 	if msg.DocumentMessage != nil {
-		if !emitDocumentMessage(cinfo, info.ID, msg.GetDocumentMessage(), isSync) {
+		if !emitDocumentMessage(callback, info.ID, msg.GetDocumentMessage(), isSync) {
 			return
 		}
 	}
 	if msg.StickerMessage != nil {
-		if !emitStickerMessage(cinfo, info.ID, msg.GetStickerMessage(), isSync) {
+		if !emitStickerMessage(callback, info.ID, msg.GetStickerMessage(), isSync) {
 			return
 		}
 	}

--- a/whatsrust/lib/message_handling_test.go
+++ b/whatsrust/lib/message_handling_test.go
@@ -29,11 +29,11 @@ func TestHandleMessageOrchestrationOwnership(t *testing.T) {
 	for _, fragment := range []string{
 		"emitTextMessage(cinfo, msg.GetConversation(), isSync)",
 		"emitTextMessage(cinfo, text, isSync)",
-		"emitImageMessage(cinfo, info.ID, msg.GetImageMessage(), isSync)",
-		"emitVideoMessage(cinfo, info.ID, msg.GetVideoMessage(), isSync)",
-		"emitAudioMessage(cinfo, info.ID, msg.GetAudioMessage(), isSync)",
-		"emitDocumentMessage(cinfo, info.ID, msg.GetDocumentMessage(), isSync)",
-		"emitStickerMessage(cinfo, info.ID, msg.GetStickerMessage(), isSync)",
+		"emitImageMessage(callback, info.ID, msg.GetImageMessage(), isSync)",
+		"emitVideoMessage(callback, info.ID, msg.GetVideoMessage(), isSync)",
+		"emitAudioMessage(callback, info.ID, msg.GetAudioMessage(), isSync)",
+		"emitDocumentMessage(callback, info.ID, msg.GetDocumentMessage(), isSync)",
+		"emitStickerMessage(callback, info.ID, msg.GetStickerMessage(), isSync)",
 	} {
 		if !strings.Contains(source, fragment) {
 			t.Fatalf("message orchestration call is missing: %q", fragment)


### PR DESCRIPTION
Closes #380

## Summary
- avoid allocating C strings for empty media captions
- move quoted-media IDs under the synchronous callback owner
- release replaced and final quote IDs exactly once

## Changes
| File | Change |
|---|---|
| `whatsrust/lib/file_message_payload.go` | Skip empty allocations and use callback ownership |
| `whatsrust/lib/message_callback.go` | Own, replace, and release quote IDs |
| `whatsrust/lib/message_handling.go` | Pass callback owner to media emitters |
| Go tests | Cover ownership, orchestration, and cleanup |

## Test plan
- [x] Focused and full Go tests passed
- [x] Go race suite passed
- [x] `gofmt` and diff checks passed
