### PR TITLE
fix(ffi): guard empty receipt arrays

### DIFF
--- a/whatsrust/lib/receipt_events.go
+++ b/whatsrust/lib/receipt_events.go
@@ -104,7 +104,13 @@ func receiptKind(kind types.ReceiptType) uint8 {
 
 func dispatchReceiptEvent(receipt receiptEvent) {
 	n := len(receipt.messageIDs)
-	cmessageIDs := (**C.char)(C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0)))))
+	var cmessageIDs **C.char
+	if n > 0 {
+		cmessageIDs = (**C.char)(C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0)))))
+		if cmessageIDs == nil {
+			return
+		}
+	}
 	messageIDs := unsafe.Slice(cmessageIDs, n)
 	for i, id := range receipt.messageIDs {
 		messageIDs[i] = C.CString(id)

--- a/whatsrust/lib/receipt_events_test.go
+++ b/whatsrust/lib/receipt_events_test.go
@@ -132,3 +132,33 @@ func TestReceiptDispatchKeepsCArrayAndPayloadThroughCallback(t *testing.T) {
 		t.Fatal("receipt C array must be populated before the callback")
 	}
 }
+
+func TestReceiptDispatchAndRustDecoderSupportEmptyMessageIDs(t *testing.T) {
+	goSource, err := os.ReadFile("receipt_events.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	goBody, ok := extractFunctionBody(string(goSource), "func dispatchReceiptEvent(receipt receiptEvent)")
+	if !ok {
+		t.Fatal("dispatchReceiptEvent function body not found in receipt_events.go")
+	}
+	for _, fragment := range []string{
+		"var cmessageIDs **C.char",
+		"if n > 0 {",
+		"creceipt.messageIDs = cmessageIDs",
+		"creceipt.size = C.uint32_t(n)",
+	} {
+		if !strings.Contains(goBody, fragment) {
+			t.Fatalf("empty receipt dispatch must contain %q", fragment)
+		}
+	}
+
+	rustSource, err := os.ReadFile("../src/events.rs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rustText := string(rustSource)
+	if !strings.Contains(rustText, "if receipt.count == 0 { &[] } else {") {
+		t.Fatal("Rust receipt decoder must avoid dereferencing the message ID pointer for empty arrays")
+	}
+}

--- a/whatsrust/src/events.rs
+++ b/whatsrust/src/events.rs
@@ -19,8 +19,10 @@ impl CallbackTranslator<*const CEvent> for Event {
             EventType::Receipt => {
                 let receipt = unsafe { &(*(event.data as *const CReceipt)) };
                 let chat: JID = (&receipt.chat).into();
-                let message_ids = unsafe {
-                    std::slice::from_raw_parts(receipt.message_ids, receipt.count as usize)
+                let message_ids = if receipt.count == 0 { &[] } else {
+                    unsafe {
+                        std::slice::from_raw_parts(receipt.message_ids, receipt.count as usize)
+                    }
                 }
                 .iter()
                 .map(|&id| {


### PR DESCRIPTION
Closes #381

## Summary
- encode empty receipt arrays as a coherent nil/zero ABI pair
- decode empty arrays without constructing a Rust slice from a null pointer
- preserve non-empty callback lifetime and ABI layout

## Chain context
```text
#377 fix/ffi-jid-ownership
  └── 📍 fix/ffi-receipt-empty-results
```

**Base:** `fix/ffi-jid-ownership`  
**Depends on:** #377  
**Follow-up:** combined beta validation after both PRs pass.

## Test plan
- [x] Focused and full Go tests passed
- [x] Rust bridge tests — 27 passed
- [x] Diff checks passed
